### PR TITLE
Adds version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 GO_PACKAGES=$(shell go list ./...)
 GO ?= $(shell command -v go 2> /dev/null)
+BUILD_HASH = $(shell git rev-parse HEAD)
+
+LDFLAGS += -X "github.com/mattermost/mmctl/commands.BuildHash=$(BUILD_HASH)"
 
 all: build
 
 build: vendor check
-	go build -mod=vendor
+	go build -ldflags '$(LDFLAGS)' -mod=vendor
 
 install: vendor check
-	go install -mod=vendor
+	go install -ldflags '$(LDFLAGS)' -mod=vendor
 
 package: vendor check
 	mkdir -p build

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"github.com/mattermost/mmctl/printer"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	BuildHash = "dev mode"
+	Version   = "0.1.0"
+)
+
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints the version of mmctl.",
+	Args:  cobra.NoArgs,
+	Run:   versionCmdF,
+}
+
+func init() {
+	RootCmd.AddCommand(VersionCmd)
+}
+
+func versionCmdF(cmd *cobra.Command, args []string) {
+	printer.Print("mmctl v" + Version + " -- " + BuildHash)
+}


### PR DESCRIPTION
#### Summary

Adds a simple version command that shows the `mmctl` compiled version and commit hash.

Jira ticket: https://mattermost.atlassian.net/browse/MM-19890