### PR TITLE
[MM-22166] Rejects SHA1 intermediate certificates and allows for a bypass

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ linters:
     - interfacer
     - misspell
     - nakedret
-    - scopelint
     - staticcheck
     - stylecheck
     - typecheck

--- a/commands/init.go
+++ b/commands/init.go
@@ -23,8 +23,8 @@ import (
 
 var (
 	insecureSignatureAlgorithms = map[x509.SignatureAlgorithm]bool{
-		x509.SHA1WithRSA: true,
-		x509.DSAWithSHA1: true,
+		x509.SHA1WithRSA:   true,
+		x509.DSAWithSHA1:   true,
 		x509.ECDSAWithSHA1: true,
 	}
 )

--- a/commands/init.go
+++ b/commands/init.go
@@ -22,10 +22,10 @@ import (
 )
 
 var (
-	insecureSignatureAlgorithms = []x509.SignatureAlgorithm{
-		x509.SHA1WithRSA,
-		x509.DSAWithSHA1,
-		x509.ECDSAWithSHA1,
+	insecureSignatureAlgorithms = map[x509.SignatureAlgorithm]bool{
+		x509.SHA1WithRSA: true,
+		x509.DSAWithSHA1: true,
+		x509.ECDSAWithSHA1: true,
 	}
 )
 
@@ -63,10 +63,8 @@ func isValidChain(chain []*x509.Certificate) bool {
 	certs := chain[:len(chain)-1]
 
 	for _, cert := range certs {
-		for _, alg := range insecureSignatureAlgorithms {
-			if cert.SignatureAlgorithm == alg {
-				return false
-			}
+		if _, ok := insecureSignatureAlgorithms[cert.SignatureAlgorithm]; ok {
+			return false
 		}
 	}
 	return true

--- a/commands/init.go
+++ b/commands/init.go
@@ -4,6 +4,10 @@
 package commands
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -17,6 +21,14 @@ import (
 	"github.com/mattermost/mmctl/printer"
 )
 
+var (
+	insecureSignatureAlgorithms = []x509.SignatureAlgorithm{
+		x509.SHA1WithRSA,
+		x509.DSAWithSHA1,
+		x509.ECDSAWithSHA1,
+	}
+)
+
 func CheckVersionMatch(version, serverVersion string) bool {
 	maj, min, _ := model.SplitVersion(version)
 	srvMaj, srvMin, _ := model.SplitVersion(serverVersion)
@@ -26,7 +38,9 @@ func CheckVersionMatch(version, serverVersion string) bool {
 
 func withClient(fn func(c client.Client, cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		c, serverVersion, err := InitClient()
+		allowInsecure := viper.GetBool("insecure-sha1-intermediate")
+
+		c, serverVersion, err := InitClient(allowInsecure)
 		if err != nil {
 			return err
 		}
@@ -44,8 +58,40 @@ func withClient(fn func(c client.Client, cmd *cobra.Command, args []string) erro
 	}
 }
 
-func InitClientWithUsernameAndPassword(username, password, instanceURL string) (*model.Client4, string, error) {
+func NewAPIv4Client(instanceURL string, allowInsecure bool) *model.Client4 {
 	client := model.NewAPIv4Client(instanceURL)
+
+	if !allowInsecure {
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+					// loop over certificate chains
+					for _, chain := range verifiedChains {
+						// check all certs but the root one
+						certs := chain[:len(chain)-1]
+
+						for _, cert := range certs {
+							for _, alg := range insecureSignatureAlgorithms {
+								if cert.SignatureAlgorithm == alg {
+									return fmt.Errorf("insecure algorithm %s found in the certificate chain. Use --insecure-sha1-intermediate flag to ignore. Aborting", alg)
+								}
+							}
+						}
+					}
+					return nil
+				},
+			},
+		}
+
+		client.HttpClient = &http.Client{Transport: transport}
+	}
+
+	return client
+}
+
+func InitClientWithUsernameAndPassword(username, password, instanceURL string, allowInsecure bool) (*model.Client4, string, error) {
+	client := NewAPIv4Client(instanceURL, allowInsecure)
+
 	_, response := client.Login(username, password)
 	if response.Error != nil {
 		return nil, "", response.Error
@@ -53,8 +99,8 @@ func InitClientWithUsernameAndPassword(username, password, instanceURL string) (
 	return client, response.ServerVersion, nil
 }
 
-func InitClientWithMFA(username, password, mfaToken, instanceURL string) (*model.Client4, string, error) {
-	client := model.NewAPIv4Client(instanceURL)
+func InitClientWithMFA(username, password, mfaToken, instanceURL string, allowInsecure bool) (*model.Client4, string, error) {
+	client := NewAPIv4Client(instanceURL, allowInsecure)
 	_, response := client.LoginWithMFA(username, password, mfaToken)
 	if response.Error != nil {
 		return nil, "", response.Error
@@ -62,8 +108,8 @@ func InitClientWithMFA(username, password, mfaToken, instanceURL string) (*model
 	return client, response.ServerVersion, nil
 }
 
-func InitClientWithCredentials(credentials *Credentials) (*model.Client4, string, error) {
-	client := model.NewAPIv4Client(credentials.InstanceURL)
+func InitClientWithCredentials(credentials *Credentials, allowInsecure bool) (*model.Client4, string, error) {
+	client := NewAPIv4Client(credentials.InstanceURL, allowInsecure)
 
 	client.AuthType = model.HEADER_BEARER
 	client.AuthToken = credentials.AuthToken
@@ -76,12 +122,12 @@ func InitClientWithCredentials(credentials *Credentials) (*model.Client4, string
 	return client, response.ServerVersion, nil
 }
 
-func InitClient() (*model.Client4, string, error) {
+func InitClient(allowInsecure bool) (*model.Client4, string, error) {
 	credentials, err := GetCurrentCredentials()
 	if err != nil {
 		return nil, "", err
 	}
-	return InitClientWithCredentials(credentials)
+	return InitClientWithCredentials(credentials, allowInsecure)
 }
 
 func InitWebSocketClient() (*model.WebSocketClient, error) {

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -107,6 +107,22 @@ func TestVerifyCertificates(t *testing.T) {
 			},
 			ExpectedError: false,
 		},
+		{
+			Name: "Two invalid chains",
+			Chains: [][]*x509.Certificate{
+				{
+					{SignatureAlgorithm: x509.SHA256WithRSA},
+					{SignatureAlgorithm: x509.SHA1WithRSA},
+					{SignatureAlgorithm: x509.SHA1WithRSA},
+				},
+				{
+					{SignatureAlgorithm: x509.SHA256WithRSA},
+					{SignatureAlgorithm: x509.DSAWithSHA1},
+					{SignatureAlgorithm: x509.DSAWithSHA1},
+				},
+			},
+			ExpectedError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"crypto/x509"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,6 +61,63 @@ func TestCheckVersionMatch(t *testing.T) {
 			res := CheckVersionMatch(tc.Version, tc.ServerVersion)
 
 			require.Equal(t, tc.Expected, res)
+		})
+	}
+}
+
+func TestVerifyCertificates(t *testing.T) {
+	testCases := []struct{
+		Name string
+		Chains [][]*x509.Certificate
+		ExpectedError bool
+	}{
+		{
+			Name: "One chain with a root SHA1 cert",
+			Chains: [][]*x509.Certificate{
+				{
+					{SignatureAlgorithm: x509.SHA256WithRSA},
+					{SignatureAlgorithm: x509.SHA1WithRSA},
+				},
+			},
+			ExpectedError: false,
+		},
+		{
+			Name: "One chain with an intermediate SHA1 cert",
+			Chains: [][]*x509.Certificate{
+				{
+					{SignatureAlgorithm: x509.SHA256WithRSA},
+					{SignatureAlgorithm: x509.SHA1WithRSA},
+					{SignatureAlgorithm: x509.SHA1WithRSA},
+				},
+			},
+			ExpectedError: true,
+		},
+		{
+			Name: "One valid chain and other invalid",
+			Chains: [][]*x509.Certificate{
+				{
+					{SignatureAlgorithm: x509.SHA256WithRSA},
+					{SignatureAlgorithm: x509.SHA1WithRSA},
+					{SignatureAlgorithm: x509.SHA1WithRSA},
+				},
+				{
+					{SignatureAlgorithm: x509.SHA256WithRSA},
+					{SignatureAlgorithm: x509.SHA256WithRSA},
+					{SignatureAlgorithm: x509.SHA1WithRSA},
+				},
+			},
+			ExpectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			err := VerifyCertificates([][]byte{}, tc.Chains)
+			if tc.ExpectedError {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
 		})
 	}
 }

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -56,7 +56,6 @@ func TestCheckVersionMatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			res := CheckVersionMatch(tc.Version, tc.ServerVersion)
 
@@ -66,9 +65,9 @@ func TestCheckVersionMatch(t *testing.T) {
 }
 
 func TestVerifyCertificates(t *testing.T) {
-	testCases := []struct{
-		Name string
-		Chains [][]*x509.Certificate
+	testCases := []struct {
+		Name          string
+		Chains        [][]*x509.Certificate
 		ExpectedError bool
 	}{
 		{

--- a/commands/mmctltestlib.go
+++ b/commands/mmctltestlib.go
@@ -33,7 +33,7 @@ func setupTestHelper() (*TestHelper, error) {
 		instanceURL = os.Getenv("MMCTL_INSTANCE_URL")
 	}
 
-	sysadminClient, _, err := InitClientWithUsernameAndPassword(SysadminUsername, SysadminPass, instanceURL)
+	sysadminClient, _, err := InitClientWithUsernameAndPassword(SysadminUsername, SysadminPass, instanceURL, false)
 	if err != nil {
 		return nil, fmt.Errorf("system admin client failed to connect: %s", err)
 	}
@@ -42,7 +42,7 @@ func setupTestHelper() (*TestHelper, error) {
 		return nil, fmt.Errorf("couldn't retrieve system admin user with username %s: %s", SysadminUsername, response.Error)
 	}
 
-	client, _, err := InitClientWithUsernameAndPassword(UserUsername, UserPass, instanceURL)
+	client, _, err := InitClientWithUsernameAndPassword(UserUsername, UserPass, instanceURL, false)
 	if err != nil {
 		return nil, fmt.Errorf("basic client failed to connect: %s", err)
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -12,12 +14,16 @@ import (
 
 func Run(args []string) error {
 	viper.SetEnvPrefix("mmctl")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 	RootCmd.PersistentFlags().String("format", "plain", "the format of the command output [plain, json]")
 	_ = viper.BindPFlag("format", RootCmd.PersistentFlags().Lookup("format"))
 	RootCmd.PersistentFlags().Bool("strict", false, "will only run commands if the mmctl version matches the server one")
 	_ = viper.BindPFlag("strict", RootCmd.PersistentFlags().Lookup("strict"))
+	RootCmd.PersistentFlags().Bool("insecure-sha1-intermediate", false, "allows to use insecure TLS protocols, such as SHA-1")
+	_ = viper.BindPFlag("insecure-sha1-intermediate", RootCmd.PersistentFlags().Lookup("insecure-sha1-intermediate"))
+
 	RootCmd.SetArgs(args)
 
 	return RootCmd.Execute()

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -16,9 +16,10 @@ Options
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-  -h, --help            help for mmctl
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+  -h, --help                         help for mmctl
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_auth.rst
+++ b/docs/mmctl_auth.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_auth_clean.rst
+++ b/docs/mmctl_auth_clean.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_auth_current.rst
+++ b/docs/mmctl_auth_current.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_auth_delete.rst
+++ b/docs/mmctl_auth_delete.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_auth_list.rst
+++ b/docs/mmctl_auth_list.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_auth_login.rst
+++ b/docs/mmctl_auth_login.rst
@@ -43,8 +43,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_auth_renew.rst
+++ b/docs/mmctl_auth_renew.rst
@@ -37,8 +37,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_auth_set.rst
+++ b/docs/mmctl_auth_set.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel.rst
+++ b/docs/mmctl_channel.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_add.rst
+++ b/docs/mmctl_channel_add.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_archive.rst
+++ b/docs/mmctl_channel_archive.rst
@@ -36,8 +36,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_create.rst
+++ b/docs/mmctl_channel_create.rst
@@ -41,8 +41,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_list.rst
+++ b/docs/mmctl_channel_list.rst
@@ -35,8 +35,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_make_private.rst
+++ b/docs/mmctl_channel_make_private.rst
@@ -35,8 +35,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_modify.rst
+++ b/docs/mmctl_channel_modify.rst
@@ -38,8 +38,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_remove.rst
+++ b/docs/mmctl_channel_remove.rst
@@ -36,8 +36,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_rename.rst
+++ b/docs/mmctl_channel_rename.rst
@@ -38,8 +38,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_restore.rst
+++ b/docs/mmctl_channel_restore.rst
@@ -35,8 +35,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_channel_search.rst
+++ b/docs/mmctl_channel_search.rst
@@ -38,8 +38,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_command.rst
+++ b/docs/mmctl_command.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_command_archive.rst
+++ b/docs/mmctl_command_archive.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_command_create.rst
+++ b/docs/mmctl_command_create.rst
@@ -45,8 +45,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_command_list.rst
+++ b/docs/mmctl_command_list.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_command_modify.rst
+++ b/docs/mmctl_command_modify.rst
@@ -45,8 +45,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_command_move.rst
+++ b/docs/mmctl_command_move.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_command_show.rst
+++ b/docs/mmctl_command_show.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_completion.rst
+++ b/docs/mmctl_completion.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_completion_bash.rst
+++ b/docs/mmctl_completion_bash.rst
@@ -32,8 +32,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_completion_zsh.rst
+++ b/docs/mmctl_completion_zsh.rst
@@ -32,8 +32,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_config.rst
+++ b/docs/mmctl_config.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_config_get.rst
+++ b/docs/mmctl_config_get.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_config_reset.rst
+++ b/docs/mmctl_config_reset.rst
@@ -35,8 +35,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_config_set.rst
+++ b/docs/mmctl_config_set.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_config_show.rst
+++ b/docs/mmctl_config_show.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_docs.rst
+++ b/docs/mmctl_docs.rst
@@ -28,8 +28,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group.rst
+++ b/docs/mmctl_group.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_channel.rst
+++ b/docs/mmctl_group_channel.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_channel_disable.rst
+++ b/docs/mmctl_group_channel_disable.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_channel_enable.rst
+++ b/docs/mmctl_group_channel_enable.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_channel_list.rst
+++ b/docs/mmctl_group_channel_list.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_channel_status.rst
+++ b/docs/mmctl_group_channel_status.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_list-ldap.rst
+++ b/docs/mmctl_group_list-ldap.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_team.rst
+++ b/docs/mmctl_group_team.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_team_disable.rst
+++ b/docs/mmctl_group_team_disable.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_team_enable.rst
+++ b/docs/mmctl_group_team_enable.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_team_list.rst
+++ b/docs/mmctl_group_team_list.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_group_team_status.rst
+++ b/docs/mmctl_group_team_status.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_ldap.rst
+++ b/docs/mmctl_ldap.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_ldap_sync.rst
+++ b/docs/mmctl_ldap_sync.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_license.rst
+++ b/docs/mmctl_license.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_license_remove.rst
+++ b/docs/mmctl_license_remove.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_license_upload.rst
+++ b/docs/mmctl_license_upload.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_logs.rst
+++ b/docs/mmctl_logs.rst
@@ -29,8 +29,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_permissions.rst
+++ b/docs/mmctl_permissions.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_permissions_add.rst
+++ b/docs/mmctl_permissions_add.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_permissions_remove.rst
+++ b/docs/mmctl_permissions_remove.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_permissions_show.rst
+++ b/docs/mmctl_permissions_show.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_plugin.rst
+++ b/docs/mmctl_plugin.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_plugin_add.rst
+++ b/docs/mmctl_plugin_add.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_plugin_delete.rst
+++ b/docs/mmctl_plugin_delete.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_plugin_disable.rst
+++ b/docs/mmctl_plugin_disable.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_plugin_enable.rst
+++ b/docs/mmctl_plugin_enable.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_plugin_list.rst
+++ b/docs/mmctl_plugin_list.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_post.rst
+++ b/docs/mmctl_post.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_post_create.rst
+++ b/docs/mmctl_post_create.rst
@@ -36,8 +36,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_post_list.rst
+++ b/docs/mmctl_post_list.rst
@@ -38,8 +38,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team.rst
+++ b/docs/mmctl_team.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_archive.rst
+++ b/docs/mmctl_team_archive.rst
@@ -36,8 +36,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_create.rst
+++ b/docs/mmctl_team_create.rst
@@ -39,8 +39,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_delete.rst
+++ b/docs/mmctl_team_delete.rst
@@ -36,8 +36,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_list.rst
+++ b/docs/mmctl_team_list.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_rename.rst
+++ b/docs/mmctl_team_rename.rst
@@ -38,8 +38,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_search.rst
+++ b/docs/mmctl_team_search.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_users.rst
+++ b/docs/mmctl_team_users.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_users_add.rst
+++ b/docs/mmctl_team_users_add.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_team_users_remove.rst
+++ b/docs/mmctl_team_users_remove.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -23,8 +23,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_activate.rst
+++ b/docs/mmctl_user_activate.rst
@@ -35,8 +35,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_create.rst
+++ b/docs/mmctl_user_create.rst
@@ -42,8 +42,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_deactivate.rst
+++ b/docs/mmctl_user_deactivate.rst
@@ -35,8 +35,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_email.rst
+++ b/docs/mmctl_user_email.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_invite.rst
+++ b/docs/mmctl_user_invite.rst
@@ -37,8 +37,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_list.rst
+++ b/docs/mmctl_user_list.rst
@@ -37,8 +37,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_reset_password.rst
+++ b/docs/mmctl_user_reset_password.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_resetmfa.rst
+++ b/docs/mmctl_user_resetmfa.rst
@@ -35,8 +35,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_user_search.rst
+++ b/docs/mmctl_user_search.rst
@@ -34,8 +34,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_version.rst
+++ b/docs/mmctl_version.rst
@@ -27,8 +27,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/mmctl_websocket.rst
+++ b/docs/mmctl_websocket.rst
@@ -27,8 +27,9 @@ Options inherited from parent commands
 
 ::
 
-      --format string   the format of the command output [plain, json] (default "plain")
-      --strict          will only run commands if the mmctl version matches the server one
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --strict                       will only run commands if the mmctl version matches the server one
 
 SEE ALSO
 ~~~~~~~~

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,10 +6,10 @@ github.com/cpuguy83/go-md2man/md2man
 github.com/davecgh/go-spew/spew
 # github.com/dyatlov/go-opengraph v0.0.0-20180429202543-816b6608b3c8
 github.com/dyatlov/go-opengraph/opengraph
-# github.com/go-asn1-ber/asn1-ber v1.3.2-0.20191121212151-29be175fc3a3
-github.com/go-asn1-ber/asn1-ber
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
+# github.com/go-asn1-ber/asn1-ber v1.3.2-0.20191121212151-29be175fc3a3
+github.com/go-asn1-ber/asn1-ber
 # github.com/golang/mock v1.3.1
 github.com/golang/mock/gomock
 # github.com/google/uuid v1.1.1
@@ -110,8 +110,6 @@ golang.org/x/text/internal/tag
 golang.org/x/text/language
 golang.org/x/text/transform
 golang.org/x/text/unicode/norm
-# gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d
-gopkg.in/asn1-ber.v1
 # gopkg.in/natefinch/lumberjack.v2 v2.0.0
 gopkg.in/natefinch/lumberjack.v2
 # gopkg.in/yaml.v2 v2.2.3


### PR DESCRIPTION
#### Summary
The client will now reject to communicate with a server that has a SHA1 certificate in the chain (in every position but the root one). It will allow as well to use a `--insecure-sha1-intermediate` flag and a `MMCTL_INSECURE_SHA1_INTERMEDIATE` environment variable to bypass this check and connect to insecure servers.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22166
