### PR TITLE
[MM-23036] Remove the name flag from the team rename command

### DIFF
--- a/commands/team.go
+++ b/commands/team.go
@@ -69,12 +69,12 @@ var SearchTeamCmd = &cobra.Command{
 
 // RenameTeamCmd is the command to rename team along with its display name
 var RenameTeamCmd = &cobra.Command{
-	Use:   "rename [team]",
-	Short: "Rename team",
-	Long:  "Rename an existing team",
+	Use:     "rename [team]",
+	Short:   "Rename team",
+	Long:    "Rename an existing team",
 	Example: "  team rename old-team --display_name 'New Display Name'",
-	Args: cobra.ExactArgs(1),
-	RunE: withClient(renameTeamCmdF),
+	Args:    cobra.ExactArgs(1),
+	RunE:    withClient(renameTeamCmdF),
 }
 
 func init() {

--- a/commands/team.go
+++ b/commands/team.go
@@ -72,9 +72,7 @@ var RenameTeamCmd = &cobra.Command{
 	Use:   "rename [team]",
 	Short: "Rename team",
 	Long:  "Rename an existing team",
-	Example: `  team rename old-team --name 'new-team' --display_name 'New Display Name'
-  team rename old-team --name 'new-team'
-  team rename old-team --display_name 'New Display Name'`,
+	Example: "  team rename old-team --display_name 'New Display Name'",
 	Args: cobra.ExactArgs(1),
 	RunE: withClient(renameTeamCmdF),
 }
@@ -89,8 +87,8 @@ func init() {
 	ArchiveTeamsCmd.Flags().Bool("confirm", false, "Confirm you really want to archive the team and a DB backup has been performed.")
 
 	// Add flag declaration for RenameTeam
-	RenameTeamCmd.Flags().String("name", "", "Old Team Name")
 	RenameTeamCmd.Flags().String("display_name", "", "Team Display Name")
+	_ = RenameTeamCmd.MarkFlagRequired("display_name")
 
 	TeamCmd.AddCommand(
 		TeamCreateCmd,
@@ -239,24 +237,13 @@ func removeDuplicatesAndSortTeams(teams []*model.Team) []*model.Team {
 func renameTeamCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	oldTeamName := args[0]
 	newDisplayName, _ := cmd.Flags().GetString("display_name")
-	newTeamName, _ := cmd.Flags().GetString("name")
-
-	// If both flags are absent, abort!
-	if newTeamName == "" && newDisplayName == "" {
-		return errors.New("require at least one flag to rename team, either 'name' or 'display_name'")
-	}
 
 	team := getTeamFromTeamArg(c, oldTeamName)
 	if team == nil {
 		return errors.New("Unable to find team '" + oldTeamName + "', to see the all teams try 'team list' command")
 	}
 
-	if newTeamName != "" {
-		team.Name = newTeamName
-	}
-	if newDisplayName != "" {
-		team.DisplayName = newDisplayName
-	}
+	team.DisplayName = newDisplayName
 
 	// Using UpdateTeam API Method to rename team
 	_, response := c.UpdateTeam(team)

--- a/commands/team_test.go
+++ b/commands/team_test.go
@@ -114,44 +114,12 @@ func (s *MmctlUnitTestSuite) TestCreateTeamCmd() {
 }
 
 func (s *MmctlUnitTestSuite) TestRenameTeamCmdF() {
-	s.Run("Team rename should fail with missing name and display name flag", func() {
-		printer.Clean()
-
-		cmd := &cobra.Command{}
-
-		args := []string{""}
-		args[0] = "existingName"
-
-		err := renameTeamCmdF(s.client, cmd, args)
-		s.Require().EqualError(err, "require at least one flag to rename team, either 'name' or 'display_name'")
-	})
-
-	s.Run("Team rename should fail with invalid flags", func() {
-		printer.Clean()
-
-		cmd := &cobra.Command{}
-
-		args := []string{""}
-		args[0] = "existingName"
-
-		// Setting incorrect name flag
-		cmd.Flags().String("-name", "newName", "Team Name Name")
-		err := renameTeamCmdF(s.client, cmd, args)
-
-		s.Require().EqualError(err, "require at least one flag to rename team, either 'name' or 'display_name'")
-
-		// Setting flag as display-name instead of display_name
-		cmd.Flags().String("display-name", "newDisplayName", "Team Display Name")
-		s.Require().EqualError(err, "require at least one flag to rename team, either 'name' or 'display_name'")
-	})
-
 	s.Run("Team rename should fail when unknown existing team name is entered", func() {
 		printer.Clean()
 		cmd := &cobra.Command{}
 
 		args := []string{""}
 		args[0] = "existingName"
-		cmd.Flags().String("name", "newName", "Team Name")
 		cmd.Flags().String("display_name", "newDisplayName", "Team Display Name")
 
 		// Mocking : GetTeam searches with team id, if team not found proceeds with team name search
@@ -179,22 +147,18 @@ func (s *MmctlUnitTestSuite) TestRenameTeamCmdF() {
 		existingName := "existingTeamName"
 		existingDisplayName := "existingDisplayName"
 		newDisplayName := "NewDisplayName"
-		newName := "newTeamName"
 		args := []string{""}
 
 		args[0] = existingName
-		cmd.Flags().String("name", newName, "Display Name")
 		cmd.Flags().String("display_name", newDisplayName, "Display Name")
 
 		// Only reduced model.Team struct for testing per say
 		// as we are interested in updating only name and display name
 		foundTeam := &model.Team{
 			DisplayName: existingDisplayName,
-			Name:        existingName,
 		}
 		renamedTeam := &model.Team{
 			DisplayName: newDisplayName,
-			Name:        newName,
 		}
 
 		s.client.
@@ -231,56 +195,6 @@ func (s *MmctlUnitTestSuite) TestRenameTeamCmdF() {
 		existingName := "existingTeamName"
 		existingDisplayName := "existingDisplayName"
 		newDisplayName := "NewDisplayName"
-		newName := "newTeamName"
-		args := []string{""}
-
-		args[0] = existingName
-		cmd.Flags().String("name", newName, "Display Name")
-		cmd.Flags().String("display_name", newDisplayName, "Display Name")
-
-		foundTeam := &model.Team{
-			DisplayName: existingDisplayName,
-			Name:        existingName,
-		}
-		updatedTeam := &model.Team{
-			DisplayName: newDisplayName,
-			Name:        newName,
-		}
-
-		s.client.
-			EXPECT().
-			GetTeam(args[0], "").
-			Return(nil, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetTeamByName(args[0], "").
-			Return(foundTeam, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			UpdateTeam(updatedTeam).
-			Return(updatedTeam, &model.Response{Error: nil}).
-			Times(1)
-
-		err := renameTeamCmdF(s.client, cmd, args)
-
-		s.Require().Nil(err)
-		s.Require().Len(printer.GetErrorLines(), 0)
-		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0], "'"+existingName+"' team renamed")
-	})
-
-	s.Run("Team rename should work as expected even if only display name is supplied", func() {
-		printer.Clean()
-
-		cmd := &cobra.Command{}
-
-		existingName := "existingTeamName"
-		existingDisplayName := "existingDisplayName"
-		newDisplayName := "NewDisplayName"
 		args := []string{""}
 
 		args[0] = existingName
@@ -288,61 +202,9 @@ func (s *MmctlUnitTestSuite) TestRenameTeamCmdF() {
 
 		foundTeam := &model.Team{
 			DisplayName: existingDisplayName,
-			Name:        existingName,
 		}
-
 		updatedTeam := &model.Team{
 			DisplayName: newDisplayName,
-			Name:        existingName,
-		}
-
-		s.client.
-			EXPECT().
-			GetTeam(args[0], "").
-			Return(nil, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetTeamByName(args[0], "").
-			Return(foundTeam, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			UpdateTeam(updatedTeam).
-			Return(updatedTeam, &model.Response{Error: nil}).
-			Times(1)
-
-		err := renameTeamCmdF(s.client, cmd, args)
-
-		s.Require().Nil(err)
-		s.Require().Len(printer.GetErrorLines(), 0)
-		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(printer.GetLines()[0], "'"+existingName+"' team renamed")
-	})
-
-	s.Run("Team rename should work as expected even if only name is supplied", func() {
-		printer.Clean()
-
-		cmd := &cobra.Command{}
-
-		existingName := "existingTeamName"
-		existingDisplayName := "existingDisplayName"
-		newName := "newTeamName"
-		args := []string{""}
-
-		args[0] = existingName
-		cmd.Flags().String("name", newName, "Display Name")
-
-		foundTeam := &model.Team{
-			DisplayName: existingDisplayName,
-			Name:        existingName,
-		}
-
-		updatedTeam := &model.Team{
-			DisplayName: existingDisplayName,
-			Name:        newName,
 		}
 
 		s.client.

--- a/docs/mmctl_team_rename.rst
+++ b/docs/mmctl_team_rename.rst
@@ -20,8 +20,6 @@ Examples
 
 ::
 
-    team rename old-team --name 'new-team' --display_name 'New Display Name'
-    team rename old-team --name 'new-team'
     team rename old-team --display_name 'New Display Name'
 
 Options
@@ -31,7 +29,6 @@ Options
 
       --display_name string   Team Display Name
   -h, --help                  help for rename
-      --name string           Old Team Name
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary

Removing the `--name` flag as the API doesn't support to modify the team's name.

#### Ticket

https://mattermost.atlassian.net/browse/MM-23036