### PR TITLE
[GH-13161] Add unit tests to the "PluginListCmd" mmctl command

### DIFF
--- a/commands/plugin_test.go
+++ b/commands/plugin_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -74,5 +75,91 @@ func (s *MmctlUnitTestSuite) TestPluginDisableCmd() {
 		s.Require().Len(printer.GetErrorLines(), 2)
 		s.Require().Equal(printer.GetErrorLines()[0], "Unable to disable plugin: "+args[0]+". Error: "+mockError.Error())
 		s.Require().Equal(printer.GetErrorLines()[1], "Unable to disable plugin: "+args[3]+". Error: "+mockError.Error())
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestPluginListCmd() {
+	s.Run("List JSON plugins", func() {
+		printer.Clean()
+		mockList := &model.PluginsResponse{
+			Active: []*model.PluginInfo{
+				&model.PluginInfo{
+					Manifest: model.Manifest{
+						Id:      "id1",
+						Name:    "name1",
+						Version: "v1",
+					},
+				},
+				&model.PluginInfo{
+					Manifest: model.Manifest{
+						Id:      "id2",
+						Name:    "name2",
+						Version: "v2",
+					},
+				},
+				&model.PluginInfo{
+					Manifest: model.Manifest{
+						Id:      "id3",
+						Name:    "name3",
+						Version: "v3",
+					},
+				},
+			}, Inactive: []*model.PluginInfo{
+				&model.PluginInfo{
+					Manifest: model.Manifest{
+						Id:      "id4",
+						Name:    "name4",
+						Version: "v4",
+					},
+				},
+				&model.PluginInfo{
+					Manifest: model.Manifest{
+						Id:      "id5",
+						Name:    "name5",
+						Version: "v5",
+					},
+				},
+				&model.PluginInfo{
+					Manifest: model.Manifest{
+						Id:      "id6",
+						Name:    "name6",
+						Version: "v6",
+					},
+				},
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetPlugins().
+			Return(mockList, &model.Response{Error: nil}).
+			Times(1)
+
+		err := pluginListCmdF(s.client, &cobra.Command{}, nil)
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetLines(), 8)
+		s.Require().Equal("Listing active plugins", printer.GetLines()[0])
+		for i, plugin := range mockList.Active {
+			s.Require().Equal(plugin, printer.GetLines()[i+1])
+		}
+		s.Require().Equal("Listing inactive plugins", printer.GetLines()[4])
+		for i, plugin := range mockList.Inactive {
+			s.Require().Equal(plugin, printer.GetLines()[i+5])
+		}
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+	s.Run("GetPlugins returns error", func() {
+		printer.Clean()
+		mockError := &model.AppError{Message: "Mock Error"}
+
+		s.client.
+			EXPECT().
+			GetPlugins().
+			Return(nil, &model.Response{Error: mockError}).
+			Times(1)
+
+		err := pluginListCmdF(s.client, &cobra.Command{}, nil)
+		s.Require().NotNil(err)
+		s.Require().Equal(err, errors.New("Unable to list plugins. Error: "+mockError.Error()))
 	})
 }


### PR DESCRIPTION
Summary:
Add unit tests to the "PluginListCmd" mmctl command
Link:
Fixes https://github.com/mattermost/mattermost-server/issues/13161