### PR TITLE
commands/auth: code polish and refactor error messages

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -145,7 +144,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if accessToken != "" && username != "" {
-		return errors.New("You must use --access-token or --username, but not both.")
+		return fmt.Errorf("you must use --access-token or --username, but not both")
 	}
 
 	if accessToken == "" && username == "" {
@@ -161,7 +160,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 	if username != "" && password == "" {
 		stdinPassword, err := getPasswordFromStdin()
 		if err != nil {
-			return errors.New("Couldn't read password. Error: " + err.Error())
+			return fmt.Errorf("couldn't read password: %v", err)
 		}
 		password = stdinPassword
 	}
@@ -214,7 +213,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Printf("\n  credentials for %v: %v@%v stored\n\n", name, username, url)
+	fmt.Printf("\n  credentials for %s: %s@%s stored\n\n", name, username, url)
 	return nil
 }
 
@@ -234,7 +233,7 @@ func currentCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("\n  found credentials for %v: %v @ %v\n\n", credentials.Name, credentials.Username, credentials.InstanceUrl)
+	fmt.Printf("\n  found credentials for %s: %s @ %s\n\n", credentials.Name, credentials.Username, credentials.InstanceUrl)
 	return nil
 }
 
@@ -243,7 +242,7 @@ func setCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Credentials for server \"%v\" set as active\n", args[0])
+	fmt.Printf("Credentials for server %q set as active\n", args[0])
 
 	return nil
 }
@@ -255,7 +254,7 @@ func listCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(*credentialsList) == 0 {
-		return errors.New("There are no registered credentials, maybe you need to use login first")
+		return fmt.Errorf("there are no registered credentials, maybe you need to use login first")
 	}
 
 	serverNames := []string{}
@@ -305,7 +304,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 		if password == "" {
 			stdinPassword, err := getPasswordFromStdin()
 			if err != nil {
-				return errors.New("Couldn't read password. Error: " + err.Error())
+				return fmt.Errorf("couldn't read password: %v", err)
 			}
 			password = stdinPassword
 		}
@@ -322,7 +321,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 
 	case METHOD_TOKEN:
 		if accessToken == "" {
-			return errors.New("Requires the --access-token parameter to be set")
+			return fmt.Errorf("requires the --access-token parameter to be set")
 		}
 
 		credentials.AuthToken = accessToken
@@ -332,7 +331,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 
 	case METHOD_MFA:
 		if mfaToken == "" {
-			return errors.New("Requires the --mfa-token parameter to be set")
+			return fmt.Errorf("requires the --mfa-token parameter to be set")
 		}
 
 		c, err := InitClientWithMFA(credentials.Username, password, mfaToken, credentials.InstanceUrl)
@@ -342,7 +341,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 		credentials.AuthToken = c.AuthToken
 
 	default:
-		return errors.New(fmt.Sprintf("Invalid auth method \"%s\"", credentials.AuthMethod))
+		return fmt.Errorf("invalid auth method %q", credentials.AuthMethod)
 	}
 
 	if err := SaveCredentials(*credentials); err != nil {
@@ -363,7 +362,7 @@ func deleteCmdF(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	credentials := (*credentialsList)[name]
 	if credentials == nil {
-		return errors.New(fmt.Sprintf("Cannot find credentials for server name %v", name))
+		return fmt.Errorf("cannot find credentials for server name %v", name)
 	}
 
 	delete(*credentialsList, name)

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -214,7 +214,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Printf("\n  credentials for %s: %s@%s stored\n\n", name, username, url)
+	fmt.Printf("\n  credentials for %q: \"%s@%s\" stored\n\n", name, username, url)
 	return nil
 }
 
@@ -234,7 +234,7 @@ func currentCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("\n  found credentials for %s: %s @ %s\n\n", credentials.Name, credentials.Username, credentials.InstanceUrl)
+	fmt.Printf("\n  found credentials for %q: \"%s@%s\"\n\n", credentials.Name, credentials.Username, credentials.InstanceUrl)
 	return nil
 }
 

--- a/commands/auth_utils.go
+++ b/commands/auth_utils.go
@@ -128,7 +128,7 @@ func SetCurrent(name string) error {
 	}
 
 	if !found {
-		return errors.Errorf("cannot find credentials for server %s", name)
+		return errors.Errorf("cannot find credentials for server %q", name)
 	}
 
 	return SaveCredentialsList(credentialsList)

--- a/commands/auth_utils.go
+++ b/commands/auth_utils.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -41,17 +40,17 @@ func ReadCredentialsList() (*CredentialsList, error) {
 	}
 
 	if _, errStat := os.Stat(configFilePath); err != nil {
-		return nil, errors.New("Cannot read user credentials, maybe you need to use login first. Error: " + errStat.Error())
+		return nil, fmt.Errorf("cannot read user credentials, maybe you need to use login first: %v", errStat)
 	}
 
 	fileContents, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
-		return nil, errors.New("There was a problem reading the credentials file. Error: " + err.Error())
+		return nil, fmt.Errorf("there was a problem reading the credentials file: %v", err)
 	}
 
 	var credentialsList CredentialsList
 	if err := json.Unmarshal(fileContents, &credentialsList); err != nil {
-		return nil, errors.New("There was a problem parsing the credentials file. Error: " + err.Error())
+		return nil, fmt.Errorf("there was a problem parsing the credentials file: %v", err)
 	}
 
 	return &credentialsList, nil
@@ -68,7 +67,7 @@ func GetCurrentCredentials() (*Credentials, error) {
 			return c, nil
 		}
 	}
-	return nil, errors.New("No current context available. Please use the \"auth set\" command.")
+	return nil, fmt.Errorf("no current context available. please use the %q command", "auth set")
 }
 
 func GetCredentials(name string) (*Credentials, error) {
@@ -82,7 +81,7 @@ func GetCredentials(name string) (*Credentials, error) {
 			return c, nil
 		}
 	}
-	return nil, errors.New(fmt.Sprintf("Couldn't find credentials for connection \"%s\"", name))
+	return nil, fmt.Errorf("couldn't find credentials for connection %q", name)
 }
 
 func SaveCredentials(credentials Credentials) error {
@@ -105,7 +104,7 @@ func SaveCredentialsList(credentialsList *CredentialsList) error {
 	marshaledCredentialsList, _ := json.MarshalIndent(credentialsList, "", "    ")
 
 	if err := ioutil.WriteFile(configFilePath, marshaledCredentialsList, 0600); err != nil {
-		return errors.New("Cannot save the credentials. Error: " + err.Error())
+		return fmt.Errorf("cannot save the credentials: %v", err)
 	}
 
 	return nil
@@ -128,7 +127,7 @@ func SetCurrent(name string) error {
 	}
 
 	if !found {
-		return errors.New("Cannot find credentials for server " + name)
+		return fmt.Errorf("cannot find credentials for server %s", name)
 	}
 
 	return SaveCredentialsList(credentialsList)


### PR DESCRIPTION
This PR proposes the migration to `fmt.Errorf` from `errors.New` since most of the error messages require formatting. Also, it introduces the all lowercase error messages just like its use in the standard library. (prettier error messages when chaining them.)

This PR aims to discuss these ideas. As a demonstration I implemented these ideas onto `commands/auth.go` and `commands/auth_utils.go`.