### PR TITLE
[GH-13457] Add unit tests to the "RestoreChannelsCmd" mmctl command

### DIFF
--- a/commands/channel.go
+++ b/commands/channel.go
@@ -327,7 +327,7 @@ func listChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error 
 
 func restoreChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return errors.New("Enter at least one channel")
+		return errors.New("enter at least one channel")
 	}
 
 	channels := getChannelsFromChannelArgs(c, args)

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -312,7 +312,7 @@ func listChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error 
 
 func restoreChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return errors.New("Enter at least one channel.")
+		return errors.New("Enter at least one channel")
 	}
 
 	channels := getChannelsFromChannelArgs(c, args)

--- a/commands/channel_test.go
+++ b/commands/channel_test.go
@@ -1384,11 +1384,10 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 		printer.Clean()
 
 		err := restoreChannelsCmdF(s.client, &cobra.Command{}, []string{})
-		mockErr := errors.New("Enter at least one channel")
+		mockErr := errors.New("enter at least one channel")
 
 		expected := mockErr.Error()
 		actual := err.Error()
-		 
 		s.Require().Equal(expected, actual)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 0)
@@ -1423,7 +1422,6 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			RestoreChannel(channelID).
 			Return(&mockChannel, &model.Response{Error: nil}).
 			Times(1)
-		
 
 		err := restoreChannelsCmdF(s.client, cmd, []string{args})
 		s.Require().Nil(err)
@@ -1452,7 +1450,6 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			RestoreChannel(channelID).
 			Return(&mockChannel, &model.Response{Error: nil}).
 			Times(1)
-		
 
 		err := restoreChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
@@ -1497,7 +1494,6 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			RestoreChannel(channelID2).
 			Return(&mockChannel2, &model.Response{Error: nil}).
 			Times(1)
-		
 
 		err := restoreChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
@@ -1619,7 +1615,6 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			RestoreChannel(channelID).
 			Return(nil, &model.Response{Error: mockErr}).
 			Times(1)
-		
 
 		err := restoreChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
@@ -1629,7 +1624,6 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 		actual := printer.GetErrorLines()[0]
 		expected := fmt.Sprintf("Unable to restore channel '%s'. Error: %s", channelArg, mockErr.Error())
 		s.Require().Equal(expected, actual)
-
 	})
 
 	s.Run("Fail to restore when team and channel not provided", func() {
@@ -1646,5 +1640,5 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 		actual := printer.GetErrorLines()[0]
 		expected := fmt.Sprintf("Unable to find channel '%s'", args[0])
 		s.Require().Equal(expected, actual)
-	})	
+	})
 }

--- a/commands/channel_test.go
+++ b/commands/channel_test.go
@@ -1150,3 +1150,273 @@ func (s *MmctlUnitTestSuite) TestAddChannelUsersCmdF() {
 			printer.GetErrorLines()[0])
 	})
 }
+
+func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
+	s.Run("Restore channel without args returns an error", func() {
+		printer.Clean()
+
+		err := restoreChannelsCmdF(s.client, &cobra.Command{}, []string{})
+		mockErr := errors.New("Enter at least one channel")
+
+		expected := mockErr.Error()
+		actual := err.Error()
+		 
+		s.Require().Equal(expected, actual)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Restore an existing channel on an existing team", func() {
+		printer.Clean()
+
+		teamArg := "some-team-id"
+		mockTeam := model.Team{Id: teamArg}
+		channelArg := "some-channel"
+		channelID := "some-channel-id"
+		mockChannel := model.Channel{Id: channelID, Name: channelArg}
+
+		cmd := &cobra.Command{}
+		args := teamArg + ":" + channelArg
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannelByNameIncludeDeleted(channelArg, teamArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RestoreChannel(channelID).
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+		
+
+		err := restoreChannelsCmdF(s.client, cmd, []string{args})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Restore an existing channel specified by channel id", func() {
+		printer.Clean()
+
+		channelArg := "some-channel"
+		channelID := "some-channel-id"
+		mockChannel := model.Channel{Id: channelID, Name: channelArg}
+
+		cmd := &cobra.Command{}
+		args := []string{channelArg}
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RestoreChannel(channelID).
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+		
+
+		err := restoreChannelsCmdF(s.client, cmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Restore several channels specified by channel id", func() {
+		printer.Clean()
+
+		channelArg1 := "some-channel"
+		channelID1 := "some-channel-id"
+		mockChannel1 := model.Channel{Id: channelID1, Name: channelArg1}
+
+		channelArg2 := "some-other-channel"
+		channelID2 := "some-other-channel-id"
+		mockChannel2 := model.Channel{Id: channelID2, Name: channelArg2}
+
+		cmd := &cobra.Command{}
+		args := []string{channelArg1, channelArg2}
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg1, "").
+			Return(&mockChannel1, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg2, "").
+			Return(&mockChannel2, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RestoreChannel(channelID1).
+			Return(&mockChannel1, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			RestoreChannel(channelID2).
+			Return(&mockChannel2, &model.Response{Error: nil}).
+			Times(1)
+		
+
+		err := restoreChannelsCmdF(s.client, cmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Fail to restore a channel on a non-existent team", func() {
+		printer.Clean()
+
+		teamArg := "some-non-existent-team-id"
+		channelArg := "some-channel"
+
+		cmd := &cobra.Command{}
+		args := []string{teamArg + ":" + channelArg}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetTeamByName(teamArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		err := restoreChannelsCmdF(s.client, cmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+
+		actual := printer.GetErrorLines()[0]
+		expected := fmt.Sprintf("Unable to find channel '%s'", args[0])
+		s.Require().Equal(expected, actual)
+	})
+
+	s.Run("Fail to restore a non-existing channel on an existent team", func() {
+		printer.Clean()
+
+		teamArg := "some-non-existing-team-id"
+		mockTeam := model.Team{Id: teamArg}
+		channelArg := "some-non-existing-channel"
+
+		cmd := &cobra.Command{}
+		args := []string{teamArg + ":" + channelArg}
+
+		s.client.
+			EXPECT().
+			GetTeam(teamArg, "").
+			Return(&mockTeam, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannelByNameIncludeDeleted(channelArg, teamArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		err := restoreChannelsCmdF(s.client, cmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+
+		actual := printer.GetErrorLines()[0]
+		expected := fmt.Sprintf("Unable to find channel '%s'", args[0])
+		s.Require().Equal(expected, actual)
+	})
+
+	s.Run("Fail to restore a non-existing channel", func() {
+		printer.Clean()
+
+		channelArg := "some-non-existing-channel"
+		cmd := &cobra.Command{}
+		args := []string{channelArg}
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(nil, &model.Response{Error: nil}).
+			Times(1)
+
+		err := restoreChannelsCmdF(s.client, cmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+
+		actual := printer.GetErrorLines()[0]
+		expected := fmt.Sprintf("Unable to find channel '%s'", args[0])
+		s.Require().Equal(expected, actual)
+	})
+
+	s.Run("Fail to restore an existing channel when client throws error", func() {
+		printer.Clean()
+
+		channelArg := "some-channel"
+		channelID := "some-channel-id"
+		mockChannel := model.Channel{Id: channelID, Name: channelArg}
+
+		cmd := &cobra.Command{}
+		args := []string{channelArg}
+
+		s.client.
+			EXPECT().
+			GetChannel(channelArg, "").
+			Return(&mockChannel, &model.Response{Error: nil}).
+			Times(1)
+
+		mockErr := &model.AppError{Message: "Mock error"}
+		s.client.
+			EXPECT().
+			RestoreChannel(channelID).
+			Return(nil, &model.Response{Error: mockErr}).
+			Times(1)
+		
+
+		err := restoreChannelsCmdF(s.client, cmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+
+		actual := printer.GetErrorLines()[0]
+		expected := fmt.Sprintf("Unable to restore channel '%s'. Error: %s", channelArg, mockErr.Error())
+		s.Require().Equal(expected, actual)
+
+	})
+
+	s.Run("Fail to restore when team and channel not provided", func() {
+		printer.Clean()
+
+		cmd := &cobra.Command{}
+		args := []string{":"}
+
+		err := restoreChannelsCmdF(s.client, cmd, args)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+
+		actual := printer.GetErrorLines()[0]
+		expected := fmt.Sprintf("Unable to find channel '%s'", args[0])
+		s.Require().Equal(expected, actual)
+	})	
+}


### PR DESCRIPTION
Summary
Add unit tests to the "RestoreChannelsCmd" mmctl command

Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/13457

Jira Link
https://mattermost.atlassian.net/browse/MM-21388