### PR TITLE
[MM-21501] commands/channel: add unarchive alias to restore channel cmd

### DIFF
--- a/commands/channel.go
+++ b/commands/channel.go
@@ -88,11 +88,12 @@ Channel can be specified by [team]:[channel]. ie. myteam:mychannel or by channel
 }
 
 var RestoreChannelsCmd = &cobra.Command{
-	Use:   "restore [channels]",
-	Short: "Restore some channels",
+	Use:     "restore [channels]",
+	Aliases: []string{"unarchive"},
+	Short:   "Restore some channels, alias: unarchive",
 	Long: `Restore a previously deleted channel
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
-	Example: "  channel restore myteam:mychannel",
+	Example: "  channel restore|unarchive myteam:mychannel",
 	RunE:    withClient(restoreChannelsCmdF),
 }
 

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -88,13 +88,22 @@ Channel can be specified by [team]:[channel]. ie. myteam:mychannel or by channel
 }
 
 var RestoreChannelsCmd = &cobra.Command{
-	Use:     "restore [channels]",
-	Aliases: []string{"unarchive"},
-	Short:   "Restore some channels, alias: unarchive",
+	Use:        "restore [channels]",
+	Deprecated: "please use \"unarchive\" instead",
+	Short:      "Restore some channels",
 	Long: `Restore a previously deleted channel
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
-	Example: "  channel restore|unarchive myteam:mychannel",
-	RunE:    withClient(restoreChannelsCmdF),
+	Example: "  channel restore myteam:mychannel",
+	RunE:    withClient(unarchiveChannelsCmdF),
+}
+
+var UnarchiveChannelCmd = &cobra.Command{
+	Use:   "unarchive [channels]",
+	Short: "Unarchive some channels",
+	Long: `Unarchive a previously archived channel
+Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
+	Example: "  channel unarchive myteam:mychannel",
+	RunE:    withClient(unarchiveChannelsCmdF),
 }
 
 var MakeChannelPrivateCmd = &cobra.Command{
@@ -142,6 +151,7 @@ func init() {
 		ArchiveChannelsCmd,
 		ListChannelsCmd,
 		RestoreChannelsCmd,
+		UnarchiveChannelCmd,
 		MakeChannelPrivateCmd,
 		ModifyChannelCmd,
 		ChannelRenameCmd,
@@ -326,7 +336,7 @@ func listChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error 
 	return nil
 }
 
-func restoreChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+func unarchiveChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("enter at least one channel")
 	}
@@ -338,7 +348,7 @@ func restoreChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) err
 			continue
 		}
 		if _, response := c.RestoreChannel(channel.Id); response.Error != nil {
-			printer.PrintError("Unable to restore channel '" + args[i] + "'. Error: " + response.Error.Error())
+			printer.PrintError("Unable to unarchive channel '" + args[i] + "'. Error: " + response.Error.Error())
 		}
 	}
 

--- a/commands/channel_test.go
+++ b/commands/channel_test.go
@@ -1383,11 +1383,11 @@ func (s *MmctlUnitTestSuite) TestAddChannelUsersCmdF() {
 	})
 }
 
-func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
-	s.Run("Restore channel without args returns an error", func() {
+func (s *MmctlUnitTestSuite) TestUnarchiveChannelCmdF() {
+	s.Run("Unarchive channel without args returns an error", func() {
 		printer.Clean()
 
-		err := restoreChannelsCmdF(s.client, &cobra.Command{}, []string{})
+		err := unarchiveChannelsCmdF(s.client, &cobra.Command{}, []string{})
 		mockErr := errors.New("enter at least one channel")
 
 		expected := mockErr.Error()
@@ -1397,7 +1397,7 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.Run("Restore an existing channel on an existing team", func() {
+	s.Run("Unarchive an existing channel on an existing team", func() {
 		printer.Clean()
 
 		mockTeam := model.Team{Id: teamID}
@@ -1424,13 +1424,13 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			Return(&mockChannel, &model.Response{Error: nil}).
 			Times(1)
 
-		err := restoreChannelsCmdF(s.client, cmd, []string{args})
+		err := unarchiveChannelsCmdF(s.client, cmd, []string{args})
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.Run("Restore an existing channel specified by channel id", func() {
+	s.Run("Unarchive an existing channel specified by channel id", func() {
 		printer.Clean()
 
 		mockChannel := model.Channel{Id: channelID, Name: channelName}
@@ -1450,13 +1450,13 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			Return(&mockChannel, &model.Response{Error: nil}).
 			Times(1)
 
-		err := restoreChannelsCmdF(s.client, cmd, args)
+		err := unarchiveChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.Run("Restore several channels specified by channel id", func() {
+	s.Run("Unarchive several channels specified by channel id", func() {
 		printer.Clean()
 
 		channelArg1 := "some-channel"
@@ -1494,13 +1494,13 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			Return(&mockChannel2, &model.Response{Error: nil}).
 			Times(1)
 
-		err := restoreChannelsCmdF(s.client, cmd, args)
+		err := unarchiveChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.Run("Fail to restore a channel on a non-existent team", func() {
+	s.Run("Fail to unarchive a channel on a non-existent team", func() {
 		printer.Clean()
 
 		teamArg := "some-non-existent-team-id"
@@ -1520,7 +1520,7 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
-		err := restoreChannelsCmdF(s.client, cmd, args)
+		err := unarchiveChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
@@ -1530,7 +1530,7 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 		s.Require().Equal(expected, actual)
 	})
 
-	s.Run("Fail to restore a non-existing channel on an existent team", func() {
+	s.Run("Fail to unarchive a non-existing channel on an existent team", func() {
 		printer.Clean()
 
 		teamArg := "some-non-existing-team-id"
@@ -1558,7 +1558,7 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
-		err := restoreChannelsCmdF(s.client, cmd, args)
+		err := unarchiveChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
@@ -1568,7 +1568,7 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 		s.Require().Equal(expected, actual)
 	})
 
-	s.Run("Fail to restore a non-existing channel", func() {
+	s.Run("Fail to unarchive a non-existing channel", func() {
 		printer.Clean()
 
 		channelArg := "some-non-existing-channel"
@@ -1581,7 +1581,7 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
-		err := restoreChannelsCmdF(s.client, cmd, args)
+		err := unarchiveChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
@@ -1591,7 +1591,7 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 		s.Require().Equal(expected, actual)
 	})
 
-	s.Run("Fail to restore an existing channel when client throws error", func() {
+	s.Run("Fail to unarchive an existing channel when client throws error", func() {
 		printer.Clean()
 
 		mockChannel := model.Channel{Id: channelID, Name: channelName}
@@ -1612,23 +1612,23 @@ func (s *MmctlUnitTestSuite) TestRestoreChannelCmdF() {
 			Return(nil, &model.Response{Error: mockErr}).
 			Times(1)
 
-		err := restoreChannelsCmdF(s.client, cmd, args)
+		err := unarchiveChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 
 		actual := printer.GetErrorLines()[0]
-		expected := fmt.Sprintf("Unable to restore channel '%s'. Error: %s", channelName, mockErr.Error())
+		expected := fmt.Sprintf("Unable to unarchive channel '%s'. Error: %s", channelName, mockErr.Error())
 		s.Require().Equal(expected, actual)
 	})
 
-	s.Run("Fail to restore when team and channel not provided", func() {
+	s.Run("Fail to unarchive when team and channel not provided", func() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
 		args := []string{":"}
 
-		err := restoreChannelsCmdF(s.client, cmd, args)
+		err := unarchiveChannelsCmdF(s.client, cmd, args)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)

--- a/docs/mmctl_channel.rst
+++ b/docs/mmctl_channel.rst
@@ -40,6 +40,6 @@ SEE ALSO
 * `mmctl channel modify <mmctl_channel_modify.rst>`_ 	 - Modify a channel's public/private type
 * `mmctl channel remove <mmctl_channel_remove.rst>`_ 	 - Remove users from channel
 * `mmctl channel rename <mmctl_channel_rename.rst>`_ 	 - Rename channel
-* `mmctl channel restore <mmctl_channel_restore.rst>`_ 	 - Restore some channels
+* `mmctl channel restore <mmctl_channel_restore.rst>`_ 	 - Restore some channels, alias: unarchive
 * `mmctl channel search <mmctl_channel_search.rst>`_ 	 - Search a channel
 

--- a/docs/mmctl_channel.rst
+++ b/docs/mmctl_channel.rst
@@ -40,6 +40,6 @@ SEE ALSO
 * `mmctl channel modify <mmctl_channel_modify.rst>`_ 	 - Modify a channel's public/private type
 * `mmctl channel remove <mmctl_channel_remove.rst>`_ 	 - Remove users from channel
 * `mmctl channel rename <mmctl_channel_rename.rst>`_ 	 - Rename channel
-* `mmctl channel restore <mmctl_channel_restore.rst>`_ 	 - Restore some channels, alias: unarchive
 * `mmctl channel search <mmctl_channel_search.rst>`_ 	 - Search a channel
+* `mmctl channel unarchive <mmctl_channel_unarchive.rst>`_ 	 - Unarchive some channels
 

--- a/docs/mmctl_channel_restore.rst
+++ b/docs/mmctl_channel_restore.rst
@@ -3,7 +3,7 @@
 mmctl channel restore
 ---------------------
 
-Restore some channels
+Restore some channels, alias: unarchive
 
 Synopsis
 ~~~~~~~~
@@ -21,7 +21,7 @@ Examples
 
 ::
 
-    channel restore myteam:mychannel
+    channel restore|unarchive myteam:mychannel
 
 Options
 ~~~~~~~

--- a/docs/mmctl_channel_unarchive.rst
+++ b/docs/mmctl_channel_unarchive.rst
@@ -1,34 +1,34 @@
-.. _mmctl_channel_restore:
+.. _mmctl_channel_unarchive:
 
-mmctl channel restore
----------------------
+mmctl channel unarchive
+-----------------------
 
-Restore some channels, alias: unarchive
+Unarchive some channels
 
 Synopsis
 ~~~~~~~~
 
 
-Restore a previously deleted channel
+Unarchive a previously archived channel
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.
 
 ::
 
-  mmctl channel restore [channels] [flags]
+  mmctl channel unarchive [channels] [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    channel restore|unarchive myteam:mychannel
+    channel unarchive myteam:mychannel
 
 Options
 ~~~~~~~
 
 ::
 
-  -h, --help   help for restore
+  -h, --help   help for unarchive
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
add unarchive alias to restore channel cmd.

<img width="401" alt="image" src="https://user-images.githubusercontent.com/2153367/84139587-d2480280-aa58-11ea-8760-a9e923b756b4.png">

Help will print:
```bash
Restore a previously deleted channel
Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.

Usage:
  mmctl channel restore [channels] [flags]

Aliases:
  restore, unarchive

Examples:
  channel restore|unarchive myteam:mychannel
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21501

