### PR TITLE
GH-13404: Add 3 test cases for removePermissionsCmdF

### DIFF
--- a/commands/permissions_test.go
+++ b/commands/permissions_test.go
@@ -54,3 +54,103 @@ func (s *MmctlUnitTestSuite) TestAddPermissionsCmd() {
 		s.Require().Equal(expectedError, err)
 	})
 }
+
+//---------------------------------------------------
+
+func (s *MmctlUnitTestSuite) TestRemovePermissionsCmd() {
+	s.Run("Removing a permission from an existing role", func() {
+		mockRole := &model.Role{
+			Id:          "mock-id",
+			Name:        "mock-role",
+			Permissions: []string{"view", "edit", "delete"},
+		}
+
+		expectedPatch := &model.RolePatch{
+			Permissions: &[]string{"view", "edit"},
+		}
+		s.client.
+			EXPECT().
+			GetRoleByName(mockRole.Name).
+			Return(mockRole, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			PatchRole(mockRole.Id, expectedPatch).
+			Return(&model.Role{}, &model.Response{Error: nil}).
+			Times(1)
+
+		args := []string{mockRole.Name, "delete"}
+		err := removePermissionsCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+	})
+
+	s.Run("Removing an existing permission from an existing role", func() {
+		mockRole := &model.Role{
+			Id:          "mock-id",
+			Name:        "mock-role",
+			Permissions: []string{"view", "edit"},
+		}
+
+		expectedPatch := &model.RolePatch{
+			Permissions: &[]string{"edit"},
+		}
+		s.client.
+			EXPECT().
+			GetRoleByName(mockRole.Name).
+			Return(mockRole, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			PatchRole(mockRole.Id, expectedPatch).
+			Return(&model.Role{}, &model.Response{Error: nil}).
+			Times(1)
+
+		args := []string{mockRole.Name, "view"}
+		err := removePermissionsCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+	})
+
+	s.Run("Removing a non-existing permission from an existing role", func() {
+		mockRole := &model.Role{
+			Id:          "mock-id",
+			Name:        "mock-role",
+			Permissions: []string{"view", "edit"},
+		}
+
+		expectedPatch := &model.RolePatch{
+			Permissions: &[]string{"view", "edit"},
+		}
+		s.client.
+			EXPECT().
+			GetRoleByName(mockRole.Name).
+			Return(mockRole, &model.Response{Error: nil}).
+			Times(1)
+		s.client.
+			EXPECT().
+			PatchRole(mockRole.Id, expectedPatch).
+			Return(&model.Role{}, &model.Response{Error: nil}).
+			Times(1)
+
+		args := []string{mockRole.Name, "delete"}
+		err := removePermissionsCmdF(s.client, &cobra.Command{}, args)
+		s.Require().Nil(err)
+	})
+
+	s.Run("Removing a permission from a non-existing role", func() {
+		mockRole := model.Role{
+			Name:        "exampleName",
+			Permissions: []string{"view", "edit", "delete"},
+		}
+
+		mockError := model.NewAppError("Role", "role_not_found", nil, "", http.StatusNotFound)
+		s.client.
+			EXPECT().
+			GetRoleByName(mockRole.Name).
+			Return(nil, &model.Response{Error: mockError}).
+			Times(1)
+
+		args := []string{mockRole.Name, "delete"}
+		err := removePermissionsCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+	})
+}

--- a/commands/permissions_test.go
+++ b/commands/permissions_test.go
@@ -84,11 +84,11 @@ func (s *MmctlUnitTestSuite) TestRemovePermissionsCmd() {
 		s.Require().Nil(err)
 	})
 
-	s.Run("Removing an existing permission from an existing role", func() {
+	s.Run("Removing multiple permissions from an existing role", func() {
 		mockRole := &model.Role{
 			Id:          "mock-id",
 			Name:        "mock-role",
-			Permissions: []string{"view", "edit"},
+			Permissions: []string{"view", "edit", "delete"},
 		}
 
 		expectedPatch := &model.RolePatch{
@@ -105,7 +105,7 @@ func (s *MmctlUnitTestSuite) TestRemovePermissionsCmd() {
 			Return(&model.Role{}, &model.Response{Error: nil}).
 			Times(1)
 
-		args := []string{mockRole.Name, "view"}
+		args := []string{mockRole.Name, "view", "delete"}
 		err := removePermissionsCmdF(s.client, &cobra.Command{}, args)
 		s.Require().Nil(err)
 	})

--- a/commands/permissions_test.go
+++ b/commands/permissions_test.go
@@ -55,8 +55,6 @@ func (s *MmctlUnitTestSuite) TestAddPermissionsCmd() {
 	})
 }
 
-//---------------------------------------------------
-
 func (s *MmctlUnitTestSuite) TestRemovePermissionsCmd() {
 	s.Run("Removing a permission from an existing role", func() {
 		mockRole := &model.Role{
@@ -151,6 +149,6 @@ func (s *MmctlUnitTestSuite) TestRemovePermissionsCmd() {
 
 		args := []string{mockRole.Name, "delete"}
 		err := removePermissionsCmdF(s.client, &cobra.Command{}, args)
-		s.Require().NotNil(err)
+		s.Require().EqualError(err, "Role: role_not_found, ")
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
I added 3 unit tests for the removePermissionsCmdF function.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/13404

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/13404