### PR TITLE
Bump mmctl version to 5.23.0

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	BuildHash = "dev mode"
-	Version   = "5.22.0"
+	Version   = "5.23.0"
 )
 
 var VersionCmd = &cobra.Command{


### PR DESCRIPTION
#### Summary
Bump `mmctl` version to v5.23 at the release branch