### PR TITLE
[MM-19717] commands/config: add reload config command

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -76,6 +76,7 @@ type Client interface {
 	GetConfig() (*model.Config, *model.Response)
 	UpdateConfig(*model.Config) (*model.Config, *model.Response)
 	PatchConfig(*model.Config) (*model.Config, *model.Response)
+	ReloadConfig() (bool, *model.Response)
 	SyncLdap() (bool, *model.Response)
 	GetUsers(page, perPage int, etag string) ([]*model.User, *model.Response)
 	GetUsersByIds(userIds []string) ([]*model.User, *model.Response)

--- a/commands/config.go
+++ b/commands/config.go
@@ -74,6 +74,15 @@ var ConfigShowCmd = &cobra.Command{
 	RunE:    withClient(configShowCmdF),
 }
 
+var ConfigReloadCmd = &cobra.Command{
+	Use:     "reload",
+	Short:   "Reload the server configuration",
+	Long:    "Reload the server configuration in case you want to new settings to be applied.",
+	Example: "config reload",
+	Args:    cobra.NoArgs,
+	RunE:    withClient(configReloadCmdF),
+}
+
 func init() {
 	ConfigResetCmd.Flags().Bool("confirm", false, "Confirm you really want to reset all configuration settings to its default value")
 	ConfigCmd.AddCommand(
@@ -82,6 +91,7 @@ func init() {
 		ConfigEditCmd,
 		ConfigResetCmd,
 		ConfigShowCmd,
+		ConfigReloadCmd,
 	)
 	RootCmd.AddCommand(ConfigCmd)
 }
@@ -406,4 +416,13 @@ func configShowCmdF(c client.Client, _ *cobra.Command, _ []string) error {
 
 func parseConfigPath(configPath string) []string {
 	return strings.Split(configPath, ".")
+}
+
+func configReloadCmdF(c client.Client, _ *cobra.Command, _ []string) error {
+	_, response := c.ReloadConfig()
+	if response.Error != nil {
+		return response.Error
+	}
+
+	return nil
 }

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -598,3 +598,32 @@ func (s *MmctlUnitTestSuite) TestConfigShowCmd() {
 		s.EqualError(err, configError.Error())
 	})
 }
+
+func (s *MmctlUnitTestSuite) TestConfigReloadCmd() {
+	s.Run("Should reload config", func() {
+		printer.Clean()
+
+		s.client.
+			EXPECT().
+			ReloadConfig().
+			Return(true, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configReloadCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().Nil(err)
+		s.Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("Should fail on error when reload config", func() {
+		printer.Clean()
+
+		s.client.
+			EXPECT().
+			ReloadConfig().
+			Return(false, &model.Response{Error: &model.AppError{Message: "some-error"}}).
+			Times(1)
+
+		err := configReloadCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().NotNil(err)
+	})
+}

--- a/docs/mmctl_config.rst
+++ b/docs/mmctl_config.rst
@@ -34,6 +34,7 @@ SEE ALSO
 * `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
 * `mmctl config edit <mmctl_config_edit.rst>`_ 	 - Edit the config
 * `mmctl config get <mmctl_config_get.rst>`_ 	 - Get config setting
+* `mmctl config reload <mmctl_config_reload.rst>`_ 	 - Reload the server configuration
 * `mmctl config reset <mmctl_config_reset.rst>`_ 	 - Reset config setting
 * `mmctl config set <mmctl_config_set.rst>`_ 	 - Set config setting
 * `mmctl config show <mmctl_config_show.rst>`_ 	 - Writes the server configuration to STDOUT

--- a/docs/mmctl_config_reload.rst
+++ b/docs/mmctl_config_reload.rst
@@ -1,0 +1,46 @@
+.. _mmctl_config_reload:
+
+mmctl config reload
+-------------------
+
+Reload the server configuration
+
+Synopsis
+~~~~~~~~
+
+
+Reload the server configuration in case you want to new settings to be applied.
+
+::
+
+  mmctl config reload [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+  config reload
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for reload
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --local                        allows communicating with the server through a unix socket
+      --strict                       will only run commands if the mmctl version matches the server one
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl config <mmctl_config.rst>`_ 	 - Configuration
+

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -909,6 +909,21 @@ func (mr *MockClientMockRecorder) PermanentDeleteTeam(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PermanentDeleteTeam", reflect.TypeOf((*MockClient)(nil).PermanentDeleteTeam), arg0)
 }
 
+// ReloadConfig mocks base method
+func (m *MockClient) ReloadConfig() (bool, *model.Response) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReloadConfig")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(*model.Response)
+	return ret0, ret1
+}
+
+// ReloadConfig indicates an expected call of ReloadConfig
+func (mr *MockClientMockRecorder) ReloadConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReloadConfig", reflect.TypeOf((*MockClient)(nil).ReloadConfig))
+}
+
 // RemoveLicenseFile mocks base method
 func (m *MockClient) RemoveLicenseFile() (bool, *model.Response) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
#### Summary
This PR adds config reload command to `mmctl`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19717

