### PR TITLE
[MM-27650] Add disable local precheck and disable commands that were not implemented for phase 2

### DIFF
--- a/commands/bot.go
+++ b/commands/bot.go
@@ -25,6 +25,7 @@ var CreateBotCmd = &cobra.Command{
 	Short:   "Create bot",
 	Long:    "Create bot.",
 	Example: `  bot create testbot`,
+	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(botCreateCmdF),
 	Args:    cobra.ExactArgs(1),
 }

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -89,6 +89,7 @@ Channel can be specified by [team]:[channel]. ie. myteam:mychannel or by channel
 	Example: `  channel modify myteam:mychannel --private
   channel modify channelId --public`,
 	Args: cobra.ExactArgs(1),
+	PreRun:  disableLocalPrecheck,
 	RunE: withClient(modifyChannelCmdF),
 }
 
@@ -99,6 +100,7 @@ var RestoreChannelsCmd = &cobra.Command{
 	Long: `Restore a previously deleted channel
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: "  channel restore myteam:mychannel",
+	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(unarchiveChannelsCmdF),
 }
 
@@ -108,6 +110,7 @@ var UnarchiveChannelCmd = &cobra.Command{
 	Long: `Unarchive a previously archived channel
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: "  channel unarchive myteam:mychannel",
+	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(unarchiveChannelsCmdF),
 }
 
@@ -117,6 +120,7 @@ var MakeChannelPrivateCmd = &cobra.Command{
 	Long: `Set the type of a channel from public to private.
 Channel can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: "  channel make_private myteam:mychannel",
+	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(makeChannelPrivateCmdF),
 }
 
@@ -139,6 +143,7 @@ Validates that all users in the channel belong to the target team. Incoming/Outg
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: "  channel move newteam oldteam:mychannel",
 	Args:    cobra.MinimumNArgs(2),
+	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(moveChannelCmdF),
 }
 

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -88,9 +88,9 @@ var ModifyChannelCmd = &cobra.Command{
 Channel can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: `  channel modify myteam:mychannel --private
   channel modify channelId --public`,
-	Args: cobra.ExactArgs(1),
-	PreRun:  disableLocalPrecheck,
-	RunE: withClient(modifyChannelCmdF),
+	Args:   cobra.ExactArgs(1),
+	PreRun: disableLocalPrecheck,
+	RunE:   withClient(modifyChannelCmdF),
 }
 
 var RestoreChannelsCmd = &cobra.Command{

--- a/commands/init.go
+++ b/commands/init.go
@@ -73,6 +73,14 @@ func localOnlyPrecheck(cmd *cobra.Command, args []string) {
 	}
 }
 
+func disableLocalPrecheck(cmd *cobra.Command, args []string) {
+	local := viper.GetBool("local")
+	if local {
+		fmt.Fprintln(os.Stderr, "This command cannot be run in local mode")
+		os.Exit(1)
+	}
+}
+
 func isValidChain(chain []*x509.Certificate) bool {
 	// check all certs but the root one
 	certs := chain[:len(chain)-1]

--- a/commands/team.go
+++ b/commands/team.go
@@ -58,6 +58,7 @@ var RestoreTeamsCmd = &cobra.Command{
 	Long:    "Restores archived teams.",
 	Example: "  team restore myteam",
 	Args:    cobra.MinimumNArgs(1),
+	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(restoreTeamsCmdF),
 }
 
@@ -94,6 +95,7 @@ var ModifyTeamsCmd = &cobra.Command{
 	Long:    "Modify teams' privacy setting to public or private",
 	Example: "  team modify myteam --private",
 	Args:    cobra.MinimumNArgs(1),
+	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(modifyTeamsCmdF),
 }
 


### PR DESCRIPTION
#### Summary

Adds a mechanism to forbid some commands from running in local mode and applies it to the commands that were not migrated in time for the local mode phase 2

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-27650