### PR TITLE
Added tFatal and equalLenAsserts checkers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ifeq ($(ADVANCED_VET), TRUE)
 		exit 1; \
 	fi;
 	@echo Running mattermost-govet
-	$(GO) vet -vettool=$(GOPATH)/bin/mattermost-govet -license -structuredLogging -inconsistentReceiverName ./...
+	$(GO) vet -vettool=$(GOPATH)/bin/mattermost-govet -license -structuredLogging -inconsistentReceiverName -tFatal -equalLenAsserts ./...
 	@if ! [ -x "$$(command -v shadow)" ]; then \
 		echo "shadow vet tool is not installed. Please install it executing \"GO111MODULE=off go get -u golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow\""; \
 		exit 1; \


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR adds two new mattermost govet checkers:

- tFatal checker [looks for uses of](https://github.com/mattermost/mattermost-govet/blob/master/tFatal/tFatal.go) `t.Fatal` because its use is discouraged
- equalLenAsserts that [checks for users of](https://github.com/mattermost/mattermost-govet/blob/master/equalLenAsserts/equalLenAsserts.go) `assert.Len` and `assert.Equal` and asks for changes providing a better alternative

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-21714