### PR TITLE
[GH-13124] Add unit tests to "PluginDisableCmd" to use testify

### DIFF
--- a/commands/plugin_test.go
+++ b/commands/plugin_test.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"strings"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mmctl/printer"
+
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestPluginDisableCmd() {
+	s.Run("Disable 1 plugin", func() {
+		printer.Clean()
+		arg := "plug1"
+
+		s.client.
+			EXPECT().
+			DisablePlugin(arg).
+			Return(false, &model.Response{Error: nil}).
+			Times(1)
+
+		err := pluginDisableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Disabled plugin: "+arg)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Fail to disable 1 plugin", func() {
+		printer.Clean()
+		arg := "fail1"
+		mockError := &model.AppError{Message: "Mock Error"}
+
+		s.client.
+			EXPECT().
+			DisablePlugin(arg).
+			Return(false, &model.Response{Error: mockError}).
+			Times(1)
+
+		err := pluginDisableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(printer.GetErrorLines()[0], "Unable to disable plugin: "+arg+". Error: "+mockError.Error())
+	})
+
+	s.Run("Disble several plugin with some errors", func() {
+		printer.Clean()
+		args := []string{"fail1", "plug2", "plug3", "fail4"}
+		mockError := &model.AppError{Message: "Mock Error"}
+
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "fail") {
+				s.client.
+					EXPECT().
+					DisablePlugin(arg).
+					Return(false, &model.Response{Error: mockError}).
+					Times(1)
+			} else {
+				s.client.
+					EXPECT().
+					DisablePlugin(arg).
+					Return(false, &model.Response{Error: nil}).
+					Times(1)
+			}
+		}
+
+		err := pluginDisableCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 2)
+		s.Require().Equal(printer.GetLines()[0], "Disabled plugin: "+args[1])
+		s.Require().Equal(printer.GetLines()[1], "Disabled plugin: "+args[2])
+		s.Require().Len(printer.GetErrorLines(), 2)
+		s.Require().Equal(printer.GetErrorLines()[0], "Unable to disable plugin: "+args[0]+". Error: "+mockError.Error())
+		s.Require().Equal(printer.GetErrorLines()[1], "Unable to disable plugin: "+args[3]+". Error: "+mockError.Error())
+	})
+}


### PR DESCRIPTION
Summary:
Add unit tests to "PluginDisableCmd" to use testify

Link:
Fixes https://github.com/mattermost/mattermost-server/issues/13124