### PR TITLE
Migrates the make_private command to use the update channel privacy endpoint

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -19,7 +19,6 @@ type Client interface {
 	GetPublicChannelsForTeam(teamId string, page int, perPage int, etag string) ([]*model.Channel, *model.Response)
 	GetDeletedChannelsForTeam(teamId string, page int, perPage int, etag string) ([]*model.Channel, *model.Response)
 	RestoreChannel(channelId string) (*model.Channel, *model.Response)
-	ConvertChannelToPrivate(channelId string) (*model.Channel, *model.Response)
 	PatchChannel(channelId string, patch *model.ChannelPatch) (*model.Channel, *model.Response)
 	GetChannelByName(channelName, teamId string, etag string) (*model.Channel, *model.Response)
 	GetChannelByNameIncludeDeleted(channelName, teamId string, etag string) (*model.Channel, *model.Response)

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -358,7 +358,7 @@ func makeChannelPrivateCmdF(c client.Client, cmd *cobra.Command, args []string) 
 		return errors.New("you can only change the type of public channels")
 	}
 
-	if _, response := c.ConvertChannelToPrivate(channel.Id); response.Error != nil {
+	if _, response := c.UpdateChannelPrivacy(channel.Id, model.CHANNEL_PRIVATE); response.Error != nil {
 		return response.Error
 	}
 

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -98,21 +98,6 @@ func (mr *MockClientMockRecorder) ClearServerBusy() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearServerBusy", reflect.TypeOf((*MockClient)(nil).ClearServerBusy))
 }
 
-// ConvertChannelToPrivate mocks base method
-func (m *MockClient) ConvertChannelToPrivate(arg0 string) (*model.Channel, *model.Response) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConvertChannelToPrivate", arg0)
-	ret0, _ := ret[0].(*model.Channel)
-	ret1, _ := ret[1].(*model.Response)
-	return ret0, ret1
-}
-
-// ConvertChannelToPrivate indicates an expected call of ConvertChannelToPrivate
-func (mr *MockClientMockRecorder) ConvertChannelToPrivate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertChannelToPrivate", reflect.TypeOf((*MockClient)(nil).ConvertChannelToPrivate), arg0)
-}
-
 // CreateBot mocks base method
 func (m *MockClient) CreateBot(arg0 *model.Bot) (*model.Bot, *model.Response) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
#### Summary
To allow for deprecation of the [convert channel to private endpoint](https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1convert/post) this PR migrates its usage to the [update channel privacy](https://api.mattermost.com/#tag/channels/paths/~1channels~1{channel_id}~1privacy/put) one

Jira ticket: https://mattermost.atlassian.net/browse/MM-25048