### PR TITLE
[MM-29564] Add end to end tests to the "moveCommandCmdF" 

### DIFF
--- a/commands/command_e2e_test.go
+++ b/commands/command_e2e_test.go
@@ -42,7 +42,7 @@ func (s *MmctlE2ETestSuite) TestMoveCommandCmdF() {
 			&cobra.Command{},
 			[]string{s.th.BasicTeam.Name, "nothing"})
 		s.Require().NotNil(err)
-		s.Require().Equal(fmt.Sprintf("unable to find command 'nothing'"), err.Error())
+		s.Require().Equal("unable to find command 'nothing'", err.Error())
 	})
 
 	s.RunForAllClients("move existing command to existing team", func(c client.Client) {

--- a/commands/command_e2e_test.go
+++ b/commands/command_e2e_test.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+
+	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/printer"
+)
+
+func (s *MmctlE2ETestSuite) TestMoveCommandCmdF() {
+	s.SetupTestHelper().InitBasic()
+
+	// create new command
+	newCmd := &model.Command{
+		CreatorId: s.th.BasicUser.Id,
+		TeamId:    s.th.BasicTeam.Id,
+		URL:       "http://nowhere.com",
+		Method:    model.COMMAND_METHOD_POST,
+		Trigger:   "trigger",
+	}
+	command ,_ := s.th.SystemAdminClient.CreateCommand(newCmd)
+
+	s.RunForAllClients("move command to non existing team", func(c client.Client) {
+		printer.Clean()
+
+		team := "nonexisting team"
+		err := moveCommandCmdF(s.th.SystemAdminClient,
+			&cobra.Command{},
+			[]string{team, command.Id})
+		s.Require().NotNil(err)
+		s.Require().Equal(fmt.Sprintf("unable to find team '%s'", team), err.Error())
+	})
+
+	s.RunForAllClients("move non existing command", func(c client.Client) {
+		printer.Clean()
+
+		err := moveCommandCmdF(s.th.SystemAdminClient,
+			&cobra.Command{},
+			[]string{s.th.BasicTeam.Name, "nothing"})
+		s.Require().NotNil(err)
+		s.Require().Equal(fmt.Sprintf("unable to find command 'nothing'"), err.Error())
+	})
+
+	s.RunForAllClients("move existing command to existing team", func(c client.Client) {
+		printer.Clean()
+
+		err := moveCommandCmdF(s.th.SystemAdminClient,
+			&cobra.Command{},
+			[]string{s.th.BasicTeam.Name, command.Id})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/command_e2e_test.go
+++ b/commands/command_e2e_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package commands
 
 import (
@@ -22,7 +25,7 @@ func (s *MmctlE2ETestSuite) TestMoveCommandCmdF() {
 		Method:    model.COMMAND_METHOD_POST,
 		Trigger:   "trigger",
 	}
-	command ,_ := s.th.SystemAdminClient.CreateCommand(newCmd)
+	command, _ := s.th.SystemAdminClient.CreateCommand(newCmd)
 
 	s.RunForAllClients("move command to non existing team", func(c client.Client) {
 		printer.Clean()

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -626,7 +626,7 @@ func (s *MmctlUnitTestSuite) TestTeamGroupListCmd() {
 		groupID2 := "group2"
 		mockError := &model.AppError{Message: "Get groups by team error"}
 
-		//grp1 := model.GroupWithSchemeAdmin{}
+		// grp1 := model.GroupWithSchemeAdmin{}
 
 		group1 := model.GroupWithSchemeAdmin{Group: model.Group{Id: groupID, DisplayName: "DisplayName1"}}
 		group2 := model.GroupWithSchemeAdmin{Group: model.Group{Id: groupID2, DisplayName: "DisplayName2"}}


### PR DESCRIPTION

#### Summary

add e2e testing for `moveCommandCmdF`
<!--
A description of what this pull request does.
-->

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/15942
Jira https://mattermost.atlassian.net/browse/MM-29564
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

