### PR TITLE
MM-29170: Add e2e tests to modify teams command

### DIFF
--- a/commands/team.go
+++ b/commands/team.go
@@ -343,10 +343,10 @@ func modifyTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			printer.PrintError("Unable to find team '" + args[i] + "'")
 			continue
 		}
-		if _, response := c.UpdateTeamPrivacy(team.Id, privacy); response.Error != nil {
+		if updatedTeam, response := c.UpdateTeamPrivacy(team.Id, privacy); response.Error != nil {
 			printer.PrintError("Unable to modify team '" + team.Name + "' error: " + response.Error.Error())
 		} else {
-			printer.PrintT("Modified team '{{.Name}}'", team)
+			printer.PrintT("Modified team '{{.Name}}'", updatedTeam)
 		}
 	}
 

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -66,15 +66,11 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		err := modifyTeamsCmdF(c, cmd, []string{teamID})
 		s.Require().NoError(err)
 
-		t, appErr := s.th.App.GetTeam(teamID)
-		s.Require().Nil(appErr)
-		s.Require().Equal(model.TEAM_INVITE, t.Type)
-		s.Require().Equal(s.th.BasicTeam, printer.GetLines()[0])
-
+		s.Require().Equal(model.TEAM_INVITE, printer.GetLines()[0].(*model.Team).Type)
 		// teardown
-		appErr = s.th.App.UpdateTeamPrivacy(teamID, model.TEAM_OPEN, true)
+		appErr := s.th.App.UpdateTeamPrivacy(teamID, model.TEAM_OPEN, true)
 		s.Require().Nil(appErr)
-		t, err = s.th.App.GetTeam(teamID)
+		t, err := s.th.App.GetTeam(teamID)
 		s.Require().Nil(err)
 		s.th.BasicTeam = t
 	})

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -4,10 +4,12 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mattermost-server/v5/model"
-	
+
 	"github.com/mattermost/mmctl/client"
 	"github.com/mattermost/mmctl/printer"
 )
@@ -67,10 +69,14 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		t, appErr := s.th.App.GetTeam(teamID)
 		s.Require().Nil(appErr)
 		s.Require().Equal(model.TEAM_INVITE, t.Type)
+		s.Require().Equal(s.th.BasicTeam, printer.GetLines()[0])
 
 		// teardown
 		appErr = s.th.App.UpdateTeamPrivacy(teamID, model.TEAM_OPEN, true)
 		s.Require().Nil(appErr)
+		t, err = s.th.App.GetTeam(teamID)
+		s.Require().Nil(appErr)
+		s.th.BasicTeam = t
 	})
 	s.Run("user that creates the team can't set team's privacy due to permissions", func() {
 		printer.Clean()
@@ -80,7 +86,10 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		s.th.LoginBasic()
 		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
 		s.Require().NoError(err)
-
+		s.Require().Equal(
+			fmt.Sprintf("Unable to modify team '%s' error: : You do not have the appropriate permissions., ", s.th.BasicTeam.Name),
+			printer.GetErrorLines()[0],
+		)
 		t, appErr := s.th.App.GetTeam(teamID)
 		s.Require().Nil(appErr)
 		s.Require().Equal(model.TEAM_OPEN, t.Type)
@@ -93,6 +102,10 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		s.th.LoginBasic2()
 		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
 		s.Require().NoError(err)
+		s.Require().Equal(
+			fmt.Sprintf("Unable to modify team '%s' error: : You do not have the appropriate permissions., ", s.th.BasicTeam.Name),
+			printer.GetErrorLines()[0],
+		)
 		t, appErr := s.th.App.GetTeam(teamID)
 		s.Require().Nil(appErr)
 		s.Require().Equal(model.TEAM_OPEN, t.Type)

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	
 	"github.com/mattermost/mmctl/client"
 	"github.com/mattermost/mmctl/printer"
 )

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -83,7 +83,6 @@ func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
 		teamID := s.th.BasicTeam.Id
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool("private", true, "")
-		s.th.LoginBasic()
 		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
 		s.Require().NoError(err)
 		s.Require().Equal(

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mmctl/client"
 	"github.com/mattermost/mmctl/printer"
 )
@@ -49,5 +50,50 @@ func (s *MmctlE2ETestSuite) TestRenameTeamCmdF() {
 		s.Require().Error(err)
 		s.Len(printer.GetLines(), 0)
 		s.Equal("Cannot rename team '"+s.th.BasicTeam.Name+"', error : : You do not have the appropriate permissions., ", err.Error())
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestModifyTeamsCmdF() {
+	s.SetupTestHelper().InitBasic()
+	s.RunForSystemAdminAndLocal("system & local accounts can set a team to private", func(c client.Client) {
+		printer.Clean()
+		teamID := s.th.BasicTeam.Id
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("private", true, "")
+		err := modifyTeamsCmdF(c, cmd, []string{teamID})
+		s.Require().NoError(err)
+
+		t, appErr := s.th.App.GetTeam(teamID)
+		s.Require().Nil(appErr)
+		s.Require().Equal(model.TEAM_INVITE, t.Type)
+
+		// teardown
+		appErr = s.th.App.UpdateTeamPrivacy(teamID, model.TEAM_OPEN, true)
+		s.Require().Nil(appErr)
+	})
+	s.Run("user that creates the team can't set team's privacy due to permissions", func() {
+		printer.Clean()
+		teamID := s.th.BasicTeam.Id
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("private", true, "")
+		s.th.LoginBasic()
+		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
+		s.Require().NoError(err)
+
+		t, appErr := s.th.App.GetTeam(teamID)
+		s.Require().Nil(appErr)
+		s.Require().Equal(model.TEAM_OPEN, t.Type)
+	})
+	s.Run("basic user with normal permissions that hasn't created the team can't set team's privacy", func() {
+		printer.Clean()
+		teamID := s.th.BasicTeam.Id
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("private", true, "")
+		s.th.LoginBasic2()
+		err := modifyTeamsCmdF(s.th.Client, cmd, []string{teamID})
+		s.Require().NoError(err)
+		t, appErr := s.th.App.GetTeam(teamID)
+		s.Require().Nil(appErr)
+		s.Require().Equal(model.TEAM_OPEN, t.Type)
 	})
 }


### PR DESCRIPTION
#### Summary
This PR adds tests to `mmctl team modify` command

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-29170
- Fixes https://github.com/mattermost/mattermost-server/issues/15676
