### PR TITLE
[MM-20287] Add tests for the post create command

### DIFF
--- a/commands/post.go
+++ b/commands/post.go
@@ -66,10 +66,9 @@ func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	channelArg, _ := cmd.Flags().GetString("channel")
-	channel := getChannelFromChannelArg(c, channelArg)
+	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
-		return errors.New("unable to find channel '" + channelArg + "'")
+		return errors.New("unable to find channel '" + args[0] + "'")
 	}
 
 	post := &model.Post{

--- a/commands/post.go
+++ b/commands/post.go
@@ -52,7 +52,7 @@ func init() {
 func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	message, _ := cmd.Flags().GetString("message")
 	if message == "" {
-		return errors.New("Message cannot be empty")
+		return errors.New("message cannot be empty")
 	}
 
 	replyTo, _ := cmd.Flags().GetString("reply-to")
@@ -66,9 +66,10 @@ func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	channel := getChannelFromChannelArg(c, args[0])
+	channelArg, _ := cmd.Flags().GetString("channel")
+	channel := getChannelFromChannelArg(c, channelArg)
 	if channel == nil {
-		return errors.New("Unable to find channel '" + args[0] + "'")
+		return errors.New("unable to find channel '" + channelArg + "'")
 	}
 
 	post := &model.Post{

--- a/commands/post.go
+++ b/commands/post.go
@@ -52,7 +52,7 @@ func init() {
 func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	message, _ := cmd.Flags().GetString("message")
 	if message == "" {
-		return errors.New("message cannot be empty")
+		return errors.New("Message cannot be empty")
 	}
 
 	replyTo, _ := cmd.Flags().GetString("reply-to")
@@ -68,7 +68,7 @@ func postCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
-		return errors.New("unable to find channel '" + args[0] + "'")
+		return errors.New("Unable to find channel '" + args[0] + "'")
 	}
 
 	post := &model.Post{

--- a/commands/post_test.go
+++ b/commands/post_test.go
@@ -1,0 +1,109 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestPostCreateCmdF() {
+	s.Run("create a post with empty text", func() {
+		cmd := &cobra.Command{}
+		cmd.Flags().String("message", "", "")
+
+		err := postCreateCmdF(s.client, cmd, nil)
+		s.Require().NotNil(err)
+	})
+
+	s.Run("no channel specified", func() {
+		msgArg := "some text"
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("message", msgArg, "")
+
+		err := postCreateCmdF(s.client, cmd, []string{msgArg})
+		s.Require().NotNil(err)
+	})
+
+	s.Run("wrong reply msg", func() {
+		msgArg := "some text"
+		replyToArg := "a-non-existing-post"
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("message", msgArg, "")
+		cmd.Flags().String("reply-to", replyToArg, "")
+
+		s.client.
+			EXPECT().
+			GetPost(replyToArg, "").
+			Return(nil, &model.Response{Error: &model.AppError{Message: "some-error"}}).
+			Times(1)
+
+		err := postCreateCmdF(s.client, cmd, []string{msgArg})
+		s.Require().NotNil(err)
+	})
+
+	s.Run("create a post", func() {
+		msgArg := "some text"
+		channelArg := "example-channel"
+		mockChannel := model.Channel{Name: channelArg}
+		mockPost := model.Post{Message: msgArg}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("channel", channelArg, "")
+		cmd.Flags().String("message", msgArg, "")
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			CreatePost(&mockPost).
+			Return(&mockPost, &model.Response{Error: nil}).
+			Times(1)
+
+		err := postCreateCmdF(s.client, cmd, []string{channelArg, msgArg})
+		s.Require().Nil(err)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("reply to an existing post", func() {
+		msgArg := "some text"
+		replyToArg := "an-existing-post"
+		rootID := "some-root-id"
+		channelArg := "example-channel"
+		mockChannel := model.Channel{Name: channelArg}
+		mockReplyTo := model.Post{RootId: rootID}
+		mockPost := model.Post{Message: msgArg, RootId: rootID}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("channel", channelArg, "")
+		cmd.Flags().String("reply-to", replyToArg, "")
+		cmd.Flags().String("message", msgArg, "")
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPost(replyToArg, "").
+			Return(&mockReplyTo, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			CreatePost(&mockPost).
+			Return(&mockPost, &model.Response{Error: nil}).
+			Times(1)
+
+		err := postCreateCmdF(s.client, cmd, []string{channelArg, msgArg})
+		s.Require().Nil(err)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/post_test.go
+++ b/commands/post_test.go
@@ -9,9 +9,8 @@ import (
 func (s *MmctlUnitTestSuite) TestPostCreateCmdF() {
 	s.Run("create a post with empty text", func() {
 		cmd := &cobra.Command{}
-		cmd.Flags().String("message", "", "")
 
-		err := postCreateCmdF(s.client, cmd, nil)
+		err := postCreateCmdF(s.client, cmd, []string{"some-channel", ""})
 		s.Require().NotNil(err)
 	})
 
@@ -21,7 +20,7 @@ func (s *MmctlUnitTestSuite) TestPostCreateCmdF() {
 		cmd := &cobra.Command{}
 		cmd.Flags().String("message", msgArg, "")
 
-		err := postCreateCmdF(s.client, cmd, []string{msgArg})
+		err := postCreateCmdF(s.client, cmd, []string{"", msgArg})
 		s.Require().NotNil(err)
 	})
 
@@ -50,7 +49,6 @@ func (s *MmctlUnitTestSuite) TestPostCreateCmdF() {
 		mockPost := model.Post{Message: msgArg}
 
 		cmd := &cobra.Command{}
-		cmd.Flags().String("channel", channelArg, "")
 		cmd.Flags().String("message", msgArg, "")
 
 		s.client.
@@ -80,7 +78,6 @@ func (s *MmctlUnitTestSuite) TestPostCreateCmdF() {
 		mockPost := model.Post{Message: msgArg, RootId: rootID}
 
 		cmd := &cobra.Command{}
-		cmd.Flags().String("channel", channelArg, "")
 		cmd.Flags().String("reply-to", replyToArg, "")
 		cmd.Flags().String("message", msgArg, "")
 


### PR DESCRIPTION
**Summary**

- Minor refactor on `commands/post.go`.
- Adds tests for the `mmctl post create` command.


Fixes https://github.com/mattermost/mattermost-server/issues/13160