### PR TITLE
[MM-20837] Add unit tests to the "ConfigGetCmd" mmctl command

### DIFF
--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -1,0 +1,105 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestConfigGetCmdF() {
+	s.Run("Get nested config setting", func() {
+		printer.Clean()
+
+		configNameArg := "ServiceSettings.WebsocketSecurePort"
+		configValue := 443
+		mockConfig := &model.Config{
+			ServiceSettings: model.ServiceSettings{
+				WebsocketSecurePort: &configValue,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(mockConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, []string{configNameArg})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 1)
+		s.Equal(&configValue, printer.GetLines()[0])
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get config setting block", func() {
+		printer.Clean()
+
+		configNameArg := "TeamSettings"
+		configSiteName := "Mattermost"
+		configMaxUsersPerTeam := 50
+		mockTeamSettings := model.TeamSettings{
+			SiteName:        &configSiteName,
+			MaxUsersPerTeam: &configMaxUsersPerTeam,
+		}
+		mockConfig := &model.Config{
+			TeamSettings: mockTeamSettings,
+		}
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(mockConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, []string{configNameArg})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 1)
+		s.Equal(mockTeamSettings, printer.GetLines()[0])
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Attempt to get nonexistent setting key", func() {
+		printer.Clean()
+
+		configNameArg := "Does.Not.Exist"
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(&model.Config{}, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, []string{configNameArg})
+		s.Require().NotNil(err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, "Invalid key")
+	})
+
+	s.Run("Fail to communicate with server while getting config", func() {
+		printer.Clean()
+
+		configNameArg := "ServiceSettings.WebsocketSecurePort"
+		configValue := 443
+		mockConfig := &model.Config{
+			ServiceSettings: model.ServiceSettings{
+				WebsocketSecurePort: &configValue,
+			},
+		}
+
+		mockErrorMessage := "Mock Internal Server Error"
+		mockError := &model.AppError{Message: mockErrorMessage}
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(mockConfig, &model.Response{Error: mockError}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, []string{configNameArg})
+		s.Require().NotNil(err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, mockError.Error())
+	})
+}


### PR DESCRIPTION
#### Summary
Added unit tests for the ConfigGetCmd mmctl command that covers the following test cases:
- Get a single nested config setting
- Get a block of config settings
- Assert Invalid Key error is returned when accessing nonexistent config field
- Assert error on client request is gracefully handled

#### Ticket Links
Jira: https://mattermost.atlassian.net/browse/MM-20837
Fixes mattermost/mattermost-server#13287

P.S - this repo didn't quite work for me out of the box, failing with the same errors CI is; I had to replace the import `"github.com/mattermost/mattermost-server/model"` in `license_test.go` with `"github.com/mattermost/mattermost-server/v5/model"` for it to build and have the tests run properly
