### PR TITLE
MM-27285 fix panic in bot list

### DIFF
--- a/commands/bot.go
+++ b/commands/bot.go
@@ -183,9 +183,18 @@ func botListCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			usersByID[user.Id] = user
 		}
 
+		var ownerName string
+		var ownerDeleteAt int64
 		for _, bot := range bots {
-			owner := usersByID[bot.OwnerId]
-			tplExtraText := fmt.Sprintf("(Owner by %s, {{if ne .DeleteAt 0}}Disabled{{else}}Enabled{{end}}{{if ne %d 0}}, Orphaned{{end}})", owner.Username, owner.DeleteAt)
+			if owner, ok := usersByID[bot.OwnerId]; ok {
+				ownerName = owner.Username
+				ownerDeleteAt = owner.DeleteAt
+			} else {
+				// not all bots have a userId in their ownerId field.
+				ownerName = bot.OwnerId
+				ownerDeleteAt = 0
+			}
+			tplExtraText := fmt.Sprintf("(Owned by %s, {{if ne .DeleteAt 0}}Disabled{{else}}Enabled{{end}}{{if ne %d 0}}, Orphaned{{end}})", ownerName, ownerDeleteAt)
 			printer.PrintT(tpl+tplExtraText, bot)
 		}
 


### PR DESCRIPTION
#### Summary

This PR fixes a panic in the `bot list` command.  Panic was caused by the code assuming all bots have a valid userId in their ownerId field.  Some bots simply have a descriptive name there.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27285