### PR TITLE
MM-20838 Add unit tests to the "ConfigShowCmd" mmctl command

### DIFF
--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -384,7 +384,6 @@ func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
 func (s *MmctlUnitTestSuite) TestConfigShowCmd() {
 	s.Run("Should show config", func() {
 		printer.Clean()
-		configShowArg := "config-show"
 		mockConfig := &model.Config{}
 
 		s.client.
@@ -393,7 +392,7 @@ func (s *MmctlUnitTestSuite) TestConfigShowCmd() {
 			Return(mockConfig, &model.Response{Error: nil}).
 			Times(1)
 
-		err := configShowCmdF(s.client, &cobra.Command{}, []string{configShowArg})
+		err := configShowCmdF(s.client, &cobra.Command{}, []string{})
 		s.Require().Nil(err)
 		s.Len(printer.GetLines(), 1)
 		s.Equal(mockConfig, printer.GetLines()[0])

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestConfigShowCmd() {
+	s.Run("Should show config", func() {
+		printer.Clean()
+		configShowArg := "config-show"
+		mockConfig := &model.Config{}
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(mockConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configShowCmdF(s.client, &cobra.Command{}, []string{configShowArg})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 1)
+		s.Equal(mockConfig, printer.GetLines()[0])
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+}

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -400,4 +400,18 @@ func (s *MmctlUnitTestSuite) TestConfigShowCmd() {
 		s.Len(printer.GetErrorLines(), 0)
 	})
 
+	s.Run("Should return an error", func() {
+		printer.Clean()
+		configError := &model.AppError{Message: "Config Error"}
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(nil, &model.Response{Error: configError}).
+			Times(1)
+
+		err := configShowCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().NotNil(err)
+		s.EqualError(err, configError.Error())
+	})
 }


### PR DESCRIPTION
Summary:
Add unit tests to the "PluginListCmd" mmctl command

JIRA: https://mattermost.atlassian.net/browse/MM-20838
closes https://github.com/mattermost/mattermost-server/issues/13286
