### PR TITLE
[GH-13289] Add unit tests to the "TeamGroupEnableCmd" mmctl command

### DIFF
--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -1,0 +1,172 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
+	s.Run("Enable unexisting team", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		//mockTeam := model.Team{Id: teamArg}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(nil, &model.Response{Error: &model.AppError{}}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(arg, "").
+			Return(nil, &model.Response{Error: &model.AppError{}}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().EqualError(err, "Unable to find team '"+arg+"'")
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Error while getting the team groups", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		mockTeam := model.Team{Id: arg}
+		mockError := model.AppError{Message: "Mock error"}
+		groupOpts := model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByTeam(mockTeam.Id, groupOpts).
+			Return(nil, 0, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Equal(&mockError, err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("No groups on team", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		mockTeam := model.Team{Id: arg}
+		mockGroupList := []*model.Group{}
+		groupOpts := model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByTeam(mockTeam.Id, groupOpts).
+			Return(mockGroupList, 0, &model.Response{Error: nil}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().EqualError(err, "Team '"+arg+"' has no groups associated. It cannot be group-constrained")
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Error patching the team", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		mockTeam := model.Team{Id: arg}
+		mockError := model.AppError{Message: "Mock error"}
+		mockGroupList := []*model.Group{&model.Group{}}
+		groupOpts := model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+		teamPatch := model.TeamPatch{GroupConstrained: model.NewBool(true)}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByTeam(mockTeam.Id, groupOpts).
+			Return(mockGroupList, 1, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			PatchTeam(mockTeam.Id, &teamPatch).
+			Return(nil, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Equal(&mockError, err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Successfully enable group", func() {
+		printer.Clean()
+
+		arg := "teamId"
+		mockTeam := model.Team{Id: arg}
+		mockGroupList := []*model.Group{&model.Group{}}
+		groupOpts := model.GroupSearchOpts{
+			PageOpts: &model.PageOpts{
+				Page:    0,
+				PerPage: 10,
+			},
+		}
+		teamPatch := model.TeamPatch{GroupConstrained: model.NewBool(true)}
+
+		s.client.
+			EXPECT().
+			GetTeam(arg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetGroupsByTeam(mockTeam.Id, groupOpts).
+			Return(mockGroupList, 1, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			PatchTeam(mockTeam.Id, &teamPatch).
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().NoError(err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -11,7 +11,6 @@ func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
 		printer.Clean()
 
 		arg := "teamId"
-		//mockTeam := model.Team{Id: teamArg}
 
 		s.client.
 			EXPECT().
@@ -67,7 +66,6 @@ func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
 
 		arg := "teamId"
 		mockTeam := model.Team{Id: arg}
-		mockGroupList := []*model.Group{}
 		groupOpts := model.GroupSearchOpts{
 			PageOpts: &model.PageOpts{
 				Page:    0,
@@ -84,7 +82,7 @@ func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
 		s.client.
 			EXPECT().
 			GetGroupsByTeam(mockTeam.Id, groupOpts).
-			Return(mockGroupList, 0, &model.Response{Error: nil}).
+			Return([]*model.Group{}, 0, &model.Response{Error: nil}).
 			Times(1)
 
 		err := teamGroupEnableCmdF(s.client, &cobra.Command{}, []string{arg})
@@ -99,7 +97,6 @@ func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
 		arg := "teamId"
 		mockTeam := model.Team{Id: arg}
 		mockError := model.AppError{Message: "Mock error"}
-		mockGroupList := []*model.Group{&model.Group{}}
 		groupOpts := model.GroupSearchOpts{
 			PageOpts: &model.PageOpts{
 				Page:    0,
@@ -117,7 +114,7 @@ func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
 		s.client.
 			EXPECT().
 			GetGroupsByTeam(mockTeam.Id, groupOpts).
-			Return(mockGroupList, 1, &model.Response{Error: nil}).
+			Return([]*model.Group{&model.Group{}}, 1, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
@@ -137,7 +134,6 @@ func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
 
 		arg := "teamId"
 		mockTeam := model.Team{Id: arg}
-		mockGroupList := []*model.Group{&model.Group{}}
 		groupOpts := model.GroupSearchOpts{
 			PageOpts: &model.PageOpts{
 				Page:    0,
@@ -155,7 +151,7 @@ func (s *MmctlUnitTestSuite) TestTeamGroupEnableCmd() {
 		s.client.
 			EXPECT().
 			GetGroupsByTeam(mockTeam.Id, groupOpts).
-			Return(mockGroupList, 1, &model.Response{Error: nil}).
+			Return([]*model.Group{&model.Group{}}, 1, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
 Add unit tests to the "TeamGroupEnableCmd" mmctl command
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/mattermost-server/issues/13289
