### PR TITLE
Disable syscall usage for windows build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ifeq ($(ADVANCED_VET), TRUE)
 		exit 1; \
 	fi;
 	@echo Running mattermost-govet
-	$(GO) vet -vettool=$(GOPATH)/bin/mattermost-govet -structuredLogging -inconsistentReceiverName -tFatal -equalLenAsserts ./...
+	$(GO) vet -vettool=$(GOPATH)/bin/mattermost-govet -license -structuredLogging -inconsistentReceiverName -tFatal -equalLenAsserts ./...
 endif
 	@echo Govet success
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ifeq ($(ADVANCED_VET), TRUE)
 		exit 1; \
 	fi;
 	@echo Running mattermost-govet
-	$(GO) vet -vettool=$(GOPATH)/bin/mattermost-govet -license -structuredLogging -inconsistentReceiverName -tFatal -equalLenAsserts ./...
+	$(GO) vet -vettool=$(GOPATH)/bin/mattermost-govet -structuredLogging -inconsistentReceiverName -tFatal -equalLenAsserts ./...
 endif
 	@echo Govet success
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -10,10 +10,8 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/user"
 	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 
@@ -159,34 +157,6 @@ func InitWebSocketClient() (*model.WebSocketClient, error) {
 		return nil, errors.Wrap(appErr, "unable to create the websockets connection")
 	}
 	return client, nil
-}
-
-func checkValidSocket(socketPath string) error {
-	// check file mode and permissions
-	fi, err := os.Stat(socketPath)
-	if err != nil && os.IsNotExist(err) {
-		return fmt.Errorf("socket file %q doesn't exists, please check the server configuration for local mode", socketPath)
-	} else if err != nil {
-		return err
-	}
-	if fi.Mode() != expectedSocketMode {
-		return fmt.Errorf("invalid file mode for file %q, it must be a socket with 0600 permissions", socketPath)
-	}
-
-	// check matching user
-	cUser, err := user.Current()
-	if err != nil {
-		return err
-	}
-	s, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return fmt.Errorf("cannot get owner of the file %q", socketPath)
-	}
-	if fmt.Sprint(s.Uid) != cUser.Uid {
-		return fmt.Errorf("owner of the file %q must be the same user running mmctl", socketPath)
-	}
-
-	return nil
 }
 
 func InitUnixClient(socketPath string) (*model.Client4, error) {

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -5,9 +5,6 @@ package commands
 
 import (
 	"crypto/x509"
-	"io/ioutil"
-	"net"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -138,41 +135,4 @@ func TestVerifyCertificates(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestCheckValidSocket(t *testing.T) {
-	t.Run("should return error if the file is not a socket", func(t *testing.T) {
-		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
-		require.Nil(t, err)
-		defer os.Remove(f.Name())
-		require.Nil(t, os.Chmod(f.Name(), 0600))
-
-		require.Error(t, checkValidSocket(f.Name()))
-	})
-
-	t.Run("should return error if the file has not the right permissions", func(t *testing.T) {
-		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
-		require.Nil(t, err)
-		require.Nil(t, os.Remove(f.Name()))
-
-		s, err := net.Listen("unix", f.Name())
-		require.Nil(t, err)
-		defer s.Close()
-		require.Nil(t, os.Chmod(f.Name(), 0777))
-
-		require.Error(t, checkValidSocket(f.Name()))
-	})
-
-	t.Run("should return nil if the file is a socket and has the right permissions", func(t *testing.T) {
-		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
-		require.Nil(t, err)
-		require.Nil(t, os.Remove(f.Name()))
-
-		s, err := net.Listen("unix", f.Name())
-		require.Nil(t, err)
-		defer s.Close()
-		require.Nil(t, os.Chmod(f.Name(), 0600))
-
-		require.Nil(t, checkValidSocket(f.Name()))
-	})
 }

--- a/commands/utils_unix.go
+++ b/commands/utils_unix.go
@@ -1,0 +1,41 @@
+// +build linux darwin
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"syscall"
+)
+
+func checkValidSocket(socketPath string) error {
+	// check file mode and permissions
+	fi, err := os.Stat(socketPath)
+	if err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("socket file %q doesn't exists, please check the server configuration for local mode", socketPath)
+	} else if err != nil {
+		return err
+	}
+	if fi.Mode() != expectedSocketMode {
+		return fmt.Errorf("invalid file mode for file %q, it must be a socket with 0600 permissions", socketPath)
+	}
+
+	// check matching user
+	cUser, err := user.Current()
+	if err != nil {
+		return err
+	}
+	s, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("cannot get owner of the file %q", socketPath)
+	}
+	if fmt.Sprint(s.Uid) != cUser.Uid {
+		return fmt.Errorf("owner of the file %q must be the same user running mmctl", socketPath)
+	}
+
+	return nil
+}

--- a/commands/utils_unix.go
+++ b/commands/utils_unix.go
@@ -1,7 +1,7 @@
-// +build linux darwin
-
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+// +build linux darwin
 
 package commands
 

--- a/commands/utils_unix_test.go
+++ b/commands/utils_unix_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckValidSocket(t *testing.T) {
+	t.Run("should return error if the file is not a socket", func(t *testing.T) {
+		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		require.Nil(t, err)
+		defer os.Remove(f.Name())
+		require.Nil(t, os.Chmod(f.Name(), 0600))
+
+		require.Error(t, checkValidSocket(f.Name()))
+	})
+
+	t.Run("should return error if the file has not the right permissions", func(t *testing.T) {
+		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		require.Nil(t, err)
+		require.Nil(t, os.Remove(f.Name()))
+
+		s, err := net.Listen("unix", f.Name())
+		require.Nil(t, err)
+		defer s.Close()
+		require.Nil(t, os.Chmod(f.Name(), 0777))
+
+		require.Error(t, checkValidSocket(f.Name()))
+	})
+
+	t.Run("should return nil if the file is a socket and has the right permissions", func(t *testing.T) {
+		f, err := ioutil.TempFile(os.TempDir(), "mmctl_socket_")
+		require.Nil(t, err)
+		require.Nil(t, os.Remove(f.Name()))
+
+		s, err := net.Listen("unix", f.Name())
+		require.Nil(t, err)
+		defer s.Close()
+		require.Nil(t, os.Chmod(f.Name(), 0600))
+
+		require.Nil(t, checkValidSocket(f.Name()))
+	})
+}

--- a/commands/utils_windows.go
+++ b/commands/utils_windows.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+)
+
+func checkValidSocket(socketPath string) error {
+	// check file mode and permissions
+	fi, err := os.Stat(socketPath)
+	if err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("socket file %q doesn't exists, please check the server configuration for local mode", socketPath)
+	} else if err != nil {
+		return err
+	}
+	if fi.Mode() != expectedSocketMode {
+		return fmt.Errorf("invalid file mode for file %q, it must be a socket with 0600 permissions", socketPath)
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### Summary
This PR creates two versions of the `checkValidSocket` func, as windows builds were failing due to `syscall.Stat_t` not being available for the OS.