### PR TITLE
Remove unnecessary gomock operators

### DIFF
--- a/commands/permissions_test.go
+++ b/commands/permissions_test.go
@@ -25,13 +25,13 @@ func (s *MmctlUnitTestSuite) TestAddPermissionsCmd() {
 
 		s.client.
 			EXPECT().
-			GetRoleByName(gomock.Eq(mockRole.Name)).
+			GetRoleByName(mockRole.Name).
 			Return(mockRole, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			PatchRole(gomock.Eq(mockRole.Id), gomock.Eq(expectedPatch)).
+			PatchRole(mockRole.Id, expectedPatch).
 			Return(&model.Role{}, &model.Response{Error: nil}).
 			Times(1)
 

--- a/commands/user_test.go
+++ b/commands/user_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mmctl/printer"
 
-	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +14,7 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(gomock.Eq(emailArg), gomock.Eq("")).
+			GetUserByEmail(emailArg, "").
 			Return(&mockUser, &model.Response{Error: nil}).
 			Times(1)
 
@@ -31,19 +30,19 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(gomock.Eq(arg), gomock.Eq("")).
+			GetUserByEmail(arg, "").
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetUserByUsername(gomock.Eq(arg), gomock.Eq("")).
+			GetUserByUsername(arg, "").
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetUser(gomock.Eq(arg), gomock.Eq("")).
+			GetUser(arg, "").
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 


### PR DESCRIPTION
#### Summary

Plain values are automatically wrapped with `gomock.Eq`, so we don't need to do it explicitly.