### PR TITLE
Add two new commands for config: set and reset

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -59,5 +59,6 @@ type Client interface {
 	ListCommands(teamId string, customOnly bool) ([]*model.Command, *model.Response)
 	DeleteCommand(commandId string) (bool, *model.Response)
 	GetConfig() (*model.Config, *model.Response)
+	SetConfig(*model.Config) *model.Response
 	SyncLdap() (bool, *model.Response)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -59,6 +59,6 @@ type Client interface {
 	ListCommands(teamId string, customOnly bool) ([]*model.Command, *model.Response)
 	DeleteCommand(commandId string) (bool, *model.Response)
 	GetConfig() (*model.Config, *model.Response)
-	SetConfig(*model.Config) *model.Response
+	UpdateConfig(*model.Config) (*model.Config, *model.Response)
 	SyncLdap() (bool, *model.Response)
 }

--- a/commands/config.go
+++ b/commands/config.go
@@ -237,11 +237,12 @@ func configResetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	if _, res := c.UpdateConfig(config); res.Error != nil {
+	newConfig, res := c.UpdateConfig(config)
+	if res.Error != nil {
 		return res.Error
 	}
 
-	printer.Print("Value/s reset successfully")
+	printer.PrintT("Value/s reset successfully", newConfig)
 	return nil
 }
 

--- a/commands/config.go
+++ b/commands/config.go
@@ -191,11 +191,12 @@ func configSetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	if err := setConfigValue(path, config, args[1:]); err != nil {
 		return err
 	}
-	if _, res := c.UpdateConfig(config); res.Error != nil {
+	newConfig, res := c.UpdateConfig(config)
+	if res.Error != nil {
 		return res.Error
 	}
 
-	printer.Print("Value changed successfully")
+	printer.PrintT("Value changed successfully", newConfig)
 	return nil
 }
 

--- a/commands/config.go
+++ b/commands/config.go
@@ -208,10 +208,10 @@ func configResetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		confirmationMsg := fmt.Sprintf(
 			"Are you sure you want to reset %s to their default value? (YES/NO): ",
 			args[0])
-		printer.Print(confirmationMsg)
+		fmt.Println(confirmationMsg)
 		fmt.Scanln(&confirmResetAll)
 		if confirmResetAll != "YES" {
-			printer.Print("Reset operation aborted")
+			fmt.Println("Reset operation aborted")
 			return nil
 		}
 	}

--- a/commands/config.go
+++ b/commands/config.go
@@ -232,7 +232,10 @@ func configResetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		if !ok {
 			return errors.New("Invalid key")
 		}
-		resetConfigValue(path, config, defaultValue)
+		err = resetConfigValue(path, config, defaultValue)
+		if err != nil {
+			return err
+		}
 	}
 	if _, res := c.UpdateConfig(config); res.Error != nil {
 		return res.Error

--- a/commands/config.go
+++ b/commands/config.go
@@ -184,7 +184,7 @@ func configSetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	if err := setConfigValue(path, config, args[1:]); err != nil {
 		return err
 	}
-	if res := c.SetConfig(config); res.Error != nil {
+	if _, res := c.UpdateConfig(config); res.Error != nil {
 		return res.Error
 	}
 
@@ -212,7 +212,7 @@ func configResetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 		resetConfigValue(path, config, defaultValue)
 	}
-	if res := c.SetConfig(config); res.Error != nil {
+	if _, res := c.UpdateConfig(config); res.Error != nil {
 		return res.Error
 	}
 

--- a/commands/config.go
+++ b/commands/config.go
@@ -1,10 +1,13 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mmctl/client"
 	"github.com/mattermost/mmctl/printer"
 
@@ -25,6 +28,15 @@ var ConfigGetCmd = &cobra.Command{
 	RunE:    withClient(configGetCmdF),
 }
 
+var ConfigSetCmd = &cobra.Command{
+	Use:     "set",
+	Short:   "Set config setting",
+	Long:    "Adds or updates a config setting by its name in dot notation.",
+	Example: `config set SqlSettings.DriverName postgresql`,
+	Args:    cobra.ExactArgs(2),
+	RunE:    withClient(configSetCmdF),
+}
+
 var ConfigShowCmd = &cobra.Command{
 	Use:     "show",
 	Short:   "Writes the server configuration to STDOUT",
@@ -37,6 +49,7 @@ var ConfigShowCmd = &cobra.Command{
 func init() {
 	ConfigCmd.AddCommand(
 		ConfigGetCmd,
+		ConfigSetCmd,
 		ConfigShowCmd,
 	)
 	RootCmd.AddCommand(ConfigCmd)
@@ -59,6 +72,62 @@ func getValue(path []string, obj interface{}) (interface{}, bool) {
 	}
 }
 
+func setValue(path []string, obj reflect.Value, newValue string) error {
+	val := obj.FieldByName(path[0])
+
+	if val.Kind() == reflect.Invalid {
+		return errors.New("Selected path object is not valid")
+	}
+
+	if val.Kind() == reflect.Struct {
+		return setValue(path[1:], val, newValue)
+	} else if len(path) == 1 {
+		// All the updatable values should be pointers so can be modified
+		// using reflection
+		if val.Kind() != reflect.Ptr && val.Kind() != reflect.Slice {
+			return errors.New("Value is not modifiable")
+		} else if val.Kind() == reflect.Ptr {
+			switch val.Elem().Kind() {
+			case reflect.Int:
+				v, err := strconv.ParseInt(newValue, 10, 64)
+				if err != nil {
+					return errors.New("Target value is of type Int and provided value is not")
+				}
+				val.Elem().SetInt(v)
+				return nil
+			case reflect.String:
+				val.Elem().SetString(newValue)
+				return nil
+			case reflect.Bool:
+				v, err := strconv.ParseBool(newValue)
+				if err != nil {
+					return errors.New("Target value is of type Bool and provided value is not")
+				}
+				val.Elem().SetBool(v)
+				return nil
+			default:
+				return errors.New("Target value type is not supported")
+			}
+		} else {
+			var newSlice []string
+			err := json.Unmarshal([]byte(newValue), &newSlice)
+			if err != nil {
+				return errors.New("Target value is of type array of strings and provided value is not")
+			}
+			val.Set(reflect.ValueOf(newSlice))
+			return nil
+		}
+	} else {
+		return errors.New("Path object type is not supported")
+	}
+
+	return nil
+}
+
+func setConfigValue(path []string, config *model.Config, newValue string) error {
+	return setValue(path, reflect.ValueOf(config).Elem(), newValue)
+}
+
 func configGetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 	printer.SetFormat(printer.FORMAT_JSON)
@@ -78,6 +147,26 @@ func configGetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func configSetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	config, response := c.GetConfig()
+	if response.Error != nil {
+		return response.Error
+	}
+
+	path, err := parseConfigPath(args[0])
+	if err != nil {
+		return err
+	}
+	if err := setConfigValue(path, config, args[1]); err != nil {
+		return err
+	}
+	if res := c.SetConfig(config); res.Error != nil {
+		return res.Error
+	}
+
+	return nil
+}
+
 func configShowCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 	printer.SetFormat(printer.FORMAT_JSON)
@@ -89,4 +178,8 @@ func configShowCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	printer.Print(config)
 
 	return nil
+}
+
+func parseConfigPath(configPath string) ([]string, error) {
+	return strings.Split(configPath, "."), nil
 }

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -170,7 +170,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(string), "Value changed successfully")
+		s.Require().Equal(printer.GetLines()[0].(*model.Config), inputConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -198,7 +198,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(string), "Value changed successfully")
+		s.Require().Equal(printer.GetLines()[0].(*model.Config), inputConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -226,7 +226,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(string), "Value changed successfully")
+		s.Require().Equal(printer.GetLines()[0].(*model.Config), inputConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -253,7 +253,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(string), "Value changed successfully")
+		s.Require().Equal(printer.GetLines()[0].(*model.Config), inputConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -1,0 +1,392 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestConfigGetCmd() {
+	s.Run("Get a string config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(*(printer.GetLines()[0].(*string)), "mysql")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get an int config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.MaxIdleConns"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(*(printer.GetLines()[0].(*int)), 20)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get a boolean config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.Trace"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(*(printer.GetLines()[0].(*bool)), false)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get a slice of string config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DataSourceReplicas"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0].([]string), []string{})
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get config struct for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+		sqlSettings := model.SqlSettings{}
+		sqlSettings.SetDefaults(false)
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0].(model.SqlSettings), sqlSettings)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get error if the key doesn't exists", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.WrongKey"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+		sqlSettings := model.SqlSettings{}
+		sqlSettings.SetDefaults(false)
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should handle the response error", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+		sqlSettings := model.SqlSettings{}
+		sqlSettings.SetDefaults(false)
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{StatusCode: 500, Error: &model.AppError{}}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
+	s.Run("Set a string config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName", "postgres"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		changedValue := "postgres"
+		inputConfig.SqlSettings.DriverName = &changedValue
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0].(string), "Value changed successfully")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Set an int config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.MaxIdleConns", "20"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		changedValue := 20
+		inputConfig.SqlSettings.MaxIdleConns = &changedValue
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0].(string), "Value changed successfully")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Set a boolean config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.Trace", "true"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		changedValue := true
+		inputConfig.SqlSettings.Trace = &changedValue
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0].(string), "Value changed successfully")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Set a slice of string config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DataSourceReplicas", "test1", "test2"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		inputConfig.SqlSettings.DataSourceReplicas = []string{"test1", "test2"}
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0].(string), "Value changed successfully")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get error if the key doesn't exists", func() {
+		printer.Clean()
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		args := []string{"SqlSettings.WrongKey", "test1"}
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(0)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should handle response error from the server", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName", "postgres"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		changedValue := "postgres"
+		inputConfig.SqlSettings.DriverName = &changedValue
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{StatusCode: 500, Error: &model.AppError{}}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
+	s.Run("Reset a single key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(defaultConfig).
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		resetCmd := &cobra.Command{}
+		resetCmd.Flags().Bool("confirm", true, "")
+		err := configResetCmdF(s.client, resetCmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0].(string), "Value/s reset successfully")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Reset a whole config section", func() {
+		printer.Clean()
+		args := []string{"SqlSettings"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(defaultConfig).
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		resetCmd := &cobra.Command{}
+		resetCmd.Flags().Bool("confirm", true, "")
+		resetCmd.ParseFlags([]string{"confirm"})
+		err := configResetCmdF(s.client, resetCmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0].(string), "Value/s reset successfully")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should fail if the key doesn't exists", func() {
+		printer.Clean()
+		args := []string{"WrongKey"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(defaultConfig).
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(0)
+
+		resetCmd := &cobra.Command{}
+		resetCmd.Flags().Bool("confirm", true, "")
+		resetCmd.ParseFlags([]string{"confirm"})
+		err := configResetCmdF(s.client, resetCmd, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -79,7 +79,7 @@ func (s *MmctlUnitTestSuite) TestConfigGetCmd() {
 		err := configGetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].([]string), []string{})
+		s.Require().Equal(printer.GetLines()[0], []string{})
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -100,7 +100,7 @@ func (s *MmctlUnitTestSuite) TestConfigGetCmd() {
 		err := configGetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(model.SqlSettings), sqlSettings)
+		s.Require().Equal(printer.GetLines()[0], sqlSettings)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -170,7 +170,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(*model.Config), inputConfig)
+		s.Require().Equal(printer.GetLines()[0], inputConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -198,7 +198,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(*model.Config), inputConfig)
+		s.Require().Equal(printer.GetLines()[0], inputConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -226,7 +226,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(*model.Config), inputConfig)
+		s.Require().Equal(printer.GetLines()[0], inputConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -253,7 +253,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(*model.Config), inputConfig)
+		s.Require().Equal(printer.GetLines()[0], inputConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -328,7 +328,7 @@ func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
 		err := configResetCmdF(s.client, resetCmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(*model.Config), defaultConfig)
+		s.Require().Equal(printer.GetLines()[0], defaultConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -355,7 +355,7 @@ func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
 		err := configResetCmdF(s.client, resetCmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(*model.Config), defaultConfig)
+		s.Require().Equal(printer.GetLines()[0], defaultConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -270,11 +270,6 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 			GetConfig().
 			Return(defaultConfig, &model.Response{Error: nil}).
 			Times(1)
-		s.client.
-			EXPECT().
-			UpdateConfig(inputConfig).
-			Return(inputConfig, &model.Response{Error: nil}).
-			Times(0)
 
 		err := configSetCmdF(s.client, &cobra.Command{}, args)
 		s.Require().NotNil(err)
@@ -375,11 +370,6 @@ func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
 			GetConfig().
 			Return(defaultConfig, &model.Response{Error: nil}).
 			Times(1)
-		s.client.
-			EXPECT().
-			UpdateConfig(defaultConfig).
-			Return(defaultConfig, &model.Response{Error: nil}).
-			Times(0)
 
 		resetCmd := &cobra.Command{}
 		resetCmd.Flags().Bool("confirm", true, "")

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -328,7 +328,7 @@ func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
 		err := configResetCmdF(s.client, resetCmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(string), "Value/s reset successfully")
+		s.Require().Equal(printer.GetLines()[0].(*model.Config), defaultConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
@@ -355,7 +355,7 @@ func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
 		err := configResetCmdF(s.client, resetCmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0].(string), "Value/s reset successfully")
+		s.Require().Equal(printer.GetLines()[0].(*model.Config), defaultConfig)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -741,20 +741,6 @@ func (mr *MockClientMockRecorder) SendPasswordResetEmail(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendPasswordResetEmail", reflect.TypeOf((*MockClient)(nil).SendPasswordResetEmail), arg0)
 }
 
-// SetConfig mocks base method
-func (m *MockClient) SetConfig(arg0 *model.Config) *model.Response {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
-	ret0, _ := ret[0].(*model.Response)
-	return ret0
-}
-
-// SetConfig indicates an expected call of SetConfig
-func (mr *MockClientMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockClient)(nil).SetConfig), arg0)
-}
-
 // SyncLdap mocks base method
 func (m *MockClient) SyncLdap() (bool, *model.Response) {
 	m.ctrl.T.Helper()
@@ -768,6 +754,21 @@ func (m *MockClient) SyncLdap() (bool, *model.Response) {
 func (mr *MockClientMockRecorder) SyncLdap() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncLdap", reflect.TypeOf((*MockClient)(nil).SyncLdap))
+}
+
+// UpdateConfig mocks base method
+func (m *MockClient) UpdateConfig(arg0 *model.Config) (*model.Config, *model.Response) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateConfig", arg0)
+	ret0, _ := ret[0].(*model.Config)
+	ret1, _ := ret[1].(*model.Response)
+	return ret0, ret1
+}
+
+// UpdateConfig indicates an expected call of UpdateConfig
+func (mr *MockClientMockRecorder) UpdateConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfig", reflect.TypeOf((*MockClient)(nil).UpdateConfig), arg0)
 }
 
 // UpdateUser mocks base method

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -741,6 +741,20 @@ func (mr *MockClientMockRecorder) SendPasswordResetEmail(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendPasswordResetEmail", reflect.TypeOf((*MockClient)(nil).SendPasswordResetEmail), arg0)
 }
 
+// SetConfig mocks base method
+func (m *MockClient) SetConfig(arg0 *model.Config) *model.Response {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret0, _ := ret[0].(*model.Response)
+	return ret0
+}
+
+// SetConfig indicates an expected call of SetConfig
+func (mr *MockClientMockRecorder) SetConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockClient)(nil).SetConfig), arg0)
+}
+
 // SyncLdap mocks base method
 func (m *MockClient) SyncLdap() (bool, *model.Response) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR adds two new options (set and reset) to the config option for mmctl

This PR depends on #64 so we need to merge that PR before this one