### PR TITLE
With client refactor

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -94,24 +94,24 @@ func init() {
 	RootCmd.AddCommand(AuthCmd)
 }
 
-func loginCmdF(command *cobra.Command, args []string) error {
-	name, err := command.Flags().GetString("name")
+func loginCmdF(cmd *cobra.Command, args []string) error {
+	name, err := cmd.Flags().GetString("name")
 	if err != nil {
 		return err
 	}
-	username, err := command.Flags().GetString("username")
+	username, err := cmd.Flags().GetString("username")
 	if err != nil {
 		return err
 	}
-	password, err := command.Flags().GetString("password")
+	password, err := cmd.Flags().GetString("password")
 	if err != nil {
 		return err
 	}
-	accessToken, err := command.Flags().GetString("access-token")
+	accessToken, err := cmd.Flags().GetString("access-token")
 	if err != nil {
 		return err
 	}
-	mfaToken, err := command.Flags().GetString("mfa-token")
+	mfaToken, err := cmd.Flags().GetString("mfa-token")
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func loginCmdF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	noActivate, _ := command.Flags().GetBool("no-activate")
+	noActivate, _ := cmd.Flags().GetBool("no-activate")
 	if !noActivate {
 		if err := SetCurrent(name); err != nil {
 			return err
@@ -209,7 +209,7 @@ func getPasswordFromStdin() (string, error) {
 	return string(bytePassword), nil
 }
 
-func currentCmdF(command *cobra.Command, args []string) error {
+func currentCmdF(cmd *cobra.Command, args []string) error {
 	credentials, err := GetCurrentCredentials()
 	if err != nil {
 		return err
@@ -219,7 +219,7 @@ func currentCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func setCmdF(command *cobra.Command, args []string) error {
+func setCmdF(cmd *cobra.Command, args []string) error {
 	if err := SetCurrent(args[0]); err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func setCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func listCmdF(command *cobra.Command, args []string) error {
+func listCmdF(cmd *cobra.Command, args []string) error {
 	credentialsList, err := ReadCredentialsList()
 	if err != nil {
 		return err
@@ -271,7 +271,7 @@ func listCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func deleteCmdF(command *cobra.Command, args []string) error {
+func deleteCmdF(cmd *cobra.Command, args []string) error {
 	credentialsList, err := ReadCredentialsList()
 	if err != nil {
 		return err
@@ -287,7 +287,7 @@ func deleteCmdF(command *cobra.Command, args []string) error {
 	return SaveCredentialsList(credentialsList)
 }
 
-func cleanCmdF(command *cobra.Command, args []string) error {
+func cleanCmdF(cmd *cobra.Command, args []string) error {
 	if err := CleanCredentials(); err != nil {
 		return err
 	}

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -124,24 +124,24 @@ func init() {
 	RootCmd.AddCommand(ChannelCmd)
 }
 
-func createChannelCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func createChannelCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
-	name, errn := command.Flags().GetString("name")
+	name, errn := cmd.Flags().GetString("name")
 	if errn != nil || name == "" {
 		return errors.New("Name is required")
 	}
-	displayname, errdn := command.Flags().GetString("display_name")
+	displayname, errdn := cmd.Flags().GetString("display_name")
 	if errdn != nil || displayname == "" {
 		return errors.New("Display Name is required")
 	}
-	teamArg, errteam := command.Flags().GetString("team")
+	teamArg, errteam := cmd.Flags().GetString("team")
 	if errteam != nil || teamArg == "" {
 		return errors.New("Team is required")
 	}
-	header, _ := command.Flags().GetString("header")
-	purpose, _ := command.Flags().GetString("purpose")
-	useprivate, _ := command.Flags().GetBool("private")
+	header, _ := cmd.Flags().GetString("header")
+	purpose, _ := cmd.Flags().GetString("purpose")
+	useprivate, _ := cmd.Flags().GetBool("private")
 
 	channelType := model.CHANNEL_OPEN
 	if useprivate {
@@ -173,8 +173,8 @@ func createChannelCmdF(c *model.Client4, command *cobra.Command, args []string) 
 	return nil
 }
 
-func removeChannelUsersCmdF(c *model.Client4, command *cobra.Command, args []string) error {
-	allUsers, _ := command.Flags().GetBool("all-users")
+func removeChannelUsersCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
+	allUsers, _ := cmd.Flags().GetBool("all-users")
 
 	if allUsers && len(args) != 1 {
 		return errors.New("individual users must not be specified in conjunction with the --all-users flag")
@@ -224,7 +224,7 @@ func removeAllUsersFromChannel(c *model.Client4, channel *model.Channel) {
 	}
 }
 
-func addChannelUsersCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func addChannelUsersCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
 	}
@@ -252,7 +252,7 @@ func addUserToChannel(c *model.Client4, channel *model.Channel, user *model.User
 	}
 }
 
-func archiveChannelsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func archiveChannelsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Enter at least one channel to archive.")
 	}
@@ -271,7 +271,7 @@ func archiveChannelsCmdF(c *model.Client4, command *cobra.Command, args []string
 	return nil
 }
 
-func listChannelsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func listChannelsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Enter at least one team.")
 	}
@@ -303,7 +303,7 @@ func listChannelsCmdF(c *model.Client4, command *cobra.Command, args []string) e
 	return nil
 }
 
-func restoreChannelsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func restoreChannelsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Enter at least one channel.")
 	}
@@ -322,7 +322,7 @@ func restoreChannelsCmdF(c *model.Client4, command *cobra.Command, args []string
 	return nil
 }
 
-func makeChannelPrivateCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func makeChannelPrivateCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("Enter one channel to modify.")
 	}
@@ -343,7 +343,7 @@ func makeChannelPrivateCmdF(c *model.Client4, command *cobra.Command, args []str
 	return nil
 }
 
-func renameChannelCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func renameChannelCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	var newDisplayName, newChannelName string
 
 	if len(args) < 2 {
@@ -356,7 +356,7 @@ func renameChannelCmdF(c *model.Client4, command *cobra.Command, args []string) 
 	}
 
 	newChannelName = args[1]
-	newDisplayName, errdn := command.Flags().GetString("display_name")
+	newDisplayName, errdn := cmd.Flags().GetString("display_name")
 	if errdn != nil {
 		return errdn
 	}
@@ -373,12 +373,12 @@ func renameChannelCmdF(c *model.Client4, command *cobra.Command, args []string) 
 	return nil
 }
 
-func searchChannelCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func searchChannelCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	var channel *model.Channel
 
-	if teamArg, _ := command.Flags().GetString("team"); teamArg != "" {
+	if teamArg, _ := cmd.Flags().GetString("team"); teamArg != "" {
 		team := getTeamFromTeamArg(c, teamArg)
 		if team == nil {
 			printer.PrintT("Team {{.}} is not found", teamArg)

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -19,7 +19,7 @@ var ChannelCreateCmd = &cobra.Command{
 	Long:  `Create a channel.`,
 	Example: `  channel create --team myteam --name mynewchannel --display_name "My New Channel"
   channel create --team myteam --name mynewprivatechannel --display_name "My New Private Channel" --private`,
-	RunE: createChannelCmdF,
+	RunE: withClient(createChannelCmdF),
 }
 
 var ChannelRenameCmd = &cobra.Command{
@@ -27,7 +27,7 @@ var ChannelRenameCmd = &cobra.Command{
 	Short:   "Rename a channel",
 	Long:    `Rename a channel.`,
 	Example: `  channel rename myteam:mychannel newchannelname --display_name "New Display Name"`,
-	RunE:    renameChannelCmdF,
+	RunE:    withClient(renameChannelCmdF),
 }
 
 var RemoveChannelUsersCmd = &cobra.Command{
@@ -36,7 +36,7 @@ var RemoveChannelUsersCmd = &cobra.Command{
 	Long:  "Remove some users from channel",
 	Example: `  channel remove myteam:mychannel user@example.com username
   channel remove myteam:mychannel --all-users`,
-	RunE: removeChannelUsersCmdF,
+	RunE: withClient(removeChannelUsersCmdF),
 }
 
 var AddChannelUsersCmd = &cobra.Command{
@@ -44,7 +44,7 @@ var AddChannelUsersCmd = &cobra.Command{
 	Short:   "Add users to channel",
 	Long:    "Add some users to channel",
 	Example: "  channel add myteam:mychannel user@example.com username",
-	RunE:    addChannelUsersCmdF,
+	RunE:    withClient(addChannelUsersCmdF),
 }
 
 var ArchiveChannelsCmd = &cobra.Command{
@@ -54,7 +54,7 @@ var ArchiveChannelsCmd = &cobra.Command{
 Archive a channel along with all related information including posts from the database.
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: "  channel archive myteam:mychannel",
-	RunE:    archiveChannelsCmdF,
+	RunE:    withClient(archiveChannelsCmdF),
 }
 
 var ListChannelsCmd = &cobra.Command{
@@ -63,7 +63,7 @@ var ListChannelsCmd = &cobra.Command{
 	Long: `List all channels on specified teams.
 Archived channels are appended with ' (archived)'.`,
 	Example: "  channel list myteam",
-	RunE:    listChannelsCmdF,
+	RunE:    withClient(listChannelsCmdF),
 }
 
 var RestoreChannelsCmd = &cobra.Command{
@@ -72,7 +72,7 @@ var RestoreChannelsCmd = &cobra.Command{
 	Long: `Restore a previously deleted channel
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: "  channel restore myteam:mychannel",
-	RunE:    restoreChannelsCmdF,
+	RunE:    withClient(restoreChannelsCmdF),
 }
 
 var MakeChannelPrivateCmd = &cobra.Command{
@@ -81,7 +81,7 @@ var MakeChannelPrivateCmd = &cobra.Command{
 	Long: `Set the type of a channel from public to private.
 Channel can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: "  channel make_private myteam:mychannel",
-	RunE:    makeChannelPrivateCmdF,
+	RunE:    withClient(makeChannelPrivateCmdF),
 }
 
 var SearchChannelCmd = &cobra.Command{
@@ -92,7 +92,7 @@ Channel can be specified by team. ie. --team myTeam myChannel or by team ID.`,
 	Example: `  channel search myChannel
   channel search --team myTeam myChannel`,
 	Args: cobra.ExactArgs(1),
-	RunE: searchChannelCmdF,
+	RunE: withClient(searchChannelCmdF),
 }
 
 func init() {
@@ -124,11 +124,7 @@ func init() {
 	RootCmd.AddCommand(ChannelCmd)
 }
 
-func createChannelCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
+func createChannelCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	name, errn := command.Flags().GetString("name")
@@ -177,12 +173,7 @@ func createChannelCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeChannelUsersCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func removeChannelUsersCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	allUsers, _ := command.Flags().GetBool("all-users")
 
 	if allUsers && len(args) != 1 {
@@ -233,12 +224,7 @@ func removeAllUsersFromChannel(c *model.Client4, channel *model.Channel) {
 	}
 }
 
-func addChannelUsersCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func addChannelUsersCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
 	}
@@ -266,12 +252,7 @@ func addUserToChannel(c *model.Client4, channel *model.Channel, user *model.User
 	}
 }
 
-func archiveChannelsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func archiveChannelsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Enter at least one channel to archive.")
 	}
@@ -290,12 +271,7 @@ func archiveChannelsCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func listChannelsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func listChannelsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Enter at least one team.")
 	}
@@ -327,12 +303,7 @@ func listChannelsCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func restoreChannelsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func restoreChannelsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Enter at least one channel.")
 	}
@@ -351,12 +322,7 @@ func restoreChannelsCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func makeChannelPrivateCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func makeChannelPrivateCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("Enter one channel to modify.")
 	}
@@ -377,12 +343,8 @@ func makeChannelPrivateCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func renameChannelCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
+func renameChannelCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	var newDisplayName, newChannelName string
-	if err != nil {
-		return err
-	}
 
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
@@ -411,11 +373,7 @@ func renameChannelCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func searchChannelCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
+func searchChannelCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	var channel *model.Channel
@@ -440,7 +398,7 @@ func searchChannelCmdF(command *cobra.Command, args []string) error {
 	} else {
 		teams, response := c.GetAllTeams("", 0, 9999)
 		if response.Error != nil {
-			return errors.Wrap(err, "failed to GetAllTeams")
+			return errors.Wrap(response.Error, "failed to GetAllTeams")
 		}
 
 		for _, team := range teams {

--- a/commands/completion.go
+++ b/commands/completion.go
@@ -44,11 +44,11 @@ func init() {
 	RootCmd.AddCommand(CompletionCmd)
 }
 
-func bashCmdF(command *cobra.Command, args []string) {
+func bashCmdF(cmd *cobra.Command, args []string) {
 	RootCmd.GenBashCompletion(os.Stdout)
 }
 
-func zshCmdF(command *cobra.Command, args []string) {
+func zshCmdF(cmd *cobra.Command, args []string) {
 	zshInitialization := `
 __mmctl_bash_source() {
 	alias shopt=':'

--- a/commands/group.go
+++ b/commands/group.go
@@ -19,7 +19,7 @@ var ListLdapGroupsCmd = &cobra.Command{
 	Short:   "List LDAP groups",
 	Example: "  group list-ldap",
 	Args:    cobra.NoArgs,
-	RunE:    listLdapGroupsCmdF,
+	RunE:    withClient(listLdapGroupsCmdF),
 }
 
 var ChannelGroupCmd = &cobra.Command{
@@ -32,7 +32,7 @@ var ChannelGroupEnableCmd = &cobra.Command{
 	Short:   "Enables group constrains in the specified channel",
 	Example: "  group channel enable myteam:mychannel",
 	Args:    cobra.ExactArgs(1),
-	RunE:    channelGroupEnableCmdF,
+	RunE:    withClient(channelGroupEnableCmdF),
 }
 
 var ChannelGroupDisableCmd = &cobra.Command{
@@ -40,7 +40,7 @@ var ChannelGroupDisableCmd = &cobra.Command{
 	Short:   "Disables group constrains in the specified channel",
 	Example: "  group channel disable myteam:mychannel",
 	Args:    cobra.ExactArgs(1),
-	RunE:    channelGroupDisableCmdF,
+	RunE:    withClient(channelGroupDisableCmdF),
 }
 
 var ChannelGroupStatusCmd = &cobra.Command{
@@ -48,7 +48,7 @@ var ChannelGroupStatusCmd = &cobra.Command{
 	Short:   "Show's the group constrain status for the specified channel",
 	Example: "  group channel status myteam:mychannel",
 	Args:    cobra.ExactArgs(1),
-	RunE:    channelGroupStatusCmdF,
+	RunE:    withClient(channelGroupStatusCmdF),
 }
 
 var ChannelGroupListCmd = &cobra.Command{
@@ -57,7 +57,7 @@ var ChannelGroupListCmd = &cobra.Command{
 	Long:    "List the groups associated with a channel",
 	Example: "  group channel list myteam:mychannel",
 	Args:    cobra.ExactArgs(1),
-	RunE:    channelGroupListCmdF,
+	RunE:    withClient(channelGroupListCmdF),
 }
 
 var TeamGroupCmd = &cobra.Command{
@@ -70,7 +70,7 @@ var TeamGroupEnableCmd = &cobra.Command{
 	Short:   "Enables group constrains in the specified team",
 	Example: "  group team enable myteam",
 	Args:    cobra.ExactArgs(1),
-	RunE:    teamGroupEnableCmdF,
+	RunE:    withClient(teamGroupEnableCmdF),
 }
 
 var TeamGroupDisableCmd = &cobra.Command{
@@ -78,7 +78,7 @@ var TeamGroupDisableCmd = &cobra.Command{
 	Short:   "Disables group constrains in the specified team",
 	Example: "  group team disable myteam",
 	Args:    cobra.ExactArgs(1),
-	RunE:    teamGroupDisableCmdF,
+	RunE:    withClient(teamGroupDisableCmdF),
 }
 
 var TeamGroupStatusCmd = &cobra.Command{
@@ -86,7 +86,7 @@ var TeamGroupStatusCmd = &cobra.Command{
 	Short:   "Show's the group constrain status for the specified team",
 	Example: "  group team status myteam",
 	Args:    cobra.ExactArgs(1),
-	RunE:    teamGroupStatusCmdF,
+	RunE:    withClient(teamGroupStatusCmdF),
 }
 
 var TeamGroupListCmd = &cobra.Command{
@@ -95,7 +95,7 @@ var TeamGroupListCmd = &cobra.Command{
 	Long:    "List the groups associated with a team",
 	Example: "  group team list myteam",
 	Args:    cobra.ExactArgs(1),
-	RunE:    teamGroupListCmdF,
+	RunE:    withClient(teamGroupListCmdF),
 }
 
 func init() {
@@ -122,12 +122,7 @@ func init() {
 	RootCmd.AddCommand(GroupCmd)
 }
 
-func listLdapGroupsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func listLdapGroupsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	groups, res := c.GetLdapGroups()
 	if res.Error != nil {
 		return res.Error
@@ -140,12 +135,7 @@ func listLdapGroupsCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func channelGroupEnableCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func channelGroupEnableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
@@ -168,12 +158,7 @@ func channelGroupEnableCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func channelGroupDisableCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func channelGroupDisableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
@@ -187,12 +172,7 @@ func channelGroupDisableCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func channelGroupStatusCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func channelGroupStatusCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
@@ -207,12 +187,7 @@ func channelGroupStatusCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func channelGroupListCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func channelGroupListCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
@@ -230,12 +205,7 @@ func channelGroupListCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func teamGroupEnableCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func teamGroupEnableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
@@ -258,12 +228,7 @@ func teamGroupEnableCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func teamGroupDisableCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func teamGroupDisableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
@@ -277,12 +242,7 @@ func teamGroupDisableCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func teamGroupStatusCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func teamGroupStatusCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
@@ -297,12 +257,7 @@ func teamGroupStatusCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func teamGroupListCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func teamGroupListCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")

--- a/commands/group.go
+++ b/commands/group.go
@@ -122,7 +122,7 @@ func init() {
 	RootCmd.AddCommand(GroupCmd)
 }
 
-func listLdapGroupsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func listLdapGroupsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	groups, res := c.GetLdapGroups()
 	if res.Error != nil {
 		return res.Error
@@ -135,7 +135,7 @@ func listLdapGroupsCmdF(c *model.Client4, command *cobra.Command, args []string)
 	return nil
 }
 
-func channelGroupEnableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func channelGroupEnableCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
@@ -158,7 +158,7 @@ func channelGroupEnableCmdF(c *model.Client4, command *cobra.Command, args []str
 	return nil
 }
 
-func channelGroupDisableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func channelGroupDisableCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
@@ -172,7 +172,7 @@ func channelGroupDisableCmdF(c *model.Client4, command *cobra.Command, args []st
 	return nil
 }
 
-func channelGroupStatusCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func channelGroupStatusCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
@@ -187,7 +187,7 @@ func channelGroupStatusCmdF(c *model.Client4, command *cobra.Command, args []str
 	return nil
 }
 
-func channelGroupListCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func channelGroupListCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
@@ -205,7 +205,7 @@ func channelGroupListCmdF(c *model.Client4, command *cobra.Command, args []strin
 	return nil
 }
 
-func teamGroupEnableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func teamGroupEnableCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
@@ -228,7 +228,7 @@ func teamGroupEnableCmdF(c *model.Client4, command *cobra.Command, args []string
 	return nil
 }
 
-func teamGroupDisableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func teamGroupDisableCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
@@ -242,7 +242,7 @@ func teamGroupDisableCmdF(c *model.Client4, command *cobra.Command, args []strin
 	return nil
 }
 
-func teamGroupStatusCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func teamGroupStatusCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
@@ -257,7 +257,7 @@ func teamGroupStatusCmdF(c *model.Client4, command *cobra.Command, args []string
 	return nil
 }
 
-func teamGroupListCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func teamGroupListCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")

--- a/commands/init.go
+++ b/commands/init.go
@@ -9,14 +9,11 @@ import (
 )
 
 func withClient(fn func(c *model.Client4, cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		c, err := InitClient()
+		if err != nil {
 			return err
 		}
-	}
-
-	return func(cmd *cobra.Command, args []string) error {
 		return fn(c, cmd, args)
 	}
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -8,16 +8,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func withClient(fn func(c *model.Client4, command *cobra.Command, args []string) error) func(command *cobra.Command, args []string) error {
+func withClient(fn func(c *model.Client4, cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
 	c, err := InitClient()
 	if err != nil {
-		return func(command *cobra.Command, args []string) error {
+		return func(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
 
-	return func(command *cobra.Command, args []string) error {
-		return fn(c, command, args)
+	return func(cmd *cobra.Command, args []string) error {
+		return fn(c, cmd, args)
 	}
 }
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -5,7 +5,21 @@ import (
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
+
+func withClient(fn func(c *model.Client4, command *cobra.Command, args []string) error) func(command *cobra.Command, args []string) error {
+	c, err := InitClient()
+	if err != nil {
+		return func(command *cobra.Command, args []string) error {
+			return err
+		}
+	}
+
+	return func(command *cobra.Command, args []string) error {
+		return fn(c, command, args)
+	}
+}
 
 func InitClientWithUsernameAndPassword(username, password, instanceUrl string) (*model.Client4, error) {
 	client := model.NewAPIv4Client(instanceUrl)

--- a/commands/license.go
+++ b/commands/license.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"io/ioutil"
 
+	"github.com/mattermost/mattermost-server/model"
+
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +19,7 @@ var UploadLicenseCmd = &cobra.Command{
 	Short:   "Upload a license.",
 	Long:    "Upload a license. Replaces current license.",
 	Example: "  license upload /path/to/license/mylicensefile.mattermost-license",
-	RunE:    uploadLicenseCmdF,
+	RunE:    withClient(uploadLicenseCmdF),
 }
 
 var RemoveLicenseCmd = &cobra.Command{
@@ -25,7 +27,7 @@ var RemoveLicenseCmd = &cobra.Command{
 	Short:   "Remove the current license.",
 	Long:    "Remove the current license and leave mattermost in Team Edition.",
 	Example: "  license remove",
-	RunE:    removeLicenseCmdF,
+	RunE:    withClient(removeLicenseCmdF),
 }
 
 func init() {
@@ -34,18 +36,13 @@ func init() {
 	RootCmd.AddCommand(LicenseCmd)
 }
 
-func uploadLicenseCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func uploadLicenseCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("Enter one license file to upload")
 	}
 
-	var fileBytes []byte
-	if fileBytes, err = ioutil.ReadFile(args[0]); err != nil {
+	fileBytes, err := ioutil.ReadFile(args[0])
+	if err != nil {
 		return err
 	}
 
@@ -58,12 +55,7 @@ func uploadLicenseCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeLicenseCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func removeLicenseCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if _, response := c.RemoveLicenseFile(); response.Error != nil {
 		return response.Error
 	}

--- a/commands/license.go
+++ b/commands/license.go
@@ -36,7 +36,7 @@ func init() {
 	RootCmd.AddCommand(LicenseCmd)
 }
 
-func uploadLicenseCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func uploadLicenseCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New("Enter one license file to upload")
 	}
@@ -55,7 +55,7 @@ func uploadLicenseCmdF(c *model.Client4, command *cobra.Command, args []string) 
 	return nil
 }
 
-func removeLicenseCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func removeLicenseCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if _, response := c.RemoveLicenseFile(); response.Error != nil {
 		return response.Error
 	}

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -23,8 +23,8 @@ func init() {
 	RootCmd.AddCommand(LogsCmd)
 }
 
-func logsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
-	number, _ := command.Flags().GetInt("number")
+func logsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
+	number, _ := cmd.Flags().GetInt("number")
 	logLines, response := c.GetLogs(0, number)
 	if response.Error != nil {
 		return errors.New("Unable to retrieve logs. Error: " + response.Error.Error())
@@ -33,7 +33,7 @@ func logsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	reader := bytes.NewReader([]byte(strings.Join(logLines, "")))
 
 	var writer human.LogWriter
-	if logrus, _ := command.Flags().GetBool("logrus"); logrus {
+	if logrus, _ := cmd.Flags().GetBool("logrus"); logrus {
 		writer = human.NewLogrusWriter(os.Stdout)
 	} else {
 		writer = human.NewSimpleWriter(os.Stdout)

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-server/mlog/human"
+	"github.com/mattermost/mattermost-server/model"
 	"github.com/spf13/cobra"
 )
 
 var LogsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Display logs in a human-readable format",
-	RunE:  logsCmdF,
+	RunE:  withClient(logsCmdF),
 }
 
 func init() {
@@ -22,12 +23,7 @@ func init() {
 	RootCmd.AddCommand(LogsCmd)
 }
 
-func logsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func logsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	number, _ := command.Flags().GetInt("number")
 	logLines, response := c.GetLogs(0, number)
 	if response.Error != nil {

--- a/commands/permissions.go
+++ b/commands/permissions.go
@@ -19,7 +19,7 @@ var AddPermissionsCmd = &cobra.Command{
 	Long:    `Add one or more permissions to an existing role (Only works in Enterprise Edition).`,
 	Example: `  permissions add system_user list_open_teams`,
 	Args:    cobra.MinimumNArgs(2),
-	RunE:    addPermissionsCmdF,
+	RunE:    withClient(addPermissionsCmdF),
 }
 
 var RemovePermissionsCmd = &cobra.Command{
@@ -28,7 +28,7 @@ var RemovePermissionsCmd = &cobra.Command{
 	Long:    `Remove one or more permissions from an existing role (Only works in Enterprise Edition).`,
 	Example: `  permissions remove system_user list_open_teams`,
 	Args:    cobra.MinimumNArgs(2),
-	RunE:    removePermissionsCmdF,
+	RunE:    withClient(removePermissionsCmdF),
 }
 
 var ShowRoleCmd = &cobra.Command{
@@ -37,7 +37,7 @@ var ShowRoleCmd = &cobra.Command{
 	Long:    "Show all the information about a role.",
 	Example: `  permissions show system_user`,
 	Args:    cobra.ExactArgs(1),
-	RunE:    showRoleCmdF,
+	RunE:    withClient(showRoleCmdF),
 }
 
 func init() {
@@ -50,12 +50,7 @@ func init() {
 	RootCmd.AddCommand(PermissionsCmd)
 }
 
-func addPermissionsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func addPermissionsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	role, response := c.GetRoleByName(args[0])
 	if response.Error != nil {
 		return response.Error
@@ -82,12 +77,7 @@ func removePermission(permissions []string, permission string) []string {
 	return newPermissions
 }
 
-func removePermissionsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func removePermissionsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	role, response := c.GetRoleByName(args[0])
 	if response.Error != nil {
 		return response.Error
@@ -109,12 +99,7 @@ func removePermissionsCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func showRoleCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func showRoleCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	role, response := c.GetRoleByName(args[0])
 	if response.Error != nil {
 		return response.Error

--- a/commands/permissions.go
+++ b/commands/permissions.go
@@ -50,7 +50,7 @@ func init() {
 	RootCmd.AddCommand(PermissionsCmd)
 }
 
-func addPermissionsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func addPermissionsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	role, response := c.GetRoleByName(args[0])
 	if response.Error != nil {
 		return response.Error
@@ -77,7 +77,7 @@ func removePermission(permissions []string, permission string) []string {
 	return newPermissions
 }
 
-func removePermissionsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func removePermissionsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	role, response := c.GetRoleByName(args[0])
 	if response.Error != nil {
 		return response.Error
@@ -99,7 +99,7 @@ func removePermissionsCmdF(c *model.Client4, command *cobra.Command, args []stri
 	return nil
 }
 
-func showRoleCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func showRoleCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	role, response := c.GetRoleByName(args[0])
 	if response.Error != nil {
 		return response.Error

--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -65,7 +65,7 @@ func init() {
 	RootCmd.AddCommand(PluginCmd)
 }
 
-func pluginAddCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func pluginAddCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -87,7 +87,7 @@ func pluginAddCmdF(c *model.Client4, command *cobra.Command, args []string) erro
 	return nil
 }
 
-func pluginDeleteCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func pluginDeleteCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -103,7 +103,7 @@ func pluginDeleteCmdF(c *model.Client4, command *cobra.Command, args []string) e
 	return nil
 }
 
-func pluginEnableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func pluginEnableCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -119,7 +119,7 @@ func pluginEnableCmdF(c *model.Client4, command *cobra.Command, args []string) e
 	return nil
 }
 
-func pluginDisableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func pluginDisableCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -135,7 +135,7 @@ func pluginDisableCmdF(c *model.Client4, command *cobra.Command, args []string) 
 	return nil
 }
 
-func pluginListCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func pluginListCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	pluginsResp, response := c.GetPlugins()
 	if response.Error != nil {
 		return errors.New("Unable to list plugins. Error: " + response.Error.Error())

--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"os"
 
+	"github.com/mattermost/mattermost-server/model"
+
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +19,7 @@ var PluginAddCmd = &cobra.Command{
 	Short:   "Add plugins",
 	Long:    "Add plugins to your Mattermost server.",
 	Example: `  plugin add hovercardexample.tar.gz pluginexample.tar.gz`,
-	RunE:    pluginAddCmdF,
+	RunE:    withClient(pluginAddCmdF),
 }
 
 var PluginDeleteCmd = &cobra.Command{
@@ -25,7 +27,7 @@ var PluginDeleteCmd = &cobra.Command{
 	Short:   "Delete plugins",
 	Long:    "Delete previously uploaded plugins from your Mattermost server.",
 	Example: `  plugin delete hovercardexample pluginexample`,
-	RunE:    pluginDeleteCmdF,
+	RunE:    withClient(pluginDeleteCmdF),
 }
 
 var PluginEnableCmd = &cobra.Command{
@@ -33,7 +35,7 @@ var PluginEnableCmd = &cobra.Command{
 	Short:   "Enable plugins",
 	Long:    "Enable plugins for use on your Mattermost server.",
 	Example: `  plugin enable hovercardexample pluginexample`,
-	RunE:    pluginEnableCmdF,
+	RunE:    withClient(pluginEnableCmdF),
 }
 
 var PluginDisableCmd = &cobra.Command{
@@ -41,7 +43,7 @@ var PluginDisableCmd = &cobra.Command{
 	Short:   "Disable plugins",
 	Long:    "Disable plugins. Disabled plugins are immediately removed from the user interface and logged out of all sessions.",
 	Example: `  plugin disable hovercardexample pluginexample`,
-	RunE:    pluginDisableCmdF,
+	RunE:    withClient(pluginDisableCmdF),
 }
 
 var PluginListCmd = &cobra.Command{
@@ -49,7 +51,7 @@ var PluginListCmd = &cobra.Command{
 	Short:   "List plugins",
 	Long:    "List all active and inactive plugins installed on your Mattermost server.",
 	Example: `  plugin list`,
-	RunE:    pluginListCmdF,
+	RunE:    withClient(pluginListCmdF),
 }
 
 func init() {
@@ -63,12 +65,7 @@ func init() {
 	RootCmd.AddCommand(PluginCmd)
 }
 
-func pluginAddCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func pluginAddCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -90,12 +87,7 @@ func pluginAddCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func pluginDeleteCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func pluginDeleteCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -111,12 +103,7 @@ func pluginDeleteCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func pluginEnableCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func pluginEnableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -132,12 +119,7 @@ func pluginEnableCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func pluginDisableCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func pluginDisableCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -153,12 +135,7 @@ func pluginDisableCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func pluginListCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func pluginListCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	pluginsResp, response := c.GetPlugins()
 	if response.Error != nil {
 		return errors.New("Unable to list plugins. Error: " + response.Error.Error())

--- a/commands/post.go
+++ b/commands/post.go
@@ -20,7 +20,7 @@ var PostCreateCmd = &cobra.Command{
 	Short:   "Create a post",
 	Example: `  post create myteam:mychannel --message "some text for the post"`,
 	Args:    cobra.ExactArgs(1),
-	RunE:    postCreateCmdF,
+	RunE:    withClient(postCreateCmdF),
 }
 
 var PostListCmd = &cobra.Command{
@@ -29,7 +29,7 @@ var PostListCmd = &cobra.Command{
 	Example: `  post list myteam:mychannel
   post list myteam:mychannel --number 20`,
 	Args: cobra.ExactArgs(1),
-	RunE: postListCmdF,
+	RunE: withClient(postListCmdF),
 }
 
 func init() {
@@ -48,12 +48,7 @@ func init() {
 	RootCmd.AddCommand(PostCmd)
 }
 
-func postCreateCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func postCreateCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	message, _ := command.Flags().GetString("message")
 	if message == "" {
 		return errors.New("Message cannot be empty")
@@ -125,12 +120,7 @@ func printPost(c *model.Client4, post *model.Post, usernames map[string]string, 
 	}
 }
 
-func postListCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func postListCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")

--- a/commands/post.go
+++ b/commands/post.go
@@ -48,13 +48,13 @@ func init() {
 	RootCmd.AddCommand(PostCmd)
 }
 
-func postCreateCmdF(c *model.Client4, command *cobra.Command, args []string) error {
-	message, _ := command.Flags().GetString("message")
+func postCreateCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
+	message, _ := cmd.Flags().GetString("message")
 	if message == "" {
 		return errors.New("Message cannot be empty")
 	}
 
-	replyTo, _ := command.Flags().GetString("reply-to")
+	replyTo, _ := cmd.Flags().GetString("reply-to")
 	if replyTo != "" {
 		replyToPost, res := c.GetPost(replyTo, "")
 		if res.Error != nil {
@@ -120,15 +120,15 @@ func printPost(c *model.Client4, post *model.Post, usernames map[string]string, 
 	}
 }
 
-func postListCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func postListCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
 	}
 
-	number, _ := command.Flags().GetInt("number")
-	showIds, _ := command.Flags().GetBool("show-ids")
-	follow, _ := command.Flags().GetBool("follow")
+	number, _ := cmd.Flags().GetInt("number")
+	showIds, _ := cmd.Flags().GetBool("show-ids")
+	follow, _ := cmd.Flags().GetBool("follow")
 
 	postList, res := c.GetPostsForChannel(channel.Id, 0, number, "")
 	if res.Error != nil {

--- a/commands/root.go
+++ b/commands/root.go
@@ -17,11 +17,11 @@ var RootCmd = &cobra.Command{
 	Use:   "mmctl",
 	Short: "Remote client for the Open Source, self-hosted Slack-alternative",
 	Long:  `Mattermost offers workplace messaging across web, PC and phones with archiving, search and integration with your existing systems. Documentation available at https://docs.mattermost.com`,
-	PersistentPreRun: func(command *cobra.Command, args []string) {
-		format, _ := command.Flags().GetString("format")
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		format, _ := cmd.Flags().GetString("format")
 		printer.SetFormat(format)
 	},
-	PersistentPostRun: func(command *cobra.Command, args []string) {
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		printer.Flush()
 	},
 }

--- a/commands/team.go
+++ b/commands/team.go
@@ -22,7 +22,7 @@ var TeamCreateCmd = &cobra.Command{
 	Long:  `Create a team.`,
 	Example: `  team create --name mynewteam --display_name "My New Team"
   team create --name private --display_name "My New Private Team" --private`,
-	RunE: createTeamCmdF,
+	RunE: withClient(createTeamCmdF),
 }
 
 var RemoveUsersCmd = &cobra.Command{
@@ -30,7 +30,7 @@ var RemoveUsersCmd = &cobra.Command{
 	Short:   "Remove users from team",
 	Long:    "Remove some users from team",
 	Example: "  team remove myteam user@example.com username",
-	RunE:    removeUsersCmdF,
+	RunE:    withClient(removeUsersCmdF),
 }
 
 var AddUsersCmd = &cobra.Command{
@@ -38,7 +38,7 @@ var AddUsersCmd = &cobra.Command{
 	Short:   "Add users to team",
 	Long:    "Add some users to team",
 	Example: "  team add myteam user@example.com username",
-	RunE:    addUsersCmdF,
+	RunE:    withClient(addUsersCmdF),
 }
 
 var DeleteTeamsCmd = &cobra.Command{
@@ -47,7 +47,7 @@ var DeleteTeamsCmd = &cobra.Command{
 	Long: `Permanently delete some teams.
 Permanently deletes a team along with all related information including posts from the database.`,
 	Example: "  team delete myteam",
-	RunE:    deleteTeamsCmdF,
+	RunE:    withClient(deleteTeamsCmdF),
 }
 
 var ListTeamsCmd = &cobra.Command{
@@ -55,7 +55,7 @@ var ListTeamsCmd = &cobra.Command{
 	Short:   "List all teams.",
 	Long:    `List all teams on the server.`,
 	Example: "  team list",
-	RunE:    listTeamsCmdF,
+	RunE:    withClient(listTeamsCmdF),
 }
 
 var SearchTeamCmd = &cobra.Command{
@@ -64,7 +64,7 @@ var SearchTeamCmd = &cobra.Command{
 	Long:    "Search for teams based on name",
 	Example: "  team search team1",
 	Args:    cobra.MinimumNArgs(1),
-	RunE:    searchTeamCmdF,
+	RunE:    withClient(searchTeamCmdF),
 }
 
 func init() {
@@ -87,11 +87,7 @@ func init() {
 	RootCmd.AddCommand(TeamCmd)
 }
 
-func createTeamCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
+func createTeamCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	name, errn := command.Flags().GetString("name")
@@ -127,12 +123,7 @@ func createTeamCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func removeUsersCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func removeUsersCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
 	}
@@ -160,12 +151,7 @@ func removeUserFromTeam(c *model.Client4, team *model.Team, user *model.User, us
 	}
 }
 
-func addUsersCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func addUsersCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
 	}
@@ -194,12 +180,7 @@ func addUserToTeam(c *model.Client4, team *model.Team, user *model.User, userArg
 	}
 }
 
-func deleteTeamsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func deleteTeamsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Not enough arguments.")
 	}
@@ -240,12 +221,7 @@ func deleteTeam(c *model.Client4, team *model.Team) (bool, *model.Response) {
 	return c.PermanentDeleteTeam(team.Id)
 }
 
-func listTeamsCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func listTeamsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	teams, response := c.GetAllTeams("", 0, 10000)
 	if response.Error != nil {
 		return response.Error
@@ -262,12 +238,7 @@ func listTeamsCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func searchTeamCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func searchTeamCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	var teams []*model.Team
 
 	for _, searchTerm := range args {

--- a/commands/team.go
+++ b/commands/team.go
@@ -87,19 +87,19 @@ func init() {
 	RootCmd.AddCommand(TeamCmd)
 }
 
-func createTeamCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func createTeamCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
-	name, errn := command.Flags().GetString("name")
+	name, errn := cmd.Flags().GetString("name")
 	if errn != nil || name == "" {
 		return errors.New("Name is required")
 	}
-	displayname, errdn := command.Flags().GetString("display_name")
+	displayname, errdn := cmd.Flags().GetString("display_name")
 	if errdn != nil || displayname == "" {
 		return errors.New("Display Name is required")
 	}
-	email, _ := command.Flags().GetString("email")
-	useprivate, _ := command.Flags().GetBool("private")
+	email, _ := cmd.Flags().GetString("email")
+	useprivate, _ := cmd.Flags().GetBool("private")
 
 	teamType := model.TEAM_OPEN
 	if useprivate {
@@ -123,7 +123,7 @@ func createTeamCmdF(c *model.Client4, command *cobra.Command, args []string) err
 	return nil
 }
 
-func removeUsersCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func removeUsersCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
 	}
@@ -151,7 +151,7 @@ func removeUserFromTeam(c *model.Client4, team *model.Team, user *model.User, us
 	}
 }
 
-func addUsersCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func addUsersCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
 	}
@@ -180,12 +180,12 @@ func addUserToTeam(c *model.Client4, team *model.Team, user *model.User, userArg
 	}
 }
 
-func deleteTeamsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func deleteTeamsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Not enough arguments.")
 	}
 
-	confirmFlag, _ := command.Flags().GetBool("confirm")
+	confirmFlag, _ := cmd.Flags().GetBool("confirm")
 	if !confirmFlag {
 		var confirm string
 		CommandPrettyPrintln("Have you performed a database backup? (YES/NO): ")
@@ -221,7 +221,7 @@ func deleteTeam(c *model.Client4, team *model.Team) (bool, *model.Response) {
 	return c.PermanentDeleteTeam(team.Id)
 }
 
-func listTeamsCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func listTeamsCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	teams, response := c.GetAllTeams("", 0, 10000)
 	if response.Error != nil {
 		return response.Error
@@ -238,7 +238,7 @@ func listTeamsCmdF(c *model.Client4, command *cobra.Command, args []string) erro
 	return nil
 }
 
-func searchTeamCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func searchTeamCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	var teams []*model.Team
 
 	for _, searchTerm := range args {

--- a/commands/user.go
+++ b/commands/user.go
@@ -116,7 +116,7 @@ func deactivateUsers(c *model.Client4, userArgs []string) {
 	}
 }
 
-func userDeactivateCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func userDeactivateCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -126,26 +126,26 @@ func userDeactivateCmdF(c *model.Client4, command *cobra.Command, args []string)
 	return nil
 }
 
-func userCreateCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func userCreateCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
-	username, erru := command.Flags().GetString("username")
+	username, erru := cmd.Flags().GetString("username")
 	if erru != nil {
 		return errors.Wrap(erru, "Username is required")
 	}
-	email, erre := command.Flags().GetString("email")
+	email, erre := cmd.Flags().GetString("email")
 	if erre != nil {
 		return errors.Wrap(erre, "Email is required")
 	}
-	password, errp := command.Flags().GetString("password")
+	password, errp := cmd.Flags().GetString("password")
 	if errp != nil {
 		return errors.Wrap(errp, "Password is required")
 	}
-	nickname, _ := command.Flags().GetString("nickname")
-	firstname, _ := command.Flags().GetString("firstname")
-	lastname, _ := command.Flags().GetString("lastname")
-	locale, _ := command.Flags().GetString("locale")
-	systemAdmin, _ := command.Flags().GetBool("system_admin")
+	nickname, _ := cmd.Flags().GetString("nickname")
+	firstname, _ := cmd.Flags().GetString("firstname")
+	lastname, _ := cmd.Flags().GetString("lastname")
+	locale, _ := cmd.Flags().GetString("locale")
+	systemAdmin, _ := cmd.Flags().GetBool("system_admin")
 
 	user := &model.User{
 		Username:  username,
@@ -174,7 +174,7 @@ func userCreateCmdF(c *model.Client4, command *cobra.Command, args []string) err
 	return nil
 }
 
-func userInviteCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func userInviteCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("Expected at least two arguments. See help text for details.")
 	}
@@ -211,7 +211,7 @@ func inviteUser(c *model.Client4, email string, team *model.Team, teamArg string
 	return nil
 }
 
-func sendPasswordResetEmailCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func sendPasswordResetEmailCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -229,7 +229,7 @@ func sendPasswordResetEmailCmdF(c *model.Client4, command *cobra.Command, args [
 	return nil
 }
 
-func updateUserEmailCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func updateUserEmailCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	if len(args) != 2 {
@@ -263,7 +263,7 @@ func updateUserEmailCmdF(c *model.Client4, command *cobra.Command, args []string
 	return nil
 }
 
-func resetUserMfaCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func resetUserMfaCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -283,7 +283,7 @@ func resetUserMfaCmdF(c *model.Client4, command *cobra.Command, args []string) e
 	return nil
 }
 
-func searchUserCmdF(c *model.Client4, command *cobra.Command, args []string) error {
+func searchUserCmdF(c *model.Client4, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	if len(args) < 1 {

--- a/commands/user.go
+++ b/commands/user.go
@@ -21,7 +21,7 @@ var UserDeactivateCmd = &cobra.Command{
 	Long:  "Deactivate users. Deactivated users are immediately logged out of all sessions and are unable to log back in.",
 	Example: `  user deactivate user@example.com
   user deactivate username`,
-	RunE: userDeactivateCmdF,
+	RunE: withClient(userDeactivateCmdF),
 }
 
 var UserCreateCmd = &cobra.Command{
@@ -29,7 +29,7 @@ var UserCreateCmd = &cobra.Command{
 	Short:   "Create a user",
 	Long:    "Create a user",
 	Example: `  user create --email user@example.com --username userexample --password Password1`,
-	RunE:    userCreateCmdF,
+	RunE:    withClient(userCreateCmdF),
 }
 
 var UserInviteCmd = &cobra.Command{
@@ -40,7 +40,7 @@ You can invite a user to multiple teams by listing them.
 You can specify teams by name or ID.`,
 	Example: `  user invite user@example.com myteam
   user invite user@example.com myteam1 myteam2`,
-	RunE: userInviteCmdF,
+	RunE: withClient(userInviteCmdF),
 }
 
 var SendPasswordResetEmailCmd = &cobra.Command{
@@ -48,7 +48,7 @@ var SendPasswordResetEmailCmd = &cobra.Command{
 	Short:   "Send users an email to reset their password",
 	Long:    "Send users an email to reset their password",
 	Example: "  user reset_password user@example.com",
-	RunE:    sendPasswordResetEmailCmdF,
+	RunE:    withClient(sendPasswordResetEmailCmdF),
 }
 
 var updateUserEmailCmd = &cobra.Command{
@@ -57,7 +57,7 @@ var updateUserEmailCmd = &cobra.Command{
 	Long:  "Change email of the user.",
 	Example: `  user email test user@example.com
   user activate username`,
-	RunE: updateUserEmailCmdF,
+	RunE: withClient(updateUserEmailCmdF),
 }
 
 var ResetUserMfaCmd = &cobra.Command{
@@ -66,7 +66,7 @@ var ResetUserMfaCmd = &cobra.Command{
 	Long: `Turn off multi-factor authentication for a user.
 If MFA enforcement is enabled, the user will be forced to re-enable MFA as soon as they login.`,
 	Example: "  user resetmfa user@example.com",
-	RunE:    resetUserMfaCmdF,
+	RunE:    withClient(resetUserMfaCmdF),
 }
 
 var SearchUserCmd = &cobra.Command{
@@ -74,7 +74,7 @@ var SearchUserCmd = &cobra.Command{
 	Short:   "Search for users",
 	Long:    "Search for users based on username, email, or user ID.",
 	Example: "  user search user1@mail.com user2@mail.com",
-	RunE:    searchUserCmdF,
+	RunE:    withClient(searchUserCmdF),
 }
 
 func init() {
@@ -116,12 +116,7 @@ func deactivateUsers(c *model.Client4, userArgs []string) {
 	}
 }
 
-func userDeactivateCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func userDeactivateCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -131,11 +126,7 @@ func userDeactivateCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func userCreateCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
+func userCreateCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	username, erru := command.Flags().GetString("username")
@@ -183,12 +174,7 @@ func userCreateCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func userInviteCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func userInviteCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return errors.New("Expected at least two arguments. See help text for details.")
 	}
@@ -225,12 +211,7 @@ func inviteUser(c *model.Client4, email string, team *model.Team, teamArg string
 	return nil
 }
 
-func sendPasswordResetEmailCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func sendPasswordResetEmailCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -248,11 +229,7 @@ func sendPasswordResetEmailCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func updateUserEmailCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
+func updateUserEmailCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	if len(args) != 2 {
@@ -286,12 +263,7 @@ func updateUserEmailCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func resetUserMfaCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
-
+func resetUserMfaCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -311,11 +283,7 @@ func resetUserMfaCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func searchUserCmdF(command *cobra.Command, args []string) error {
-	c, err := InitClient()
-	if err != nil {
-		return err
-	}
+func searchUserCmdF(c *model.Client4, command *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
 	if len(args) < 1 {

--- a/commands/websockets.go
+++ b/commands/websockets.go
@@ -17,7 +17,7 @@ func init() {
 	RootCmd.AddCommand(WebsocketCmd)
 }
 
-func websocketCmdF(command *cobra.Command, args []string) error {
+func websocketCmdF(cmd *cobra.Command, args []string) error {
 	c, err := InitWebSocketClient()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR renames the `command` variables into `cmd`, and refactors the `Client` initialisation to use the `withClient` decorator.