### PR TITLE
Fix bot list loop logic and related tests

### DIFF
--- a/commands/bot.go
+++ b/commands/bot.go
@@ -168,10 +168,6 @@ func botListCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			return errors.Wrap(res.Error, "Failed to fetch bots")
 		}
 
-		if len(bots) < 200 {
-			break
-		}
-
 		userIds := []string{}
 		for _, bot := range bots {
 			userIds = append(userIds, bot.OwnerId)
@@ -191,6 +187,10 @@ func botListCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			owner := usersByID[bot.OwnerId]
 			tplExtraText := fmt.Sprintf("(Owner by %s, {{if ne .DeleteAt 0}}Disabled{{else}}Enabled{{end}}{{if ne %d 0}}, Orphaned{{end}})", owner.Username, owner.DeleteAt)
 			printer.PrintT(tpl+tplExtraText, bot)
+		}
+
+		if len(bots) < 200 {
+			break
 		}
 
 		page++

--- a/commands/bot.go
+++ b/commands/bot.go
@@ -116,7 +116,7 @@ func botCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 
 func botUpdateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	if !cmd.Flags().Changed("username") && !cmd.Flags().Changed("display-name") && !cmd.Flags().Changed("description") {
-		return errors.New("At least one of --username, --display-name or --description must be set")
+		return errors.New("at least one of --username, --display-name or --description must be set")
 	}
 
 	user := getUserFromUserArg(c, args[0])

--- a/commands/bot_test.go
+++ b/commands/bot_test.go
@@ -98,6 +98,9 @@ func (s *MmctlUnitTestSuite) TestBotUpdateCmd() {
 		printer.Clean()
 
 		botArg := "a-bot"
+		cmd := &cobra.Command{}
+		cmd.Flags().String("username", "bot-username", "")
+		cmd.Flags().Lookup("username").Changed = true
 
 		s.client.
 			EXPECT().
@@ -117,7 +120,7 @@ func (s *MmctlUnitTestSuite) TestBotUpdateCmd() {
 			Return(nil, &model.Response{Error: &model.AppError{Id: "Mock Error"}}).
 			Times(1)
 
-		err := botUpdateCmdF(s.client, &cobra.Command{}, []string{botArg})
+		err := botUpdateCmdF(s.client, cmd, []string{botArg})
 		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Contains(err.Error(), "unable to find user 'a-bot'")
@@ -178,12 +181,6 @@ func (s *MmctlUnitTestSuite) TestBotListCmd() {
 
 		s.client.
 			EXPECT().
-			GetBotsIncludeDeleted(1, 200, "").
-			Return([]*model.Bot{}, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUsersByIds([]string{mockBot.OwnerId}).
 			Return([]*model.User{&mockUser}, &model.Response{Error: nil}).
 			Times(1)
@@ -201,30 +198,16 @@ func (s *MmctlUnitTestSuite) TestBotListCmd() {
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool("orphaned", false, "")
 		cmd.Flags().Bool("all", true, "")
-		mockBot := model.Bot{UserId: model.NewId(), Username: botArg, DisplayName: "some-name", Description: "some-text", OwnerId: model.NewId()}
-		mockUser := model.User{Id: mockBot.OwnerId}
 
 		s.client.
 			EXPECT().
 			GetBotsIncludeDeleted(0, 200, "").
-			Return([]*model.Bot{&mockBot}, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetBotsIncludeDeleted(1, 200, "").
 			Return(nil, &model.Response{Error: &model.AppError{Message: "Mock Error"}}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUsersByIds([]string{mockBot.OwnerId}).
-			Return([]*model.User{&mockUser}, &model.Response{Error: nil}).
 			Times(1)
 
 		err := botListCmdF(s.client, cmd, []string{botArg})
 		s.Require().NotNil(err)
-		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Contains(err.Error(), "Failed to fetch bots")
 	})
 
@@ -246,12 +229,6 @@ func (s *MmctlUnitTestSuite) TestBotListCmd() {
 
 		s.client.
 			EXPECT().
-			GetBotsOrphaned(1, 200, "").
-			Return([]*model.Bot{}, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUsersByIds([]string{mockBot.OwnerId}).
 			Return([]*model.User{&mockUser}, &model.Response{Error: nil}).
 			Times(1)
@@ -269,30 +246,16 @@ func (s *MmctlUnitTestSuite) TestBotListCmd() {
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool("orphaned", true, "")
 		cmd.Flags().Bool("all", false, "")
-		mockBot := model.Bot{UserId: model.NewId(), Username: botArg, DisplayName: "some-name", Description: "some-text", OwnerId: model.NewId()}
-		mockUser := model.User{Id: mockBot.OwnerId}
 
 		s.client.
 			EXPECT().
 			GetBotsOrphaned(0, 200, "").
-			Return([]*model.Bot{&mockBot}, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetBotsOrphaned(1, 200, "").
 			Return(nil, &model.Response{Error: &model.AppError{Message: "Mock Error"}}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUsersByIds([]string{mockBot.OwnerId}).
-			Return([]*model.User{&mockUser}, &model.Response{Error: nil}).
 			Times(1)
 
 		err := botListCmdF(s.client, cmd, []string{botArg})
 		s.Require().NotNil(err)
-		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Contains(err.Error(), "Failed to fetch bots")
 	})
 
@@ -314,12 +277,6 @@ func (s *MmctlUnitTestSuite) TestBotListCmd() {
 
 		s.client.
 			EXPECT().
-			GetBots(1, 200, "").
-			Return([]*model.Bot{}, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
 			GetUsersByIds([]string{mockBot.OwnerId}).
 			Return([]*model.User{&mockUser}, &model.Response{Error: nil}).
 			Times(1)
@@ -337,30 +294,16 @@ func (s *MmctlUnitTestSuite) TestBotListCmd() {
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool("orphaned", false, "")
 		cmd.Flags().Bool("all", false, "")
-		mockBot := model.Bot{UserId: model.NewId(), Username: botArg, DisplayName: "some-name", Description: "some-text", OwnerId: model.NewId()}
-		mockUser := model.User{Id: mockBot.OwnerId}
 
 		s.client.
 			EXPECT().
 			GetBots(0, 200, "").
-			Return([]*model.Bot{&mockBot}, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetBots(1, 200, "").
 			Return(nil, &model.Response{Error: &model.AppError{Message: "Mock Error"}}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUsersByIds([]string{mockBot.OwnerId}).
-			Return([]*model.User{&mockUser}, &model.Response{Error: nil}).
 			Times(1)
 
 		err := botListCmdF(s.client, cmd, []string{botArg})
 		s.Require().NotNil(err)
-		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Contains(err.Error(), "Failed to fetch bots")
 	})
 

--- a/docs/mmctl_bot_disable.rst
+++ b/docs/mmctl_bot_disable.rst
@@ -9,7 +9,7 @@ Synopsis
 ~~~~~~~~
 
 
-Disable a disabled bot
+Disable an enabled bot
 
 ::
 
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-    bot enable testbot
+    bot disable testbot
 
 Options
 ~~~~~~~


### PR DESCRIPTION
#### Summary

Fixes the bot list loop logic that was breaking before processing the resulting users, and the related tests that were duplicating calls to the list endpoint and having other minor issues.

Related to https://github.com/mattermost/mmctl/pull/141