### PR TITLE
[GH-13402] Add unit tests to the "ListLdapGroupsCmd" mmctl command

### DIFF
--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestListLdapGroupsCmd() {
+	s.Run("Failure getting Ldap Groups", func() {
+		printer.Clean()
+		mockError := model.AppError{Id: "Mock Error"}
+
+		s.client.
+			EXPECT().
+			GetLdapGroups().
+			Return(nil, &model.Response{Error: &mockError}).
+			Times(1)
+
+		err := listLdapGroupsCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Equal(&mockError, err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("List several groups", func() {
+		printer.Clean()
+		mockList := []*model.Group{
+			&model.Group{DisplayName: "Group1"},
+			&model.Group{DisplayName: "Group2"},
+			&model.Group{DisplayName: "Group3"},
+		}
+
+		s.client.
+			EXPECT().
+			GetLdapGroups().
+			Return(mockList, &model.Response{Error: nil}).
+			Times(1)
+
+		err := listLdapGroupsCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetLines(), 3)
+		for i, v := range mockList {
+			s.Require().Equal(v, printer.GetLines()[i])
+		}
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add unit tests to the "ListLdapGroupsCmd" mmctl command
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/13402
