### PR TITLE
Add tests for remove license command

### DIFF
--- a/commands/license_test.go
+++ b/commands/license_test.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestRemoveLicenseCmd() {
+	s.Run("Remove license successfully", func() {
+		printer.Clean()
+
+		s.client.
+			EXPECT().
+			RemoveLicenseFile().
+			Return(false, &model.Response{Error: nil}).
+			Times(1)
+
+		err := removeLicenseCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Equal(printer.GetLines()[0], "Removed license")
+	})
+
+	s.Run("Fail to remove license", func() {
+		printer.Clean()
+		mockErr := &model.AppError{Message: "Mock error"}
+
+		s.client.
+			EXPECT().
+			RemoveLicenseFile().
+			Return(false, &model.Response{Error: mockErr}).
+			Times(1)
+
+		err := removeLicenseCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Equal(err, mockErr)
+	})
+}


### PR DESCRIPTION
Summary:
Add unit tests for `mmctl license remove` command.

Link:
Fixes mattermost/mattermost-server#13158