### PR TITLE
[MM-20290] Add unit tests to the "ShowRoleCmd" mmctl command

### DIFF
--- a/commands/permissions_test.go
+++ b/commands/permissions_test.go
@@ -170,7 +170,7 @@ func (s *MmctlUnitTestSuite) TestShowRoleCmd() {
 		s.client.
 			EXPECT().
 			GetRoleByName(mockRole.Name).
-			Return(&mockRole, &model.Response{Error: nil}).
+			Return(mockRole, &model.Response{Error: nil}).
 			Times(1)
 
 		err := showRoleCmdF(s.client, &cobra.Command{}, []string{commandArg})

--- a/commands/permissions_test.go
+++ b/commands/permissions_test.go
@@ -160,13 +160,13 @@ func (s *MmctlUnitTestSuite) TestRemovePermissionsCmd() {
 
 func (s *MmctlUnitTestSuite) TestShowRoleCmd() {
 	s.Run("Show custom role", func() {
+		printer.Clean()
+		
 		commandArg := "example-role-name"
 		mockRole := &model.Role{
 			Id:   "example-mock-id",
 			Name: commandArg,
 		}
-
-		printer.Clean()
 
 		s.client.
 			EXPECT().
@@ -182,11 +182,11 @@ func (s *MmctlUnitTestSuite) TestShowRoleCmd() {
 	})
 
 	s.Run("Show custom role with invalid name", func() {
+		printer.Clean()
+		
 		expectedError := model.NewAppError("Role", "role_not_found", nil, "", http.StatusNotFound)
 
 		commandArgBogus := "bogus-role-name"
-
-		printer.Clean()
 
 		// showRoleCmdF will look up role by name
 		s.client.

--- a/commands/permissions_test.go
+++ b/commands/permissions_test.go
@@ -161,7 +161,7 @@ func (s *MmctlUnitTestSuite) TestRemovePermissionsCmd() {
 func (s *MmctlUnitTestSuite) TestShowRoleCmd() {
 	s.Run("Show custom role", func() {
 		printer.Clean()
-		
+
 		commandArg := "example-role-name"
 		mockRole := &model.Role{
 			Id:   "example-mock-id",
@@ -183,7 +183,7 @@ func (s *MmctlUnitTestSuite) TestShowRoleCmd() {
 
 	s.Run("Show custom role with invalid name", func() {
 		printer.Clean()
-		
+
 		expectedError := model.NewAppError("Role", "role_not_found", nil, "", http.StatusNotFound)
 
 		commandArgBogus := "bogus-role-name"

--- a/commands/permissions_test.go
+++ b/commands/permissions_test.go
@@ -6,8 +6,9 @@ package commands
 import (
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mmctl/printer"
+
+	"github.com/mattermost/mattermost-server/v5/model"
 
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Summary: 
Add unit tests to the "ShowRoleCmd" mmctl command

Jira: https://mattermost.atlassian.net/browse/MM-20290
Fixes: https://github.com/mattermost/mattermost-server/issues/13403