### PR TITLE
GH-13291 Add unit tests to the ChannelGroupEnableCmd mmctl command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 mmctl
 bin
 build
+
+# Editor files
+.vscode

--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,7 @@ type Client interface {
 	PatchTeam(teamId string, patch *model.TeamPatch) (*model.Team, *model.Response)
 	AddTeamMember(teamId, userId string) (*model.TeamMember, *model.Response)
 	RemoveTeamMember(teamId, userId string) (bool, *model.Response)
+	SoftDeleteTeam(teamId string) (bool, *model.Response)
 	PermanentDeleteTeam(teamId string) (bool, *model.Response)
 	SearchTeams(search *model.TeamSearch) ([]*model.Team, *model.Response)
 	GetPost(postId string, etag string) (*model.Post, *model.Response)
@@ -59,5 +60,7 @@ type Client interface {
 	ListCommands(teamId string, customOnly bool) ([]*model.Command, *model.Response)
 	DeleteCommand(commandId string) (bool, *model.Response)
 	GetConfig() (*model.Config, *model.Response)
+	UpdateConfig(*model.Config) (*model.Config, *model.Response)
 	SyncLdap() (bool, *model.Response)
+	UpdateTeam(team *model.Team) (*model.Team, *model.Response)
 }

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -2,13 +2,13 @@ package commands
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 	"syscall"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -145,7 +145,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if accessToken != "" && username != "" {
-		return errors.New("You must use --access-token or --username, but not both.")
+		return errors.New("you must use --access-token or --username, but not both")
 	}
 
 	if accessToken == "" && username == "" {
@@ -161,7 +161,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 	if username != "" && password == "" {
 		stdinPassword, err := getPasswordFromStdin()
 		if err != nil {
-			return errors.New("Couldn't read password. Error: " + err.Error())
+			return errors.WithMessage(err, "couldn't read password")
 		}
 		password = stdinPassword
 	}
@@ -214,7 +214,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Printf("\n  credentials for %v: %v@%v stored\n\n", name, username, url)
+	fmt.Printf("\n  credentials for %q: \"%s@%s\" stored\n\n", name, username, url)
 	return nil
 }
 
@@ -234,7 +234,7 @@ func currentCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("\n  found credentials for %v: %v @ %v\n\n", credentials.Name, credentials.Username, credentials.InstanceUrl)
+	fmt.Printf("\n  found credentials for %q: \"%s@%s\"\n\n", credentials.Name, credentials.Username, credentials.InstanceUrl)
 	return nil
 }
 
@@ -243,7 +243,7 @@ func setCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Credentials for server \"%v\" set as active\n", args[0])
+	fmt.Printf("Credentials for server %q set as active\n", args[0])
 
 	return nil
 }
@@ -255,7 +255,7 @@ func listCmdF(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(*credentialsList) == 0 {
-		return errors.New("There are no registered credentials, maybe you need to use login first")
+		return errors.New("there are no registered credentials, maybe you need to use login first")
 	}
 
 	serverNames := []string{}
@@ -305,7 +305,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 		if password == "" {
 			stdinPassword, err := getPasswordFromStdin()
 			if err != nil {
-				return errors.New("Couldn't read password. Error: " + err.Error())
+				return errors.WithMessage(err, "couldn't read password")
 			}
 			password = stdinPassword
 		}
@@ -322,7 +322,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 
 	case METHOD_TOKEN:
 		if accessToken == "" {
-			return errors.New("Requires the --access-token parameter to be set")
+			return errors.New("requires the --access-token parameter to be set")
 		}
 
 		credentials.AuthToken = accessToken
@@ -332,7 +332,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 
 	case METHOD_MFA:
 		if mfaToken == "" {
-			return errors.New("Requires the --mfa-token parameter to be set")
+			return errors.New("requires the --mfa-token parameter to be set")
 		}
 
 		c, err := InitClientWithMFA(credentials.Username, password, mfaToken, credentials.InstanceUrl)
@@ -342,7 +342,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 		credentials.AuthToken = c.AuthToken
 
 	default:
-		return errors.New(fmt.Sprintf("Invalid auth method \"%s\"", credentials.AuthMethod))
+		return errors.Errorf("invalid auth method %q", credentials.AuthMethod)
 	}
 
 	if err := SaveCredentials(*credentials); err != nil {
@@ -363,7 +363,7 @@ func deleteCmdF(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	credentials := (*credentialsList)[name]
 	if credentials == nil {
-		return errors.New(fmt.Sprintf("Cannot find credentials for server name %v", name))
+		return errors.Errorf("cannot find credentials for server name %q", name)
 	}
 
 	delete(*credentialsList, name)

--- a/commands/auth_utils.go
+++ b/commands/auth_utils.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -41,17 +41,17 @@ func ReadCredentialsList() (*CredentialsList, error) {
 	}
 
 	if _, errStat := os.Stat(configFilePath); err != nil {
-		return nil, errors.New("Cannot read user credentials, maybe you need to use login first. Error: " + errStat.Error())
+		return nil, errors.WithMessage(errStat, "cannot read user credentials, maybe you need to use login first")
 	}
 
 	fileContents, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
-		return nil, errors.New("There was a problem reading the credentials file. Error: " + err.Error())
+		return nil, errors.WithMessage(err, "there was a problem reading the credentials file")
 	}
 
 	var credentialsList CredentialsList
 	if err := json.Unmarshal(fileContents, &credentialsList); err != nil {
-		return nil, errors.New("There was a problem parsing the credentials file. Error: " + err.Error())
+		return nil, errors.WithMessage(err, "there was a problem parsing the credentials file")
 	}
 
 	return &credentialsList, nil
@@ -68,7 +68,7 @@ func GetCurrentCredentials() (*Credentials, error) {
 			return c, nil
 		}
 	}
-	return nil, errors.New("No current context available. Please use the \"auth set\" command.")
+	return nil, errors.Errorf("no current context available. please use the %q command", "auth set")
 }
 
 func GetCredentials(name string) (*Credentials, error) {
@@ -82,7 +82,7 @@ func GetCredentials(name string) (*Credentials, error) {
 			return c, nil
 		}
 	}
-	return nil, errors.New(fmt.Sprintf("Couldn't find credentials for connection \"%s\"", name))
+	return nil, errors.Errorf("couldn't find credentials for connection %q", name)
 }
 
 func SaveCredentials(credentials Credentials) error {
@@ -105,7 +105,7 @@ func SaveCredentialsList(credentialsList *CredentialsList) error {
 	marshaledCredentialsList, _ := json.MarshalIndent(credentialsList, "", "    ")
 
 	if err := ioutil.WriteFile(configFilePath, marshaledCredentialsList, 0600); err != nil {
-		return errors.New("Cannot save the credentials. Error: " + err.Error())
+		return errors.WithMessage(err, "cannot save the credentials")
 	}
 
 	return nil
@@ -128,7 +128,7 @@ func SetCurrent(name string) error {
 	}
 
 	if !found {
-		return errors.New("Cannot find credentials for server " + name)
+		return errors.Errorf("cannot find credentials for server %q", name)
 	}
 
 	return SaveCredentialsList(credentialsList)

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -1,0 +1,382 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestConfigGetCmd() {
+	s.Run("Get a string config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(*(printer.GetLines()[0].(*string)), "mysql")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get an int config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.MaxIdleConns"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(*(printer.GetLines()[0].(*int)), 20)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get a boolean config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.Trace"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(*(printer.GetLines()[0].(*bool)), false)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get a slice of string config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DataSourceReplicas"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], []string{})
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get config struct for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+		sqlSettings := model.SqlSettings{}
+		sqlSettings.SetDefaults(false)
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], sqlSettings)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get error if the key doesn't exists", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.WrongKey"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+		sqlSettings := model.SqlSettings{}
+		sqlSettings.SetDefaults(false)
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should handle the response error", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName"}
+		outputConfig := &model.Config{}
+		outputConfig.SetDefaults()
+		sqlSettings := model.SqlSettings{}
+		sqlSettings.SetDefaults(false)
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(outputConfig, &model.Response{StatusCode: 500, Error: &model.AppError{}}).
+			Times(1)
+
+		err := configGetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
+	s.Run("Set a string config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName", "postgres"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		changedValue := "postgres"
+		inputConfig.SqlSettings.DriverName = &changedValue
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], inputConfig)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Set an int config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.MaxIdleConns", "20"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		changedValue := 20
+		inputConfig.SqlSettings.MaxIdleConns = &changedValue
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], inputConfig)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Set a boolean config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.Trace", "true"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		changedValue := true
+		inputConfig.SqlSettings.Trace = &changedValue
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], inputConfig)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Set a slice of string config value for a given key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DataSourceReplicas", "test1", "test2"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		inputConfig.SqlSettings.DataSourceReplicas = []string{"test1", "test2"}
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], inputConfig)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Get error if the key doesn't exists", func() {
+		printer.Clean()
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		args := []string{"SqlSettings.WrongKey", "test1"}
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should handle response error from the server", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName", "postgres"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		changedValue := "postgres"
+		inputConfig.SqlSettings.DriverName = &changedValue
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(inputConfig).
+			Return(inputConfig, &model.Response{StatusCode: 500, Error: &model.AppError{}}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestConfigResetCmd() {
+	s.Run("Reset a single key", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DriverName"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(defaultConfig).
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		resetCmd := &cobra.Command{}
+		resetCmd.Flags().Bool("confirm", true, "")
+		err := configResetCmdF(s.client, resetCmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], defaultConfig)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Reset a whole config section", func() {
+		printer.Clean()
+		args := []string{"SqlSettings"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			UpdateConfig(defaultConfig).
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		resetCmd := &cobra.Command{}
+		resetCmd.Flags().Bool("confirm", true, "")
+		resetCmd.ParseFlags([]string{"confirm"})
+		err := configResetCmdF(s.client, resetCmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], defaultConfig)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should fail if the key doesn't exists", func() {
+		printer.Clean()
+		args := []string{"WrongKey"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		resetCmd := &cobra.Command{}
+		resetCmd.Flags().Bool("confirm", true, "")
+		resetCmd.ParseFlags([]string{"confirm"})
+		err := configResetCmdF(s.client, resetCmd, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -1,0 +1,152 @@
+package commands
+
+import (
+	"strings"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestChannelGroupEnableCmdF() {
+	s.Run("Enable group constrains with existing team and channel", func() {
+		teamArg := "team-id"
+		mockTeam := model.Team{Id: teamArg}
+		channelPart := "channel-id"
+		mockChannel := model.Channel{Id: channelPart}
+		channelArg := strings.Join([]string{teamArg, channelPart}, ":")
+		group := &model.Group{Name: "group-name"}
+		mockGroups := []*model.Group{group}
+		groupOpts := &model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannelByNameIncludeDeleted(channelPart, teamArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByChannel(channelPart, *groupOpts).
+			Return(mockGroups, 0, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			PatchChannel(channelPart, &model.ChannelPatch{GroupConstrained: model.NewBool(true)}).
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		err := channelGroupEnableCmdF(s.client, &cobra.Command{}, []string{channelArg})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Enable group constrains with no associated groups", func() {
+		teamArg := "team-id"
+		mockTeam := model.Team{Id: teamArg}
+		channelPart := "channel-id"
+		mockChannel := model.Channel{Id: channelPart}
+		channelArg := strings.Join([]string{teamArg, channelPart}, ":")
+		mockGroups := []*model.Group{}
+		groupOpts := &model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannelByNameIncludeDeleted(channelPart, teamArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByChannel(channelPart, *groupOpts).
+			Return(mockGroups, 0, &model.Response{Error: nil}).
+			Times(1)
+
+		err := channelGroupEnableCmdF(s.client, &cobra.Command{}, []string{channelArg})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, "Channel '"+channelArg+"' has no groups associated. It cannot be group-constrained")
+	})
+
+	s.Run("Enable group constrains with nonexistant team", func() {
+		printer.Clean()
+		teamArg := "team-id"
+		channelPart := "channel-id"
+		channelArg := strings.Join([]string{teamArg, channelPart}, ":")
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(teamArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		err := channelGroupEnableCmdF(s.client, &cobra.Command{}, []string{channelArg})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, "Unable to find channel '"+channelArg+"'")
+	})
+
+	s.Run("Enable group constrains with nonexistant channel", func() {
+		printer.Clean()
+		teamArg := "team-id"
+		mockTeam := model.Team{Id: teamArg}
+		channelPart := "channel-id"
+		channelArg := strings.Join([]string{teamArg, channelPart}, ":")
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannelByNameIncludeDeleted(channelPart, teamArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannel(channelPart, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		err := channelGroupEnableCmdF(s.client, &cobra.Command{}, []string{channelArg})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, "Unable to find channel '"+channelArg+"'")
+	})
+}

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"strings"
-
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mmctl/printer"
 	"github.com/spf13/cobra"
@@ -10,11 +8,12 @@ import (
 
 func (s *MmctlUnitTestSuite) TestChannelGroupEnableCmdF() {
 	s.Run("Enable group constrains with existing team and channel", func() {
+		printer.Clean()
 		teamArg := "team-id"
 		mockTeam := model.Team{Id: teamArg}
 		channelPart := "channel-id"
 		mockChannel := model.Channel{Id: channelPart}
-		channelArg := strings.Join([]string{teamArg, channelPart}, ":")
+		channelArg := teamArg + ":" + channelPart
 		group := &model.Group{Name: "group-name"}
 		mockGroups := []*model.Group{group}
 		groupOpts := &model.GroupSearchOpts{
@@ -54,12 +53,160 @@ func (s *MmctlUnitTestSuite) TestChannelGroupEnableCmdF() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.Run("Enable group constrains with no associated groups", func() {
+	s.Run("Enable group constrains with GetTeam error", func() {
+		printer.Clean()
+		teamArg := "team-id"
+		channelPart := "channel-id"
+		channelArg := teamArg + ":" + channelPart
+		mockError := model.AppError{Id: "Mock Error"}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(nil, &model.Response{Error: &mockError}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(teamArg, "").
+			Return(nil, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := channelGroupEnableCmdF(s.client, &cobra.Command{}, []string{channelArg})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, "Unable to find channel '"+channelArg+"'")
+	})
+
+	s.Run("Enable group constrains with GetChannelByNameIncludeDeleted error", func() {
+		printer.Clean()
+		teamArg := "team-id"
+		mockTeam := model.Team{Id: teamArg}
+		channelPart := "channel-id"
+		channelArg := teamArg + ":" + channelPart
+		mockError := model.AppError{Id: "Mock Error"}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannelByNameIncludeDeleted(channelPart, teamArg, "").
+			Return(nil, &model.Response{Error: &mockError}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannel(channelPart, "").
+			Return(nil, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := channelGroupEnableCmdF(s.client, &cobra.Command{}, []string{channelArg})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, "Unable to find channel '"+channelArg+"'")
+	})
+
+	s.Run("Enable group constrains with GetGroupsByChannel error", func() {
+		printer.Clean()
 		teamArg := "team-id"
 		mockTeam := model.Team{Id: teamArg}
 		channelPart := "channel-id"
 		mockChannel := model.Channel{Id: channelPart}
-		channelArg := strings.Join([]string{teamArg, channelPart}, ":")
+		channelArg := teamArg + ":" + channelPart
+		mockError := model.AppError{Id: "Mock Error"}
+		groupOpts := &model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannelByNameIncludeDeleted(channelPart, teamArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByChannel(channelPart, *groupOpts).
+			Return(nil, 0, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := channelGroupEnableCmdF(s.client, &cobra.Command{}, []string{channelArg})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, mockError.Error())
+	})
+
+	s.Run("Enable group constrains with PatchChannel error", func() {
+		printer.Clean()
+		teamArg := "team-id"
+		mockTeam := model.Team{Id: teamArg}
+		channelPart := "channel-id"
+		mockChannel := model.Channel{Id: channelPart}
+		channelArg := teamArg + ":" + channelPart
+		group := &model.Group{Name: "group-name"}
+		mockGroups := []*model.Group{group}
+		mockError := model.AppError{Id: "Mock Error"}
+		groupOpts := &model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannelByNameIncludeDeleted(channelPart, teamArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByChannel(channelPart, *groupOpts).
+			Return(mockGroups, 0, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			PatchChannel(channelPart, &model.ChannelPatch{GroupConstrained: model.NewBool(true)}).
+			Return(nil, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := channelGroupEnableCmdF(s.client, &cobra.Command{}, []string{channelArg})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.EqualError(err, mockError.Error())
+	})
+
+	s.Run("Enable group constrains with no associated groups", func() {
+		printer.Clean()
+		teamArg := "team-id"
+		mockTeam := model.Team{Id: teamArg}
+		channelPart := "channel-id"
+		mockChannel := model.Channel{Id: channelPart}
+		channelArg := teamArg + ":" + channelPart
 		mockGroups := []*model.Group{}
 		groupOpts := &model.GroupSearchOpts{
 			PageOpts: &model.PageOpts{
@@ -97,7 +244,7 @@ func (s *MmctlUnitTestSuite) TestChannelGroupEnableCmdF() {
 		printer.Clean()
 		teamArg := "team-id"
 		channelPart := "channel-id"
-		channelArg := strings.Join([]string{teamArg, channelPart}, ":")
+		channelArg := teamArg + ":" + channelPart
 
 		s.client.
 			EXPECT().
@@ -123,7 +270,7 @@ func (s *MmctlUnitTestSuite) TestChannelGroupEnableCmdF() {
 		teamArg := "team-id"
 		mockTeam := model.Team{Id: teamArg}
 		channelPart := "channel-id"
-		channelArg := strings.Join([]string{teamArg, channelPart}, ":")
+		channelArg := teamArg + ":" + channelPart
 
 		s.client.
 			EXPECT().

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -297,3 +297,164 @@ func (s *MmctlUnitTestSuite) TestChannelGroupEnableCmdF() {
 		s.EqualError(err, "Unable to find channel '"+channelArg+"'")
 	})
 }
+
+func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
+	s.Run("Enable unexisting team", func() {
+		printer.Clean()
+
+		arg := "teamId"
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(nil, &model.Response{Error: &model.AppError{}}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(arg, "").
+			Return(nil, &model.Response{Error: &model.AppError{}}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().EqualError(err, "Unable to find team '"+arg+"'")
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Error while getting the team groups", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		mockTeam := model.Team{Id: arg}
+		mockError := model.AppError{Message: "Mock error"}
+		groupOpts := model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByTeam(mockTeam.Id, groupOpts).
+			Return(nil, 0, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Equal(&mockError, err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("No groups on team", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		mockTeam := model.Team{Id: arg}
+		groupOpts := model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByTeam(mockTeam.Id, groupOpts).
+			Return([]*model.Group{}, 0, &model.Response{Error: nil}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().EqualError(err, "Team '"+arg+"' has no groups associated. It cannot be group-constrained")
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Error patching the team", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		mockTeam := model.Team{Id: arg}
+		mockError := model.AppError{Message: "Mock error"}
+		groupOpts := model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+		teamPatch := model.TeamPatch{GroupConstrained: model.NewBool(true)}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByTeam(mockTeam.Id, groupOpts).
+			Return([]*model.Group{&model.Group{}}, 1, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			PatchTeam(mockTeam.Id, &teamPatch).
+			Return(nil, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Equal(&mockError, err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Successfully enable group", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		mockTeam := model.Team{Id: arg}
+		groupOpts := model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+		teamPatch := model.TeamPatch{GroupConstrained: model.NewBool(true)}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByTeam(mockTeam.Id, groupOpts).
+			Return([]*model.Group{&model.Group{}}, 1, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			PatchTeam(mockTeam.Id, &teamPatch).
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().NoError(err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/license_test.go
+++ b/commands/license_test.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestRemoveLicenseCmd() {
+	s.Run("Remove license successfully", func() {
+		printer.Clean()
+
+		s.client.
+			EXPECT().
+			RemoveLicenseFile().
+			Return(false, &model.Response{Error: nil}).
+			Times(1)
+
+		err := removeLicenseCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Equal(printer.GetLines()[0], "Removed license")
+	})
+
+	s.Run("Fail to remove license", func() {
+		printer.Clean()
+		mockErr := &model.AppError{Message: "Mock error"}
+
+		s.client.
+			EXPECT().
+			RemoveLicenseFile().
+			Return(false, &model.Response{Error: mockErr}).
+			Times(1)
+
+		err := removeLicenseCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Equal(err, mockErr)
+	})
+}

--- a/commands/logs_test.go
+++ b/commands/logs_test.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	testLogInfo       = `{"level":"info","ts":1573516747,"caller":"app/server.go:490","msg":"Server is listening on [::]:8065"}`
-	testLogInfoStdout = "2019-11-11T23:59:07Z info app/server.go:490 Server is listening on [::]:8065"
-	testLogrusStdout  = "time=\"2019-11-11T23:59:07Z\" level=info msg=\"Server is listening on [::]:8065\" caller=\"app/server.go:490\""
+	testLogInfoStdout = "info app/server.go:490 Server is listening on [::]:8065"
+	testLogrusStdout  = "level=info msg=\"Server is listening on [::]:8065\" caller=\"app/server.go:490\""
 )
 
 func (s *MmctlUnitTestSuite) TestLogsCmd() {
@@ -33,7 +33,7 @@ func (s *MmctlUnitTestSuite) TestLogsCmd() {
 
 		s.Require().Nil(err)
 		s.Require().Len(data, 1)
-		s.EqualValues(testLogInfoStdout, data[0])
+		s.Contains(data[0], testLogInfoStdout)
 	})
 
 	s.Run("Display logs", func() {
@@ -50,7 +50,7 @@ func (s *MmctlUnitTestSuite) TestLogsCmd() {
 
 		s.Require().Nil(err)
 		s.Require().Len(data, 1)
-		s.EqualValues(testLogInfoStdout, data[0])
+		s.Contains(data[0], testLogInfoStdout)
 	})
 
 	s.Run("Display logs logrus format", func() {
@@ -69,7 +69,7 @@ func (s *MmctlUnitTestSuite) TestLogsCmd() {
 
 		s.Require().Nil(err)
 		s.Require().Len(data, 1)
-		s.EqualValues(testLogrusStdout, data[0])
+		s.Contains(data[0], testLogrusStdout)
 	})
 }
 

--- a/commands/plugin_test.go
+++ b/commands/plugin_test.go
@@ -2,13 +2,105 @@ package commands
 
 import (
 	"errors"
+	"io/ioutil"
+	"os"
 	"strings"
 
+	"github.com/golang/mock/gomock"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mmctl/printer"
 
 	"github.com/spf13/cobra"
 )
+
+func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
+	s.Run("Add without args", func() {
+		printer.Clean()
+		err := pluginAddCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Error(err)
+	})
+
+	s.Run("Add 1 plugin", func() {
+		printer.Clean()
+		tmpFile, err := ioutil.TempFile("", "tmpPlugin")
+		s.Require().Nil(err)
+		defer os.Remove(tmpFile.Name())
+
+		pluginName := tmpFile.Name()
+
+		s.client.
+			EXPECT().
+			UploadPlugin(gomock.AssignableToTypeOf(tmpFile)).
+			Return(&model.Manifest{}, &model.Response{Error: nil}).
+			Times(1)
+
+		err = pluginAddCmdF(s.client, &cobra.Command{}, []string{pluginName})
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Added plugin: "+pluginName)
+	})
+
+	s.Run("Add 1 plugin no file", func() {
+		printer.Clean()
+		err := pluginAddCmdF(s.client, &cobra.Command{}, []string{"non_existent_plugin"})
+		s.Require().EqualError(err, "open non_existent_plugin: no such file or directory")
+	})
+
+	s.Run("Add 1 plugin with error", func() {
+		printer.Clean()
+		tmpFile, err := ioutil.TempFile("", "tmpPlugin")
+		s.Require().Nil(err)
+		defer os.Remove(tmpFile.Name())
+
+		pluginName := tmpFile.Name()
+		mockError := &model.AppError{Message: "Plugin Add Error"}
+
+		s.client.
+			EXPECT().
+			UploadPlugin(gomock.AssignableToTypeOf(tmpFile)).
+			Return(&model.Manifest{}, &model.Response{Error: mockError}).
+			Times(1)
+
+		err = pluginAddCmdF(s.client, &cobra.Command{}, []string{pluginName})
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(printer.GetErrorLines()[0], "Unable to add plugin: "+pluginName+". Error: "+mockError.Error())
+	})
+
+	s.Run("Add several plugins with some error", func() {
+		printer.Clean()
+		args := []string{"fail", "ok", "fail"}
+		mockError := &model.AppError{Message: "Plugin Add Error"}
+
+		for idx, arg := range args {
+			tmpFile, err := ioutil.TempFile("", "tmpPlugin")
+			s.Require().Nil(err)
+			defer os.Remove(tmpFile.Name())
+			if arg == "fail" {
+				s.client.
+					EXPECT().
+					UploadPlugin(gomock.AssignableToTypeOf(tmpFile)).
+					Return(nil, &model.Response{Error: mockError}).
+					Times(1)
+			} else {
+				s.client.
+					EXPECT().
+					UploadPlugin(gomock.AssignableToTypeOf(tmpFile)).
+					Return(&model.Manifest{}, &model.Response{Error: nil}).
+					Times(1)
+			}
+			args[idx] = tmpFile.Name()
+		}
+
+		err := pluginAddCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Added plugin: "+args[1])
+		s.Require().Len(printer.GetErrorLines(), 2)
+		s.Require().Equal(printer.GetErrorLines()[0], "Unable to add plugin: "+args[0]+". Error: "+mockError.Error())
+		s.Require().Equal(printer.GetErrorLines()[1], "Unable to add plugin: "+args[2]+". Error: "+mockError.Error())
+	})
+}
 
 func (s *MmctlUnitTestSuite) TestPluginDisableCmd() {
 	s.Run("Disable 1 plugin", func() {

--- a/commands/post_test.go
+++ b/commands/post_test.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestPostCreateCmdF() {
+	s.Run("create a post with empty text", func() {
+		cmd := &cobra.Command{}
+
+		err := postCreateCmdF(s.client, cmd, []string{"some-channel", ""})
+		s.Require().EqualError(err, "Message cannot be empty")
+	})
+
+	s.Run("no channel specified", func() {
+		msgArg := "some text"
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("message", msgArg, "")
+
+		err := postCreateCmdF(s.client, cmd, []string{"", msgArg})
+		s.Require().EqualError(err, "Unable to find channel ''")
+	})
+
+	s.Run("wrong reply msg", func() {
+		msgArg := "some text"
+		replyToArg := "a-non-existing-post"
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("message", msgArg, "")
+		cmd.Flags().String("reply-to", replyToArg, "")
+
+		s.client.
+			EXPECT().
+			GetPost(replyToArg, "").
+			Return(nil, &model.Response{Error: &model.AppError{Message: "some-error"}}).
+			Times(1)
+
+		err := postCreateCmdF(s.client, cmd, []string{msgArg})
+		s.Require().Contains(err.Error(), "some-error")
+	})
+
+	s.Run("error when creating a post", func() {
+		msgArg := "some text"
+		channelArg := "example-channel"
+		mockChannel := model.Channel{Name: channelArg}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("message", msgArg, "")
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			CreatePost(&model.Post{Message: msgArg}).
+			Return(nil, &model.Response{Error: &model.AppError{Message: "some-error"}}).
+			Times(1)
+
+		err := postCreateCmdF(s.client, cmd, []string{channelArg, msgArg})
+		s.Require().Contains(err.Error(), "some-error")
+	})
+
+	s.Run("create a post", func() {
+		msgArg := "some text"
+		channelArg := "example-channel"
+		mockChannel := model.Channel{Name: channelArg}
+		mockPost := model.Post{Message: msgArg}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("message", msgArg, "")
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			CreatePost(&mockPost).
+			Return(&mockPost, &model.Response{Error: nil}).
+			Times(1)
+
+		err := postCreateCmdF(s.client, cmd, []string{channelArg, msgArg})
+		s.Require().Nil(err)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("reply to an existing post", func() {
+		msgArg := "some text"
+		replyToArg := "an-existing-post"
+		rootID := "some-root-id"
+		channelArg := "example-channel"
+		mockChannel := model.Channel{Name: channelArg}
+		mockReplyTo := model.Post{RootId: rootID}
+		mockPost := model.Post{Message: msgArg, RootId: rootID}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("reply-to", replyToArg, "")
+		cmd.Flags().String("message", msgArg, "")
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPost(replyToArg, "").
+			Return(&mockReplyTo, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			CreatePost(&mockPost).
+			Return(&mockPost, &model.Response{Error: nil}).
+			Times(1)
+
+		err := postCreateCmdF(s.client, cmd, []string{channelArg, msgArg})
+		s.Require().Nil(err)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/team.go
+++ b/commands/team.go
@@ -51,6 +51,16 @@ Permanently deletes a team along with all related information including posts fr
 	RunE:    withClient(deleteTeamsCmdF),
 }
 
+var ArchiveTeamsCmd = &cobra.Command{
+	Use:   "archive [teams]",
+	Short: "Archive teams",
+	Long: `Archive some teams.
+Archives a team along with all related information including posts from the database.`,
+	Example: "  team archive myteam",
+	Args:    cobra.MinimumNArgs(1),
+	RunE:    withClient(archiveTeamsCmdF),
+}
+
 var ListTeamsCmd = &cobra.Command{
 	Use:     "list",
 	Short:   "List all teams.",
@@ -68,6 +78,18 @@ var SearchTeamCmd = &cobra.Command{
 	RunE:    withClient(searchTeamCmdF),
 }
 
+// RenameTeamCmd is the command to rename team along with its display name
+var RenameTeamCmd = &cobra.Command{
+	Use:   "rename [team]",
+	Short: "Rename team",
+	Long:  "Rename an existing team",
+	Example: `  team rename old-team --name 'new-team' --display_name 'New Display Name'
+  team rename old-team --name 'new-team'
+  team rename old-team --display_name 'New Display Name'`,
+	Args: cobra.ExactArgs(1),
+	RunE: withClient(renameTeamCmdF),
+}
+
 func init() {
 	TeamCreateCmd.Flags().String("name", "", "Team Name")
 	TeamCreateCmd.Flags().String("display_name", "", "Team Display Name")
@@ -75,14 +97,21 @@ func init() {
 	TeamCreateCmd.Flags().String("email", "", "Administrator Email (anyone with this email is automatically a team admin)")
 
 	DeleteTeamsCmd.Flags().Bool("confirm", false, "Confirm you really want to delete the team and a DB backup has been performed.")
+	ArchiveTeamsCmd.Flags().Bool("confirm", false, "Confirm you really want to archive the team and a DB backup has been performed.")
+
+	// Add flag declaration for RenameTeam
+	RenameTeamCmd.Flags().String("name", "", "Old Team Name")
+	RenameTeamCmd.Flags().String("display_name", "", "Team Display Name")
 
 	TeamCmd.AddCommand(
 		TeamCreateCmd,
 		RemoveUsersCmd,
 		AddUsersCmd,
 		DeleteTeamsCmd,
+		ArchiveTeamsCmd,
 		ListTeamsCmd,
 		SearchTeamCmd,
+		RenameTeamCmd,
 	)
 
 	RootCmd.AddCommand(TeamCmd)
@@ -222,6 +251,39 @@ func deleteTeam(c client.Client, team *model.Team) (bool, *model.Response) {
 	return c.PermanentDeleteTeam(team.Id)
 }
 
+func archiveTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	confirmFlag, _ := cmd.Flags().GetBool("confirm")
+	if !confirmFlag {
+		var confirm string
+		fmt.Println("Have you performed a database backup? (YES/NO): ")
+		fmt.Scanln(&confirm)
+
+		if confirm != "YES" {
+			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
+		}
+		fmt.Println("Are you sure you want to archive the specified teams? (YES/NO): ")
+		fmt.Scanln(&confirm)
+		if confirm != "YES" {
+			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
+		}
+	}
+
+	teams := getTeamsFromTeamArgs(c, args)
+	for i, team := range teams {
+		if team == nil {
+			printer.PrintError("Unable to find team '" + args[i] + "'")
+			continue
+		}
+		if _, response := c.SoftDeleteTeam(team.Id); response.Error != nil {
+			printer.PrintError("Unable to archive team '" + team.Name + "' error: " + response.Error.Error())
+		} else {
+			printer.PrintT("Archived team '{{.Name}}'", team)
+		}
+	}
+
+	return nil
+}
+
 func listTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	teams, response := c.GetAllTeams("", 0, 10000)
 	if response.Error != nil {
@@ -273,4 +335,36 @@ func removeDuplicatesAndSortTeams(teams []*model.Team) []*model.Team {
 		return result[i].Name < result[j].Name
 	})
 	return result
+}
+
+func renameTeamCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	oldTeamName := args[0]
+	newDisplayName, _ := cmd.Flags().GetString("display_name")
+	newTeamName, _ := cmd.Flags().GetString("name")
+
+	// If both flags are absent, abort!
+	if newTeamName == "" && newDisplayName == "" {
+		return errors.New("Require atleast one flag to rename team, either 'name' or 'display_name'")
+	}
+
+	team := getTeamFromTeamArg(c, oldTeamName)
+	if team == nil {
+		return errors.New("Unable to find team '" + oldTeamName + "', to see the all teams try 'team list' command")
+	}
+
+	if newTeamName != "" {
+		team.Name = newTeamName
+	}
+	if newDisplayName != "" {
+		team.DisplayName = newDisplayName
+	}
+
+	// Using UpdateTeam API Method to rename team
+	_, response := c.UpdateTeam(team)
+	if response.Error != nil {
+		return errors.New("Cannot rename team '" + oldTeamName + "', error : " + response.Error.Error())
+	}
+
+	printer.Print("'" + oldTeamName + "' team renamed")
+	return nil
 }

--- a/commands/team_test.go
+++ b/commands/team_test.go
@@ -1,0 +1,616 @@
+package commands
+
+import (
+	"errors"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestCreateTeamCmd() {
+	mockTeamName := "Mock Team"
+	mockTeamDisplayname := "Mock Display Name"
+	mockTeamEmail := "mock@mattermost.com"
+
+	s.Run("Create team with no name returns error", func() {
+		printer.Clean()
+		cmd := &cobra.Command{}
+		err := createTeamCmdF(s.client, cmd, []string{})
+
+		s.Require().Equal(err, errors.New("Name is required"))
+		s.Require().Len(printer.GetLines(), 0)
+	})
+
+	s.Run("Create team with a name but no display name returns error", func() {
+		printer.Clean()
+		cmd := &cobra.Command{}
+		cmd.Flags().String("name", mockTeamName, "")
+
+		err := createTeamCmdF(s.client, cmd, []string{})
+		s.Require().Equal(err, errors.New("Display Name is required"))
+		s.Require().Len(printer.GetLines(), 0)
+	})
+
+	s.Run("Create valid open team prints the created team", func() {
+		printer.Clean()
+		cmd := &cobra.Command{}
+		cmd.Flags().String("name", mockTeamName, "")
+		cmd.Flags().String("display_name", mockTeamDisplayname, "")
+
+		mockTeam := &model.Team{
+			Name:        mockTeamName,
+			DisplayName: mockTeamDisplayname,
+			Type:        model.TEAM_OPEN,
+		}
+
+		s.client.
+			EXPECT().
+			CreateTeam(mockTeam).
+			Return(mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		err := createTeamCmdF(s.client, cmd, []string{})
+		s.Require().Nil(err)
+		s.Require().Equal(mockTeam, printer.GetLines()[0])
+		s.Require().Len(printer.GetLines(), 1)
+	})
+
+	s.Run("Create valid invite team with email prints the created team", func() {
+		printer.Clean()
+		cmd := &cobra.Command{}
+		cmd.Flags().String("name", mockTeamName, "")
+		cmd.Flags().String("display_name", mockTeamDisplayname, "")
+		cmd.Flags().String("email", mockTeamEmail, "")
+		cmd.Flags().Bool("private", true, "")
+
+		mockTeam := &model.Team{
+			Name:        mockTeamName,
+			DisplayName: mockTeamDisplayname,
+			Email:       mockTeamEmail,
+			Type:        model.TEAM_INVITE,
+		}
+
+		s.client.
+			EXPECT().
+			CreateTeam(mockTeam).
+			Return(mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		err := createTeamCmdF(s.client, cmd, []string{})
+		s.Require().Nil(err)
+		s.Require().Equal(mockTeam, printer.GetLines()[0])
+		s.Require().Len(printer.GetLines(), 1)
+	})
+
+	s.Run("Create returns an error when the client returns an error", func() {
+		printer.Clean()
+		cmd := &cobra.Command{}
+		cmd.Flags().String("name", mockTeamName, "")
+		cmd.Flags().String("display_name", mockTeamDisplayname, "")
+
+		mockTeam := &model.Team{
+			Name:        mockTeamName,
+			DisplayName: mockTeamDisplayname,
+			Type:        model.TEAM_OPEN,
+		}
+		mockError := &model.AppError{Message: "Remote error"}
+
+		s.client.
+			EXPECT().
+			CreateTeam(mockTeam).
+			Return(nil, &model.Response{Error: mockError}).
+			Times(1)
+
+		err := createTeamCmdF(s.client, cmd, []string{})
+		s.Require().Equal("Team creation failed: : Remote error, ", err.Error())
+		s.Require().Len(printer.GetLines(), 0)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestRenameTeamCmdF() {
+	s.Run("Team rename should fail with missing name and display name flag", func() {
+		printer.Clean()
+
+		cmd := &cobra.Command{}
+
+		args := []string{""}
+		args[0] = "existingName"
+
+		err := renameTeamCmdF(s.client, cmd, args)
+		s.Require().EqualError(err, "Require atleast one flag to rename team, either 'name' or 'display_name'")
+	})
+
+	s.Run("Team rename should fail with invalid flags", func() {
+		printer.Clean()
+
+		cmd := &cobra.Command{}
+
+		args := []string{""}
+		args[0] = "existingName"
+
+		// Setting incorrect name flag
+		cmd.Flags().String("-name", "newName", "Team Name Name")
+		err := renameTeamCmdF(s.client, cmd, args)
+
+		s.Require().EqualError(err, "Require atleast one flag to rename team, either 'name' or 'display_name'")
+
+		// Setting flag as display-name instead of display_name
+		cmd.Flags().String("display-name", "newDisplayName", "Team Display Name")
+		s.Require().EqualError(err, "Require atleast one flag to rename team, either 'name' or 'display_name'")
+	})
+
+	s.Run("Team rename should fail when unknown existing team name is entered", func() {
+		printer.Clean()
+		cmd := &cobra.Command{}
+
+		args := []string{""}
+		args[0] = "existingName"
+		cmd.Flags().String("name", "newName", "Team Name")
+		cmd.Flags().String("display_name", "newDisplayName", "Team Display Name")
+
+		// Mocking : GetTeam searches with team id, if team not found proceeds with team name search
+		s.client.
+			EXPECT().
+			GetTeam("existingName", "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		// Mocking : GetTeamByname is called, if GetTeam fails to return any team, as team name was passed instead of team id
+		s.client.
+			EXPECT().
+			GetTeamByName("existingName", "").
+			Return(nil, &model.Response{Error: nil}). // Error is nil as team not found will not return error from API
+			Times(1)
+
+		err := renameTeamCmdF(s.client, cmd, args)
+		s.Require().EqualError(err, "Unable to find team 'existingName', to see the all teams try 'team list' command")
+	})
+
+	s.Run("Team rename should fail when api fails to rename", func() {
+		printer.Clean()
+		cmd := &cobra.Command{}
+
+		existingName := "existingTeamName"
+		existingDisplayName := "existingDisplayName"
+		newDisplayName := "NewDisplayName"
+		newName := "newTeamName"
+		args := []string{""}
+
+		args[0] = existingName
+		cmd.Flags().String("name", newName, "Display Name")
+		cmd.Flags().String("display_name", newDisplayName, "Display Name")
+
+		// Only reduced model.Team struct for testing per say
+		// as we are interested in updating only name and display name
+		foundTeam := &model.Team{
+			DisplayName: existingDisplayName,
+			Name:        existingName,
+		}
+		renamedTeam := &model.Team{
+			DisplayName: newDisplayName,
+			Name:        newName,
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(args[0], "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(args[0], "").
+			Return(foundTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		// Some UN-foreseeable error from the api
+		mockError := model.NewAppError("at-random-location.go", "Mock Error", nil, "mocking a random error", 0)
+
+		// Mock out UpdateTeam which calls the api to rename team
+		s.client.
+			EXPECT().
+			UpdateTeam(renamedTeam).
+			Return(nil, &model.Response{Error: mockError}).
+			Times(1)
+
+		err := renameTeamCmdF(s.client, cmd, args)
+		s.Require().EqualError(err, "Cannot rename team '"+existingName+"', error : at-random-location.go: Mock Error, mocking a random error")
+	})
+
+	s.Run("Team rename should work as expected", func() {
+		printer.Clean()
+
+		cmd := &cobra.Command{}
+
+		existingName := "existingTeamName"
+		existingDisplayName := "existingDisplayName"
+		newDisplayName := "NewDisplayName"
+		newName := "newTeamName"
+		args := []string{""}
+
+		args[0] = existingName
+		cmd.Flags().String("name", newName, "Display Name")
+		cmd.Flags().String("display_name", newDisplayName, "Display Name")
+
+		foundTeam := &model.Team{
+			DisplayName: existingDisplayName,
+			Name:        existingName,
+		}
+		updatedTeam := &model.Team{
+			DisplayName: newDisplayName,
+			Name:        newName,
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(args[0], "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(args[0], "").
+			Return(foundTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			UpdateTeam(updatedTeam).
+			Return(updatedTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		err := renameTeamCmdF(s.client, cmd, args)
+
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "'"+existingName+"' team renamed")
+	})
+
+	s.Run("Team rename should work as expected even if only display name is supplied", func() {
+		printer.Clean()
+
+		cmd := &cobra.Command{}
+
+		existingName := "existingTeamName"
+		existingDisplayName := "existingDisplayName"
+		newDisplayName := "NewDisplayName"
+		args := []string{""}
+
+		args[0] = existingName
+		cmd.Flags().String("display_name", newDisplayName, "Display Name")
+
+		foundTeam := &model.Team{
+			DisplayName: existingDisplayName,
+			Name:        existingName,
+		}
+
+		updatedTeam := &model.Team{
+			DisplayName: newDisplayName,
+			Name:        existingName,
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(args[0], "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(args[0], "").
+			Return(foundTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			UpdateTeam(updatedTeam).
+			Return(updatedTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		err := renameTeamCmdF(s.client, cmd, args)
+
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "'"+existingName+"' team renamed")
+	})
+
+	s.Run("Team rename should work as expected even if only name is supplied", func() {
+		printer.Clean()
+
+		cmd := &cobra.Command{}
+
+		existingName := "existingTeamName"
+		existingDisplayName := "existingDisplayName"
+		newName := "newTeamName"
+		args := []string{""}
+
+		args[0] = existingName
+		cmd.Flags().String("name", newName, "Display Name")
+
+		foundTeam := &model.Team{
+			DisplayName: existingDisplayName,
+			Name:        existingName,
+		}
+
+		updatedTeam := &model.Team{
+			DisplayName: existingDisplayName,
+			Name:        newName,
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(args[0], "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(args[0], "").
+			Return(foundTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			UpdateTeam(updatedTeam).
+			Return(updatedTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		err := renameTeamCmdF(s.client, cmd, args)
+
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "'"+existingName+"' team renamed")
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestRemoveUserCmd() {
+	teamArg := "example-team-id"
+	userArg := "example-user-id"
+	s.Run("Remove users from team without args returns an error", func() {
+		printer.Clean()
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Equal(err, errors.New("Not enough arguments."))
+		s.Require().Len(printer.GetLines(), 0)
+	})
+
+	s.Run("Remove users from team with one arg returns an error", func() {
+		printer.Clean()
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{teamArg})
+		s.Require().Equal(err, errors.New("Not enough arguments."))
+		s.Require().Len(printer.GetLines(), 0)
+	})
+
+	s.Run("Remove users from team with a non-existent team returns an error", func() {
+		printer.Clean()
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(teamArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{teamArg, userArg})
+		s.Require().Equal(err, errors.New("Unable to find team '"+teamArg+"'"))
+		s.Require().Len(printer.GetLines(), 0)
+	})
+
+	s.Run("Remove users from team with a non-existent user returns an error", func() {
+		printer.Clean()
+		mockTeam := &model.Team{Id: teamArg}
+		mockUser := &model.User{Id: userArg}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(mockUser.Id, "").
+			Return(nil, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByUsername(mockUser.Id, "").
+			Return(nil, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUser(mockUser.Id, "").
+			Return(nil, nil).
+			Times(1)
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{teamArg, mockUser.Id})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(printer.GetErrorLines()[0], "Can't find user '"+userArg+"'")
+	})
+
+	s.Run("Remove users from team by email and get team by name should not return an error", func() {
+		printer.Clean()
+		mockTeam := &model.Team{Id: teamArg}
+		mockUser := &model.User{Id: userArg}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(nil, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(teamArg, "").
+			Return(mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(mockUser.Id, "").
+			Return(mockUser, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RemoveTeamMember(mockTeam.Id, mockUser.Id).
+			Return(false, &model.Response{Error: nil}).
+			Times(1)
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{mockTeam.Id, mockUser.Id})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Remove users from team by email and get team should not return an error", func() {
+		printer.Clean()
+		mockTeam := &model.Team{Id: teamArg}
+		mockUser := &model.User{Id: userArg}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(mockUser.Id, "").
+			Return(mockUser, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RemoveTeamMember(mockTeam.Id, mockUser.Id).
+			Return(false, &model.Response{Error: nil}).
+			Times(1)
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{mockTeam.Id, mockUser.Id})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Remove users from team by username and get team should not return an error", func() {
+		printer.Clean()
+		mockTeam := &model.Team{Id: teamArg}
+		mockUser := &model.User{Id: userArg}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(mockUser.Id, "").
+			Return(nil, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByUsername(mockUser.Id, "").
+			Return(mockUser, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RemoveTeamMember(mockTeam.Id, mockUser.Id).
+			Return(false, &model.Response{Error: nil}).
+			Times(1)
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{mockTeam.Id, mockUser.Id})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Remove users from team by user and get team should not return an error", func() {
+		printer.Clean()
+		mockTeam := &model.Team{Id: teamArg}
+		mockUser := &model.User{Id: userArg}
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(mockUser.Id, "").
+			Return(nil, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByUsername(mockUser.Id, "").
+			Return(nil, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUser(mockUser.Id, "").
+			Return(mockUser, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RemoveTeamMember(mockTeam.Id, mockUser.Id).
+			Return(false, &model.Response{Error: nil}).
+			Times(1)
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{mockTeam.Id, mockUser.Id})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Remove users from team with an erroneous RemoveTeamMember should return an error", func() {
+		printer.Clean()
+		mockTeam := &model.Team{Id: teamArg, Name: "example-name"}
+		mockUser := &model.User{Id: userArg}
+		mockError := model.AppError{Message: "Mock error"}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(mockUser.Id, "").
+			Return(mockUser, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RemoveTeamMember(mockTeam.Id, mockUser.Id).
+			Return(false, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := removeUsersCmdF(s.client, &cobra.Command{}, []string{mockTeam.Id, mockUser.Id})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(printer.GetErrorLines()[0], "Unable to remove '"+mockUser.Id+"' from "+mockTeam.Name+". Error: "+mockError.Error())
+	})
+
+}

--- a/commands/teamargs.go
+++ b/commands/teamargs.go
@@ -21,6 +21,5 @@ func getTeamFromTeamArg(c client.Client, teamArg string) *model.Team {
 	if team == nil {
 		team, _ = c.GetTeamByName(teamArg, "")
 	}
-
 	return team
 }

--- a/commands/user.go
+++ b/commands/user.go
@@ -53,12 +53,11 @@ var SendPasswordResetEmailCmd = &cobra.Command{
 }
 
 var updateUserEmailCmd = &cobra.Command{
-	Use:   "email [user] [new email]",
-	Short: "Change email of the user",
-	Long:  "Change email of the user.",
-	Example: `  user email test user@example.com
-  user activate username`,
-	RunE: withClient(updateUserEmailCmdF),
+	Use:     "email [user] [new email]",
+	Short:   "Change email of the user",
+	Long:    "Change email of the user.",
+	Example: "  user email testuser user@example.com",
+	RunE:    withClient(updateUserEmailCmdF),
 }
 
 var ResetUserMfaCmd = &cobra.Command{

--- a/docs/mmctl.md
+++ b/docs/mmctl.md
@@ -30,5 +30,6 @@ Mattermost offers workplace messaging across web, PC and phones with archiving, 
 * [mmctl post](mmctl_post.md)	 - Management of posts
 * [mmctl team](mmctl_team.md)	 - Management of teams
 * [mmctl user](mmctl_user.md)	 - Management of users
+* [mmctl version](mmctl_version.md)	 - Prints the version of mmctl.
 * [mmctl websocket](mmctl_websocket.md)	 - Display websocket in a human-readable format
 

--- a/docs/mmctl_config.md
+++ b/docs/mmctl_config.md
@@ -22,5 +22,7 @@ Configuration
 
 * [mmctl](mmctl.md)	 - Remote client for the Open Source, self-hosted Slack-alternative
 * [mmctl config get](mmctl_config_get.md)	 - Get config setting
+* [mmctl config reset](mmctl_config_reset.md)	 - Reset config setting
+* [mmctl config set](mmctl_config_set.md)	 - Set config setting
 * [mmctl config show](mmctl_config_show.md)	 - Writes the server configuration to STDOUT
 

--- a/docs/mmctl_config_reset.md
+++ b/docs/mmctl_config_reset.md
@@ -1,0 +1,35 @@
+## mmctl config reset
+
+Reset config setting
+
+### Synopsis
+
+Resets the value of a config setting by its name in dot notation or a setting section. Accepts multiple values for array settings.
+
+```
+mmctl config reset [flags]
+```
+
+### Examples
+
+```
+config reset SqlSettings.DriverName LogSettings
+```
+
+### Options
+
+```
+      --confirm   Confirm you really want to reset all configuration settings to its default value
+  -h, --help      help for reset
+```
+
+### Options inherited from parent commands
+
+```
+      --format string   the format of the command output [plain, json] (default "plain")
+```
+
+### SEE ALSO
+
+* [mmctl config](mmctl_config.md)	 - Configuration
+

--- a/docs/mmctl_config_set.md
+++ b/docs/mmctl_config_set.md
@@ -1,0 +1,34 @@
+## mmctl config set
+
+Set config setting
+
+### Synopsis
+
+Sets the value of a config setting by its name in dot notation. Accepts multiple values for array settings
+
+```
+mmctl config set [flags]
+```
+
+### Examples
+
+```
+config set SqlSettings.DriverName mysql
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --format string   the format of the command output [plain, json] (default "plain")
+```
+
+### SEE ALSO
+
+* [mmctl config](mmctl_config.md)	 - Configuration
+

--- a/docs/mmctl_plugin_list.md
+++ b/docs/mmctl_plugin_list.md
@@ -4,7 +4,7 @@ List plugins
 
 ### Synopsis
 
-List all active and inactive plugins installed on your Mattermost server.
+List all enabled and disabled plugins installed on your Mattermost server.
 
 ```
 mmctl plugin list [flags]

--- a/docs/mmctl_team.md
+++ b/docs/mmctl_team.md
@@ -22,9 +22,11 @@ Management of teams
 
 * [mmctl](mmctl.md)	 - Remote client for the Open Source, self-hosted Slack-alternative
 * [mmctl team add](mmctl_team_add.md)	 - Add users to team
+* [mmctl team archive](mmctl_team_archive.md)	 - Archive teams
 * [mmctl team create](mmctl_team_create.md)	 - Create a team
 * [mmctl team delete](mmctl_team_delete.md)	 - Delete teams
 * [mmctl team list](mmctl_team_list.md)	 - List all teams.
 * [mmctl team remove](mmctl_team_remove.md)	 - Remove users from team
+* [mmctl team rename](mmctl_team_rename.md)	 - Rename team
 * [mmctl team search](mmctl_team_search.md)	 - Search for teams
 

--- a/docs/mmctl_team_archive.md
+++ b/docs/mmctl_team_archive.md
@@ -1,0 +1,36 @@
+## mmctl team archive
+
+Archive teams
+
+### Synopsis
+
+Archive some teams.
+Archives a team along with all related information including posts from the database.
+
+```
+mmctl team archive [teams] [flags]
+```
+
+### Examples
+
+```
+  team archive myteam
+```
+
+### Options
+
+```
+      --confirm   Confirm you really want to archive the team and a DB backup has been performed.
+  -h, --help      help for archive
+```
+
+### Options inherited from parent commands
+
+```
+      --format string   the format of the command output [plain, json] (default "plain")
+```
+
+### SEE ALSO
+
+* [mmctl team](mmctl_team.md)	 - Management of teams
+

--- a/docs/mmctl_team_rename.md
+++ b/docs/mmctl_team_rename.md
@@ -1,0 +1,38 @@
+## mmctl team rename
+
+Rename team
+
+### Synopsis
+
+Rename an existing team
+
+```
+mmctl team rename [team] [flags]
+```
+
+### Examples
+
+```
+  team rename old-team --name 'new-team' --display_name 'New Display Name'
+  team rename old-team --name 'new-team'
+  team rename old-team --display_name 'New Display Name'
+```
+
+### Options
+
+```
+      --display_name string   Team Display Name
+  -h, --help                  help for rename
+      --name string           Old Team Name
+```
+
+### Options inherited from parent commands
+
+```
+      --format string   the format of the command output [plain, json] (default "plain")
+```
+
+### SEE ALSO
+
+* [mmctl team](mmctl_team.md)	 - Management of teams
+

--- a/docs/mmctl_version.md
+++ b/docs/mmctl_version.md
@@ -1,0 +1,28 @@
+## mmctl version
+
+Prints the version of mmctl.
+
+### Synopsis
+
+Prints the version of mmctl.
+
+```
+mmctl version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --format string   the format of the command output [plain, json] (default "plain")
+```
+
+### SEE ALSO
+
+* [mmctl](mmctl.md)	 - Remote client for the Open Source, self-hosted Slack-alternative
+

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -741,6 +741,21 @@ func (mr *MockClientMockRecorder) SendPasswordResetEmail(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendPasswordResetEmail", reflect.TypeOf((*MockClient)(nil).SendPasswordResetEmail), arg0)
 }
 
+// SoftDeleteTeam mocks base method
+func (m *MockClient) SoftDeleteTeam(arg0 string) (bool, *model.Response) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SoftDeleteTeam", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(*model.Response)
+	return ret0, ret1
+}
+
+// SoftDeleteTeam indicates an expected call of SoftDeleteTeam
+func (mr *MockClientMockRecorder) SoftDeleteTeam(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SoftDeleteTeam", reflect.TypeOf((*MockClient)(nil).SoftDeleteTeam), arg0)
+}
+
 // SyncLdap mocks base method
 func (m *MockClient) SyncLdap() (bool, *model.Response) {
 	m.ctrl.T.Helper()
@@ -754,6 +769,36 @@ func (m *MockClient) SyncLdap() (bool, *model.Response) {
 func (mr *MockClientMockRecorder) SyncLdap() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncLdap", reflect.TypeOf((*MockClient)(nil).SyncLdap))
+}
+
+// UpdateConfig mocks base method
+func (m *MockClient) UpdateConfig(arg0 *model.Config) (*model.Config, *model.Response) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateConfig", arg0)
+	ret0, _ := ret[0].(*model.Config)
+	ret1, _ := ret[1].(*model.Response)
+	return ret0, ret1
+}
+
+// UpdateConfig indicates an expected call of UpdateConfig
+func (mr *MockClientMockRecorder) UpdateConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfig", reflect.TypeOf((*MockClient)(nil).UpdateConfig), arg0)
+}
+
+// UpdateTeam mocks base method
+func (m *MockClient) UpdateTeam(arg0 *model.Team) (*model.Team, *model.Response) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTeam", arg0)
+	ret0, _ := ret[0].(*model.Team)
+	ret1, _ := ret[1].(*model.Response)
+	return ret0, ret1
+}
+
+// UpdateTeam indicates an expected call of UpdateTeam
+func (mr *MockClientMockRecorder) UpdateTeam(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTeam", reflect.TypeOf((*MockClient)(nil).UpdateTeam), arg0)
 }
 
 // UpdateUser mocks base method


### PR DESCRIPTION
**Summary**

Add unit tests to the "ChannelGroupEnableCmd" mmctl command.

**Ticket Link**

Fixes https://github.com/mattermost/mattermost-server/issues/13291