### PR TITLE
[GH-15677] Add e2e tests to the 'restoreTeamsCmdF' mmctl command

### DIFF
--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -626,7 +626,7 @@ func (s *MmctlUnitTestSuite) TestTeamGroupListCmd() {
 		groupID2 := "group2"
 		mockError := &model.AppError{Message: "Get groups by team error"}
 
-		//grp1 := model.GroupWithSchemeAdmin{}
+		// grp1 := model.GroupWithSchemeAdmin{}
 
 		group1 := model.GroupWithSchemeAdmin{Group: model.Group{Id: groupID, DisplayName: "DisplayName1"}}
 		group2 := model.GroupWithSchemeAdmin{Group: model.Group{Id: groupID2, DisplayName: "DisplayName2"}}

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mmctl/client"
@@ -57,8 +58,6 @@ func (s *MmctlE2ETestSuite) TestRestoreTeamsCmd() {
 
 	s.RunForAllClients("Restore team", func(c client.Client) {
 		printer.Clean()
-		printer.SetFormat(printer.FormatPlain)
-		defer printer.SetFormat(printer.FormatJSON)
 
 		team := s.th.CreateTeam()
 		appErr := s.th.App.SoftDeleteTeam(team.Id)
@@ -67,10 +66,8 @@ func (s *MmctlE2ETestSuite) TestRestoreTeamsCmd() {
 		err := restoreTeamsCmdF(c, &cobra.Command{}, []string{team.Name})
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetErrorLines(), 0)
-
-		message := "Restored team '" + team.Name + "'"
 		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(message, printer.GetLines()[0])
+		s.Require().Zero(printer.GetLines()[0].(*model.Team).DeleteAt)
 	})
 
 	s.RunForAllClients("Restore non-existent team", func(c client.Client) {
@@ -88,8 +85,6 @@ func (s *MmctlE2ETestSuite) TestRestoreTeamsCmd() {
 
 	s.Run("Restore team without permissions", func() {
 		printer.Clean()
-		printer.SetFormat(printer.FormatPlain)
-		defer printer.SetFormat(printer.FormatJSON)
 
 		team := s.th.CreateTeamWithClient(s.th.SystemAdminClient)
 		appErr := s.th.App.SoftDeleteTeam(team.Id)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request adds end to end tests to the `restoreTeamsCmdF` command, in the `commands/team.go` file.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/mattermost-server/issues/15677
