### PR TITLE
Bump minimum Go version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ source <(mmctl completion zsh)
 
 ## Compile
 
-First we have to install the dependencies of the project. `mmctl` depends on go version 1.13 or greater.
+First we have to install the dependencies of the project. `mmctl` depends on go version 1.13.3 or greater.
 
 We can compile the binary with:
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
mmctl requires Go 1.13.3 to avoid build error (actually, fails on `go vet` using `shadow`) due to https://github.com/golang/go/issues/34053

