### PR TITLE
[MM-29637] Remove local guards for migrated commands

### DIFF
--- a/commands/channel.go
+++ b/commands/channel.go
@@ -155,7 +155,6 @@ Validates that all users in the channel belong to the target team. Incoming/Outg
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
 	Example: "  channel move newteam oldteam:mychannel",
 	Args:    cobra.MinimumNArgs(2),
-	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(moveChannelCmdF),
 }
 

--- a/commands/team.go
+++ b/commands/team.go
@@ -58,7 +58,6 @@ var RestoreTeamsCmd = &cobra.Command{
 	Long:    "Restores archived teams.",
 	Example: "  team restore myteam",
 	Args:    cobra.MinimumNArgs(1),
-	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(restoreTeamsCmdF),
 }
 
@@ -95,7 +94,6 @@ var ModifyTeamsCmd = &cobra.Command{
 	Long:    "Modify teams' privacy setting to public or private",
 	Example: "  team modify myteam --private",
 	Args:    cobra.MinimumNArgs(1),
-	PreRun:  disableLocalPrecheck,
 	RunE:    withClient(modifyTeamsCmdF),
 }
 


### PR DESCRIPTION
#### Summary
This PR removes the local guards for commands that needed endpoints migrated as part of the following tickets:

- [Migrate API handler moveChannel to be compatible with local mode](https://mattermost.atlassian.net/browse/MM-27376)
- [Migrate API handler modifyTeam to be compatible with local mode](https://mattermost.atlassian.net/browse/MM-27377)
- [Migrate API handler restoreTeam to be compatible with local mode](https://mattermost.atlassian.net/browse/MM-27378)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29637