### PR TITLE
Checks that socket file has the right permissions and ownership

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -165,12 +165,12 @@ func checkValidSocket(socketPath string) error {
 	// check file mode and permissions
 	fi, err := os.Stat(socketPath)
 	if err != nil && os.IsNotExist(err) {
-		return fmt.Errorf("socket file %q doesn't exists. Please check the server configuration for local mode", socketPath)
+		return fmt.Errorf("socket file %q doesn't exists, please check the server configuration for local mode", socketPath)
 	} else if err != nil {
 		return err
 	}
 	if fi.Mode() != expectedSocketMode {
-		return fmt.Errorf("invalid file mode for file %q. It must be a socket with 0600 permissions", socketPath)
+		return fmt.Errorf("invalid file mode for file %q, it must be a socket with 0600 permissions", socketPath)
 	}
 
 	// check matching user

--- a/commands/init.go
+++ b/commands/init.go
@@ -164,7 +164,9 @@ func InitWebSocketClient() (*model.WebSocketClient, error) {
 func checkValidSocket(socketPath string) error {
 	// check file mode and permissions
 	fi, err := os.Stat(socketPath)
-	if err != nil {
+	if err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("socket file %q doesn't exists. Please check the server configuration for local mode", socketPath)
+	} else if err != nil {
 		return err
 	}
 	if fi.Mode() != expectedSocketMode {

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -5,6 +5,9 @@ package commands
 
 import (
 	"crypto/x509"
+	"io/ioutil"
+	"net"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -135,4 +138,41 @@ func TestVerifyCertificates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckValidSocket(t *testing.T) {
+	t.Run("should return error if the file is not a socket", func(t *testing.T) {
+		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		require.Nil(t, err)
+		defer os.Remove(f.Name())
+		require.Nil(t, os.Chmod(f.Name(), 0600))
+
+		require.Error(t, checkValidSocket(f.Name()))
+	})
+
+	t.Run("should return error if the file has not the right permissions", func(t *testing.T) {
+		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		require.Nil(t, err)
+		require.Nil(t, os.Remove(f.Name()))
+
+		s, err := net.Listen("unix", f.Name())
+		require.Nil(t, err)
+		defer s.Close()
+		require.Nil(t, os.Chmod(f.Name(), 0777))
+
+		require.Error(t, checkValidSocket(f.Name()))
+	})
+
+	t.Run("should return nil if the file is a socket and has the right permissions", func(t *testing.T) {
+		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		require.Nil(t, err)
+		require.Nil(t, os.Remove(f.Name()))
+
+		s, err := net.Listen("unix", f.Name())
+		require.Nil(t, err)
+		defer s.Close()
+		require.Nil(t, os.Chmod(f.Name(), 0600))
+
+		require.Nil(t, checkValidSocket(f.Name()))
+	})
 }


### PR DESCRIPTION
#### Summary
This PR checks that when using local mode, the socket file mode and permissions are the expected ones and checks as well that the user that owns the socket is the owner of the process running `mmctl` too.

This is a follow up to the discussion at https://github.com/mattermost/mattermost-server/pull/14333