### PR TITLE
Refactor group and permissions command files to use printer

### DIFF
--- a/commands/group.go
+++ b/commands/group.go
@@ -1,10 +1,9 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -130,7 +129,7 @@ func listLdapGroupsCmdF(c client.Client, cmd *cobra.Command, args []string) erro
 	}
 
 	for _, group := range groups {
-		fmt.Println(group)
+		printer.PrintT("{{.DisplayName}}", group)
 	}
 
 	return nil
@@ -174,15 +173,17 @@ func channelGroupDisableCmdF(c client.Client, cmd *cobra.Command, args []string)
 }
 
 func channelGroupStatusCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	printer.SetSingle(true)
+
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
 	}
 
 	if channel.GroupConstrained != nil && *channel.GroupConstrained {
-		fmt.Println("Enabled")
+		printer.Print("Enabled")
 	} else {
-		fmt.Println("Disabled")
+		printer.Print("Disabled")
 	}
 
 	return nil
@@ -200,7 +201,7 @@ func channelGroupListCmdF(c client.Client, cmd *cobra.Command, args []string) er
 	}
 
 	for _, group := range groups {
-		fmt.Println(group.DisplayName)
+		printer.PrintT("{{.DisplayName}}", group)
 	}
 
 	return nil
@@ -244,15 +245,17 @@ func teamGroupDisableCmdF(c client.Client, cmd *cobra.Command, args []string) er
 }
 
 func teamGroupStatusCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	printer.SetSingle(true)
+
 	team := getTeamFromTeamArg(c, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
 	}
 
 	if team.GroupConstrained != nil && *team.GroupConstrained {
-		fmt.Println("Enabled")
+		printer.Print("Enabled")
 	} else {
-		fmt.Println("Disabled")
+		printer.Print("Disabled")
 	}
 
 	return nil
@@ -270,7 +273,7 @@ func teamGroupListCmdF(c client.Client, cmd *cobra.Command, args []string) error
 	}
 
 	for _, group := range groups {
-		fmt.Println(group.DisplayName)
+		printer.PrintT("{{.DisplayName}}", group)
 	}
 
 	return nil

--- a/commands/permissions.go
+++ b/commands/permissions.go
@@ -1,10 +1,9 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/printer"
 
 	"github.com/spf13/cobra"
 )
@@ -106,23 +105,26 @@ func showRoleCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		return response.Error
 	}
 
-	fmt.Printf("Name: %s\n", role.Name)
-	fmt.Printf("Display Name: %s\n", role.DisplayName)
-	fmt.Printf("Description: %s\n", role.Description)
-	fmt.Printf("Permissions:\n")
-	for _, permission := range role.Permissions {
-		fmt.Printf("  - %s\n", permission)
-	}
-	if role.BuiltIn {
-		fmt.Printf("Built in: yes\n")
-	} else {
-		fmt.Printf("Built in: no\n")
-	}
-	if role.SchemeManaged {
-		fmt.Printf("Scheme Managed: yes\n")
-	} else {
-		fmt.Printf("Scheme Managed: no\n")
-	}
+	tpl := `Name: {{.Name}}
+Display Name: {{.DisplayName}}
+Description: {{.Description}}
+Permissions: {{.Permissions}}
+{{range .Permissions}}
+  - {{.}}
+{{end}}
+{{if .BuildIn}}
+Built in: yes
+{{else}}
+Built in: no
+{{end}}
+{{if .SchemeManaged}}
+Scheme Managed: yes
+{{else}}
+Scheme Managed: no
+{{end}}
+`
+
+	printer.PrintT(tpl, role)
 
 	return nil
 }

--- a/commands/permissions.go
+++ b/commands/permissions.go
@@ -112,7 +112,7 @@ Permissions: {{.Permissions}}
 {{range .Permissions}}
   - {{.}}
 {{end}}
-{{if .BuildIn}}
+{{if .BuiltIn}}
 Built in: yes
 {{else}}
 Built in: no


### PR DESCRIPTION
Small refactor to use `printer` in the `group.go` and `permissions.go` files