### PR TITLE
Fix linter error from latest gosimple

### DIFF
--- a/commands/post.go
+++ b/commands/post.go
@@ -119,9 +119,9 @@ func printPost(c client.Client, post *model.Post, usernames map[string]string, s
 	}
 
 	if showIds {
-		fmt.Println(fmt.Sprintf("\u001b[31m%s\u001b[0m \u001b[34;1m[%s]\u001b[0m %s", post.Id, username, post.Message))
+		fmt.Printf("\u001b[31m%s\u001b[0m \u001b[34;1m[%s]\u001b[0m %s\n", post.Id, username, post.Message)
 	} else {
-		fmt.Println(fmt.Sprintf("\u001b[34;1m[%s]\u001b[0m %s", username, post.Message))
+		fmt.Printf("\u001b[34;1m[%s]\u001b[0m %s\n", username, post.Message)
 	}
 }
 


### PR DESCRIPTION
#### Summary 

When upgrading to go 1.14.x a new version of gosimple is fetched (probably by your IDE).  The latest gosimple looks for Sprintf within Println which occured once in mmctl.

```
Running golangci-lint
golangci-lint run ./...
commands/post.go:122:3: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
                fmt.Println(fmt.Sprintf("\u001b[31m%s\u001b[0m \u001b[34;1m[%s]\u001b[0m %s", post.Id, username, post.Message))
                ^
commands/post.go:124:3: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
                fmt.Println(fmt.Sprintf("\u001b[34;1m[%s]\u001b[0m %s", username, post.Message))

```
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
None

