### PR TITLE
[MM-29167] Add e2e tests for searchTeamCmdF

### DIFF
--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"github.com/mattermost/mattermost-server/v5/model"
+
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mmctl/client"
@@ -49,5 +51,40 @@ func (s *MmctlE2ETestSuite) TestRenameTeamCmdF() {
 		s.Require().Error(err)
 		s.Len(printer.GetLines(), 0)
 		s.Equal("Cannot rename team '"+s.th.BasicTeam.Name+"', error : : You do not have the appropriate permissions., ", err.Error())
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestSearchTeamCmdF() {
+	s.SetupTestHelper().InitBasic()
+
+	s.RunForSystemAdminAndLocal("Search for existing team", func(c client.Client) {
+		printer.Clean()
+
+		err := searchTeamCmdF(c, &cobra.Command{}, []string{s.th.BasicTeam.Name})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 1)
+		team := printer.GetLines()[0].(*model.Team)
+		s.Equal(s.th.BasicTeam.Name, team.Name)
+	})
+
+	s.Run("Search for existing team with Client", func() {
+		printer.Clean()
+
+		err := searchTeamCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicTeam.Name})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 1)
+		s.Equal("Unable to find team '"+s.th.BasicTeam.Name+"'", printer.GetErrorLines()[0])
+	})
+
+	s.RunForAllClients("Search of nonexistent team", func(c client.Client) {
+		printer.Clean()
+
+		teamnameArg := "nonexistentteam"
+		err := searchTeamCmdF(c, &cobra.Command{}, []string{teamnameArg})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 0)
+		s.Len(printer.GetErrorLines(), 1)
+		s.Equal("Unable to find team '"+teamnameArg+"'", printer.GetErrorLines()[0])
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

Adds e2e tests for the `searchTeamCmdF` function.

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link


Fixes https://github.com/mattermost/mattermost-server/issues/15673

JIRA: https://mattermost.atlassian.net/browse/MM-29167