### PR TITLE
Issue 128: fix panic in 'command list' without args

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -201,7 +201,7 @@ func listCommandCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 		commands, response := c.ListCommands(team.Id, true)
 		if response.Error != nil {
-			printer.PrintError("Unable to list commands for '" + args[i] + "'")
+			printer.PrintError("Unable to list commands for '" + team.Name + "'")
 			continue
 		}
 		for _, command := range commands {

--- a/commands/command.go
+++ b/commands/command.go
@@ -201,7 +201,7 @@ func listCommandCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 		commands, response := c.ListCommands(team.Id, true)
 		if response.Error != nil {
-			printer.PrintError("Unable to list commands for '" + team.Name + "'")
+			printer.PrintError("Unable to list commands for '" + team.Id + "'")
 			continue
 		}
 		for _, command := range commands {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes a panic when using `command list` without any arguments.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mmctl/issues/128
