### PR TITLE
Update golangci-lint to v1.31.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
     parameters:
       version:
         type: string
-        default: 1.25.1
+        default: 1.31.0
       gobin:
         type: string
         default: /go/bin


### PR DESCRIPTION
#### Summary
Update golangci-lint to v1.31.0

#### Ticket Link
Follow up on https://github.com/mattermost/mmctl/pull/242
