### PR TITLE
[MM-25067] commands/config: use patch method instead of update for set command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -71,6 +71,7 @@ type Client interface {
 	DeleteCommand(commandId string) (bool, *model.Response)
 	GetConfig() (*model.Config, *model.Response)
 	UpdateConfig(*model.Config) (*model.Config, *model.Response)
+	PatchConfig(*model.Config) (*model.Config, *model.Response)
 	SyncLdap() (bool, *model.Response)
 	GetUsers(page, perPage int, etag string) ([]*model.User, *model.Response)
 	GetUsersByIds(userIds []string) ([]*model.User, *model.Response)

--- a/commands/config.go
+++ b/commands/config.go
@@ -284,7 +284,7 @@ func configSetCmdF(c client.Client, _ *cobra.Command, args []string) error {
 	if err := setConfigValue(path, config, args[1:]); err != nil {
 		return err
 	}
-	newConfig, res := c.UpdateConfig(config)
+	newConfig, res := c.PatchConfig(config)
 	if res.Error != nil {
 		return res.Error
 	}

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -252,7 +252,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			UpdateConfig(inputConfig).
+			PatchConfig(inputConfig).
 			Return(inputConfig, &model.Response{Error: nil}).
 			Times(1)
 
@@ -280,7 +280,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			UpdateConfig(inputConfig).
+			PatchConfig(inputConfig).
 			Return(inputConfig, &model.Response{Error: nil}).
 			Times(1)
 
@@ -308,7 +308,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			UpdateConfig(inputConfig).
+			PatchConfig(inputConfig).
 			Return(inputConfig, &model.Response{Error: nil}).
 			Times(1)
 
@@ -335,7 +335,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			UpdateConfig(inputConfig).
+			PatchConfig(inputConfig).
 			Return(inputConfig, &model.Response{Error: nil}).
 			Times(1)
 
@@ -403,7 +403,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 			Times(1)
 		s.client.
 			EXPECT().
-			UpdateConfig(inputConfig).
+			PatchConfig(inputConfig).
 			Return(inputConfig, &model.Response{StatusCode: 500, Error: &model.AppError{}}).
 			Times(1)
 
@@ -444,7 +444,7 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 
 		s.client.
 			EXPECT().
-			UpdateConfig(inputConfig).
+			PatchConfig(inputConfig).
 			Return(inputConfig, &model.Response{Error: nil}).
 			Times(3)
 

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -834,6 +834,21 @@ func (mr *MockClientMockRecorder) PatchChannel(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchChannel", reflect.TypeOf((*MockClient)(nil).PatchChannel), arg0, arg1)
 }
 
+// PatchConfig mocks base method
+func (m *MockClient) PatchConfig(arg0 *model.Config) (*model.Config, *model.Response) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchConfig", arg0)
+	ret0, _ := ret[0].(*model.Config)
+	ret1, _ := ret[1].(*model.Response)
+	return ret0, ret1
+}
+
+// PatchConfig indicates an expected call of PatchConfig
+func (mr *MockClientMockRecorder) PatchConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchConfig", reflect.TypeOf((*MockClient)(nil).PatchConfig), arg0)
+}
+
 // PatchRole mocks base method
 func (m *MockClient) PatchRole(arg0 string, arg1 *model.RolePatch) (*model.Role, *model.Response) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
#### Summary
Current implementation uses `/config` endpoint to update server config, but this method shouldn't be used to update single values since it is filling remaining config values with default ones. We should use patch endpoint instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25067

