### PR TITLE
[MM-22168] commands/user: do not call API if there is a ".." in query

### DIFF
--- a/commands/channel_test.go
+++ b/commands/channel_test.go
@@ -634,6 +634,15 @@ func (s *MmctlUnitTestSuite) TestArchiveChannelCmdF() {
 		actual := fmt.Sprintf("Unable to find channel '%s'", args[0])
 		s.Require().Equal(expected, actual)
 	})
+
+	s.Run("Avoid path traversal with a valid team name", func() {
+		printer.Clean()
+		arg := "team:/../hello/channel-test"
+
+		err := archiveChannelsCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Nil(err)
+		s.Require().Equal("Unable to find channel 'team:/../hello/channel-test'", printer.GetErrorLines()[0])
+	})
 }
 
 func (s *MmctlUnitTestSuite) TestListChannelsCmd() {

--- a/commands/channel_test.go
+++ b/commands/channel_test.go
@@ -1190,6 +1190,15 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		s.Require().Equal(printer.GetLines()[4], publicChannel2)
 		s.Require().Equal(printer.GetLines()[5], archivedChannel1)
 	})
+
+	s.Run("Avoid path traversal", func() {
+		printer.Clean()
+		arg := "\"test/../hello?\"channel-test"
+
+		err := listChannelsCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Nil(err)
+		s.Require().Equal("Unable to find team '\"test/../hello?\"channel-test'", printer.GetErrorLines()[0])
+	})
 }
 
 func (s *MmctlUnitTestSuite) TestAddChannelUsersCmdF() {

--- a/commands/channelargs.go
+++ b/commands/channelargs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mmctl/client"
 )
 
-const ChannelArgSeparator = ":"
+const channelArgSeparator = ":"
 
 func getChannelsFromChannelArgs(c client.Client, channelArgs []string) []*model.Channel {
 	channels := make([]*model.Channel, 0, len(channelArgs))
@@ -23,7 +23,7 @@ func getChannelsFromChannelArgs(c client.Client, channelArgs []string) []*model.
 }
 
 func parseChannelArg(channelArg string) (string, string) {
-	result := strings.SplitN(channelArg, ChannelArgSeparator, 2)
+	result := strings.SplitN(channelArg, channelArgSeparator, 2)
 	if len(result) == 1 {
 		return "", channelArg
 	}
@@ -33,6 +33,10 @@ func parseChannelArg(channelArg string) (string, string) {
 func getChannelFromChannelArg(c client.Client, channelArg string) *model.Channel {
 	teamArg, channelPart := parseChannelArg(channelArg)
 	if teamArg == "" && channelPart == "" {
+		return nil
+	}
+
+	if checkDots(channelPart) || checkSlash(channelPart) {
 		return nil
 	}
 

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -961,4 +961,13 @@ func (s *MmctlUnitTestSuite) TestCommandShowCmd() {
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
+
+	s.Run("Avoid path traversal", func() {
+		printer.Clean()
+		arg := "\"test/../hello?\"move"
+
+		err := showCommandCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().NotNil(err)
+		s.EqualError(err, "unable to find command '\"test/../hello?\"move'")
+	})
 }

--- a/commands/commandargs.go
+++ b/commands/commandargs.go
@@ -12,6 +12,10 @@ import (
 // getCommandFromCommandArg retrieves a Command by command id. Future versions
 // may allow lookup by team:trigger
 func getCommandFromCommandArg(c client.Client, commandArg string) *model.Command {
+	if checkTraversal(commandArg) {
+		return nil
+	}
+
 	cmd, _ := c.GetCommandById(commandArg)
 	return cmd
 }

--- a/commands/commandargs.go
+++ b/commands/commandargs.go
@@ -12,7 +12,7 @@ import (
 // getCommandFromCommandArg retrieves a Command by command id. Future versions
 // may allow lookup by team:trigger
 func getCommandFromCommandArg(c client.Client, commandArg string) *model.Command {
-	if checkTraversal(commandArg) {
+	if checkSlash(commandArg) {
 		return nil
 	}
 

--- a/commands/teamargs.go
+++ b/commands/teamargs.go
@@ -19,7 +19,7 @@ func getTeamsFromTeamArgs(c client.Client, teamArgs []string) []*model.Team {
 }
 
 func getTeamFromTeamArg(c client.Client, teamArg string) *model.Team {
-	if checkDots(teamArg) || checkTraversal(teamArg) {
+	if checkDots(teamArg) || checkSlash(teamArg) {
 		return nil
 	}
 

--- a/commands/teamargs.go
+++ b/commands/teamargs.go
@@ -19,6 +19,10 @@ func getTeamsFromTeamArgs(c client.Client, teamArgs []string) []*model.Team {
 }
 
 func getTeamFromTeamArg(c client.Client, teamArg string) *model.Team {
+	if checkTraversal(teamArg) {
+		return nil
+	}
+
 	var team *model.Team
 	team, _ = c.GetTeam(teamArg, "")
 

--- a/commands/teamargs.go
+++ b/commands/teamargs.go
@@ -19,7 +19,7 @@ func getTeamsFromTeamArgs(c client.Client, teamArgs []string) []*model.Team {
 }
 
 func getTeamFromTeamArg(c client.Client, teamArg string) *model.Team {
-	if checkTraversal(teamArg) {
+	if checkDots(teamArg) || checkTraversal(teamArg) {
 		return nil
 	}
 

--- a/commands/user_test.go
+++ b/commands/user_test.go
@@ -408,11 +408,11 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 
 	s.Run("Avoid path traversal", func() {
 		printer.Clean()
-		arg := "\"test/../hello?\"@mattermost.com"
+		arg := "test/../hello?@mattermost.com"
 
 		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
 		s.Require().Nil(err)
-		s.Require().Equal("Unable to find user '\"test/../hello?\"@mattermost.com'", printer.GetErrorLines()[0])
+		s.Require().Equal("Unable to find user 'test/../hello?@mattermost.com'", printer.GetErrorLines()[0])
 	})
 }
 

--- a/commands/user_test.go
+++ b/commands/user_test.go
@@ -405,6 +405,15 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Equal("Unable to find user 'example@example.com'", printer.GetErrorLines()[0])
 	})
+
+	s.Run("Avoid path traversal", func() {
+		printer.Clean()
+		arg := "\"test/../hello?\"@mattermost.com"
+
+		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().Nil(err)
+		s.Require().Equal("Unable to find user '\"test/../hello?\"@mattermost.com'", printer.GetErrorLines()[0])
+	})
 }
 
 func (s *MmctlUnitTestSuite) TestSendPasswordResetEmailCmd() {

--- a/commands/userargs.go
+++ b/commands/userargs.go
@@ -27,7 +27,7 @@ func getUserFromUserArg(c client.Client, userArg string) *model.User {
 		user, _ = c.GetUserByEmail(userArg, "")
 	}
 
-	if !checkTraversal(userArg) {
+	if !checkSlash(userArg) {
 		if user == nil {
 			user, _ = c.GetUserByUsername(userArg, "")
 		}
@@ -40,12 +40,13 @@ func getUserFromUserArg(c client.Client, userArg string) *model.User {
 	return user
 }
 
-// returns true if any of traversal patterns recognized
-func checkTraversal(arg string) bool {
+// returns true if slash is found in the arg
+func checkSlash(arg string) bool {
 	unescapedArg, _ := url.PathUnescape(arg)
 	return strings.Contains(unescapedArg, "/")
 }
 
+// returns true if double dot is found in the arg
 func checkDots(arg string) bool {
 	unescapedArg, _ := url.PathUnescape(arg)
 	return strings.Contains(unescapedArg, "..")

--- a/commands/userargs.go
+++ b/commands/userargs.go
@@ -22,19 +22,19 @@ func getUsersFromUserArgs(c client.Client, userArgs []string) []*model.User {
 }
 
 func getUserFromUserArg(c client.Client, userArg string) *model.User {
-	if checkTraversal(userArg) {
-		return nil
-	}
-
 	var user *model.User
-	user, _ = c.GetUserByEmail(userArg, "")
-
-	if user == nil {
-		user, _ = c.GetUserByUsername(userArg, "")
+	if !checkDots(userArg) {
+		user, _ = c.GetUserByEmail(userArg, "")
 	}
 
-	if user == nil {
-		user, _ = c.GetUser(userArg, "")
+	if !checkTraversal(userArg) {
+		if user == nil {
+			user, _ = c.GetUserByUsername(userArg, "")
+		}
+
+		if user == nil {
+			user, _ = c.GetUser(userArg, "")
+		}
 	}
 
 	return user
@@ -44,4 +44,9 @@ func getUserFromUserArg(c client.Client, userArg string) *model.User {
 func checkTraversal(arg string) bool {
 	unescapedArg, _ := url.PathUnescape(arg)
 	return strings.Contains(unescapedArg, "/")
+}
+
+func checkDots(arg string) bool {
+	unescapedArg, _ := url.PathUnescape(arg)
+	return strings.Contains(unescapedArg, "..")
 }

--- a/commands/userargs.go
+++ b/commands/userargs.go
@@ -21,7 +21,7 @@ func getUsersFromUserArgs(c client.Client, userArgs []string) []*model.User {
 }
 
 func getUserFromUserArg(c client.Client, userArg string) *model.User {
-	if strings.Contains(userArg, "..") {
+	if checkTraversal(userArg) {
 		return nil
 	}
 
@@ -37,4 +37,17 @@ func getUserFromUserArg(c client.Client, userArg string) *model.User {
 	}
 
 	return user
+}
+
+// returns true if any of traversal patterns recognized
+func checkTraversal(arg string) bool {
+	if strings.Contains(arg, "..") {
+		return true
+	}
+
+	if strings.Contains(arg, "%2e%2e") {
+		return true
+	}
+
+	return false
 }

--- a/commands/userargs.go
+++ b/commands/userargs.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -42,9 +43,5 @@ func getUserFromUserArg(c client.Client, userArg string) *model.User {
 // returns true if any of traversal patterns recognized
 func checkTraversal(arg string) bool {
 	unescapedArg, _ := url.PathUnescape(arg)
-	if strings.Contains(unescapedArg, "..") {
-		return true
-	}
-
-	return false
+	return strings.Contains(unescapedArg, "/")
 }

--- a/commands/userargs.go
+++ b/commands/userargs.go
@@ -41,11 +41,8 @@ func getUserFromUserArg(c client.Client, userArg string) *model.User {
 
 // returns true if any of traversal patterns recognized
 func checkTraversal(arg string) bool {
-	if strings.Contains(arg, "..") {
-		return true
-	}
-
-	if strings.Contains(arg, "%2e%2e") {
+	unescapedArg, _ := url.PathUnescape(arg)
+	if strings.Contains(unescapedArg, "..") {
 		return true
 	}
 

--- a/commands/userargs.go
+++ b/commands/userargs.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"strings"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 
 	"github.com/mattermost/mmctl/client"
@@ -19,6 +21,10 @@ func getUsersFromUserArgs(c client.Client, userArgs []string) []*model.User {
 }
 
 func getUserFromUserArg(c client.Client, userArg string) *model.User {
+	if strings.Contains(userArg, "..") {
+		return nil
+	}
+
 	var user *model.User
 	user, _ = c.GetUserByEmail(userArg, "")
 


### PR DESCRIPTION
#### Summary

This PR adds a check when querying a user/channel/team with `..`, `/` patterns. Most of the  email providers  does not accept the sequence(`..`) in local-part of an email address. Also more info at [wikipedia article](https://en.wikipedia.org/wiki/Email_address#Local-part)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22168

