### PR TITLE
Add docs and small modifications to the commands

### DIFF
--- a/commands/roles_test.go
+++ b/commands/roles_test.go
@@ -1,85 +1,67 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package commands
 
 import (
-	"github.com/golang/mock/gomock"
-	"github.com/mattermost/mattermost-server/model"
+	"fmt"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+
 	"github.com/mattermost/mmctl/printer"
+
 	"github.com/spf13/cobra"
 )
 
-const (
-	userID   = "userID"
-	email    = "example@example.org"
-	userName = "ExampleUser"
-	roles    = ""
-)
-
 func (s *MmctlUnitTestSuite) TestMakeAdminCmd() {
-
-	s.Run("Add admin priveleges to user", func() {
+	s.Run("Add admin privileges to user", func() {
 		printer.Clean()
-		mockUser := model.User{Id: userID, Username: userName, Email: email, Roles: roles}
-		newRoles := model.SYSTEM_ADMIN_ROLE_ID
-		updatedUser := model.User{Id: userID, Username: userName, Email: email, Roles: newRoles}
+
+		mockUser := &model.User{Id: "1", Email: "u1@example.com", Roles: "system_user"}
+		newRoles := "system_user system_admin"
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(email, "").
-			Return(&mockUser, &model.Response{Error: nil}).
+			GetUserByEmail(mockUser.Email, "").
+			Return(mockUser, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			UpdateUserRoles(gomock.Eq(userID), gomock.Eq(model.SYSTEM_ADMIN_ROLE_ID)).
+			UpdateUserRoles(mockUser.Id, newRoles).
 			Return(true, &model.Response{Error: nil}).
 			Times(1)
 
-		s.client.
-			EXPECT().
-			GetUserByEmail(userID, "").
-			Return(nil, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByUsername(userID, "").
-			Return(nil, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUser(userID, "").
-			Return(&updatedUser, &model.Response{Error: nil}).
-			Times(1)
-
-		err := makeSystemAdminCmdF(s.client, &cobra.Command{}, []string{email})
+		err := rolesSystemAdminCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
 		s.Require().Nil(err)
-		s.Len(printer.GetLines(), 1)
-		s.Len(printer.GetErrorLines(), 0)
-		s.Require().Equal(&updatedUser, printer.GetLines()[0])
 
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Equal(fmt.Sprintf("System admin role assigned to user %q", mockUser.Email), printer.GetLines()[0])
 	})
 
 	s.Run("Adding admin privileges to existing admin", func() {
 		printer.Clean()
-		rolesArg := model.SYSTEM_ADMIN_ROLE_ID
-		mockUser := model.User{Id: userID, Username: userName, Email: email, Roles: rolesArg}
+
+		roles := "system_user system_admin"
+		mockUser := &model.User{Id: "1", Email: "u1@example.com", Roles: roles}
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(email, "").
-			Return(&mockUser, &model.Response{Error: nil}).
+			GetUserByEmail(mockUser.Email, "").
+			Return(mockUser, &model.Response{Error: nil}).
 			Times(1)
 
-		err := makeSystemAdminCmdF(s.client, &cobra.Command{}, []string{email})
+		err := rolesSystemAdminCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
 		s.Require().Nil(err)
-		s.Len(printer.GetLines(), 0)
-		s.Len(printer.GetErrorLines(), 0)
 
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
 	s.Run("Add admin to non existing user", func() {
 		printer.Clean()
+
 		emailArg := "doesnotexist@example.com"
 
 		s.client.
@@ -100,153 +82,113 @@ func (s *MmctlUnitTestSuite) TestMakeAdminCmd() {
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
-		err := makeSystemAdminCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().Error(err)
-		s.Require().EqualErrorf(err, err.Error(), "Unable to find user '%s'", emailArg)
+		err := rolesSystemAdminCmdF(s.client, &cobra.Command{}, []string{emailArg})
+		s.Require().Nil(err)
+
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(fmt.Sprintf("unable to find user %q", emailArg), printer.GetErrorLines()[0])
 	})
 
 	s.Run("Error while updating admin role", func() {
 		printer.Clean()
-		mockUser := model.User{Id: userID, Username: userName, Email: email, Roles: roles}
-		mockError := model.AppError{Id: "Mock Error"}
+
+		mockUser := &model.User{Id: "1", Email: "u1@example.com", Roles: "system_user"}
+		newRoles := "system_user system_admin"
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(email, "").
-			Return(&mockUser, &model.Response{Error: nil}).
+			GetUserByEmail(mockUser.Email, "").
+			Return(mockUser, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			UpdateUserRoles(gomock.Eq(userID), gomock.Eq(model.SYSTEM_ADMIN_ROLE_ID)).
-			Return(false, &model.Response{Error: &mockError}).
+			UpdateUserRoles(mockUser.Id, newRoles).
+			Return(false, &model.Response{Error: &model.AppError{Id: "Mock Error"}}).
 			Times(1)
 
-		err := makeSystemAdminCmdF(s.client, &cobra.Command{}, []string{email})
-		s.Require().Error(err)
-		s.Require().EqualError(err, "Unable to update user roles. Error: : , ")
-		s.Len(printer.GetLines(), 0)
-		s.Len(printer.GetErrorLines(), 0)
+		err := rolesSystemAdminCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
+		s.Require().Nil(err)
+
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("can't update roles for user %q", mockUser.Email))
 	})
 }
 
 func (s *MmctlUnitTestSuite) TestMakeMemberCmd() {
 	s.Run("Remove admin privileges for admin", func() {
-
 		printer.Clean()
-		rolesArg := model.SYSTEM_ADMIN_ROLE_ID
-		mockUser := model.User{Id: userID, Username: userName, Email: email, Roles: rolesArg}
-		newRoles := model.SYSTEM_USER_ROLE_ID
-		updatedUser := model.User{Id: userID, Username: userName, Email: email, Roles: newRoles}
+
+		mockUser := &model.User{Id: "1", Email: "u1@example.com", Roles: "system_user system_admin"}
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(email, "").
-			Return(&mockUser, &model.Response{Error: nil}).
+			GetUserByEmail(mockUser.Email, "").
+			Return(mockUser, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			UpdateUserRoles(gomock.Eq(userID), gomock.Eq(model.SYSTEM_USER_ROLE_ID)).
+			UpdateUserRoles(mockUser.Id, "system_user").
 			Return(true, &model.Response{Error: nil}).
 			Times(1)
 
-		s.client.
-			EXPECT().
-			GetUserByEmail(userID, "").
-			Return(nil, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByUsername(userID, "").
-			Return(nil, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUser(userID, "").
-			Return(&updatedUser, &model.Response{Error: nil}).
-			Times(1)
-
-		err := makeMemberCmdF(s.client, &cobra.Command{}, []string{email})
+		err := rolesMemberCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
 		s.Require().Nil(err)
-		s.Len(printer.GetLines(), 1)
-		s.Len(printer.GetErrorLines(), 0)
-		s.Require().Equal(&updatedUser, printer.GetLines()[0])
+
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Equal(fmt.Sprintf("System admin role revoked for user %q", mockUser.Email), printer.GetLines()[0])
 	})
 
 	s.Run("Remove admin privileges from non admin user", func() {
 		printer.Clean()
-		mockUser := model.User{Id: userID, Username: userName, Email: email, Roles: roles}
-		newRoles := model.SYSTEM_USER_ROLE_ID
-		updatedUser := model.User{Id: userID, Username: userName, Email: email, Roles: newRoles}
+
+		mockUser := &model.User{Id: "1", Email: "u1@example.com", Roles: "system_user"}
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(email, "").
-			Return(&mockUser, &model.Response{Error: nil}).
+			GetUserByEmail(mockUser.Email, "").
+			Return(mockUser, &model.Response{Error: nil}).
 			Times(1)
 
-		s.client.
-			EXPECT().
-			UpdateUserRoles(gomock.Eq(userID), gomock.Eq(model.SYSTEM_USER_ROLE_ID)).
-			Return(true, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByEmail(userID, "").
-			Return(nil, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUserByUsername(userID, "").
-			Return(nil, &model.Response{Error: nil}).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			GetUser(userID, "").
-			Return(&updatedUser, &model.Response{Error: nil}).
-			Times(1)
-
-		err := makeMemberCmdF(s.client, &cobra.Command{}, []string{email})
+		err := rolesMemberCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
 		s.Require().Nil(err)
-		s.Len(printer.GetLines(), 1)
-		s.Len(printer.GetErrorLines(), 0)
-		s.Require().Equal(&updatedUser, printer.GetLines()[0])
 
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.Run("Error while updating non admin role", func() {
+	s.Run("Error while revoking admin role", func() {
 		printer.Clean()
-		rolesArg := model.SYSTEM_ADMIN_ROLE_ID
-		mockUser := model.User{Id: userID, Username: userName, Email: email, Roles: rolesArg}
-		mockError := model.AppError{Id: "Mock Error"}
+
+		mockUser := &model.User{Id: "1", Email: "u1@example.com", Roles: "system_user system_admin"}
 
 		s.client.
 			EXPECT().
-			GetUserByEmail(email, "").
-			Return(&mockUser, &model.Response{Error: nil}).
+			GetUserByEmail(mockUser.Email, "").
+			Return(mockUser, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			UpdateUserRoles(gomock.Eq(userID), gomock.Eq(model.SYSTEM_USER_ROLE_ID)).
-			Return(false, &model.Response{Error: &mockError}).
+			UpdateUserRoles(mockUser.Id, "system_user").
+			Return(false, &model.Response{Error: &model.AppError{Id: "Mock Error"}}).
 			Times(1)
 
-		err := makeMemberCmdF(s.client, &cobra.Command{}, []string{email})
-		s.Require().Error(err)
-		s.Require().EqualError(err, "Unable to update user roles. Error: : , ")
-		s.Len(printer.GetLines(), 0)
-		s.Len(printer.GetErrorLines(), 0)
+		err := rolesMemberCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
+		s.Require().Nil(err)
+
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("can't update roles for user %q", mockUser.Email))
 	})
 
 	s.Run("Remove admin from non existing user", func() {
 		printer.Clean()
+
 		emailArg := "doesnotexist@example.com"
 
 		s.client.
@@ -267,8 +209,11 @@ func (s *MmctlUnitTestSuite) TestMakeMemberCmd() {
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
-		err := makeMemberCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().Error(err)
-		s.Require().EqualError(err, "Unable to find user 'doesnotexist@example.com'")
+		err := rolesMemberCmdF(s.client, &cobra.Command{}, []string{emailArg})
+		s.Require().Nil(err)
+
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(fmt.Sprintf("unable to find user %q", emailArg), printer.GetErrorLines()[0])
 	})
 }

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -40,6 +40,7 @@ SEE ALSO
 * `mmctl permissions <mmctl_permissions.rst>`_ 	 - Management of permissions
 * `mmctl plugin <mmctl_plugin.rst>`_ 	 - Management of plugins
 * `mmctl post <mmctl_post.rst>`_ 	 - Management of posts
+* `mmctl roles <mmctl_roles.rst>`_ 	 - Management of user roles
 * `mmctl system <mmctl_system.rst>`_ 	 - System management
 * `mmctl team <mmctl_team.rst>`_ 	 - Management of teams
 * `mmctl token <mmctl_token.rst>`_ 	 - manage users' access tokens

--- a/docs/mmctl_roles.rst
+++ b/docs/mmctl_roles.rst
@@ -1,0 +1,37 @@
+.. _mmctl_roles:
+
+mmctl roles
+-----------
+
+Management of user roles
+
+Synopsis
+~~~~~~~~
+
+
+Management of user roles
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for roles
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --local                        allows communicating with the server through a unix socket
+      --strict                       will only run commands if the mmctl version matches the server one
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
+* `mmctl roles member <mmctl_roles_member.rst>`_ 	 - Remove system admin privileges
+* `mmctl roles system_admin <mmctl_roles_system_admin.rst>`_ 	 - Set a user as system admin
+

--- a/docs/mmctl_roles_member.rst
+++ b/docs/mmctl_roles_member.rst
@@ -1,0 +1,46 @@
+.. _mmctl_roles_member:
+
+mmctl roles member
+------------------
+
+Remove system admin privileges
+
+Synopsis
+~~~~~~~~
+
+
+Remove system admin privileges from some users.
+
+::
+
+  mmctl roles member [users] [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    roles member user1
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for member
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --local                        allows communicating with the server through a unix socket
+      --strict                       will only run commands if the mmctl version matches the server one
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl roles <mmctl_roles.rst>`_ 	 - Management of user roles
+

--- a/docs/mmctl_roles_system_admin.rst
+++ b/docs/mmctl_roles_system_admin.rst
@@ -1,0 +1,46 @@
+.. _mmctl_roles_system_admin:
+
+mmctl roles system_admin
+------------------------
+
+Set a user as system admin
+
+Synopsis
+~~~~~~~~
+
+
+Make some users system admins
+
+::
+
+  mmctl roles system_admin [users] [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    roles system_admin user1
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for system_admin
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --local                        allows communicating with the server through a unix socket
+      --strict                       will only run commands if the mmctl version matches the server one
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl roles <mmctl_roles.rst>`_ 	 - Management of user roles
+


### PR DESCRIPTION
#### Summary
This PR adds the docs necessary for the CI to pass on the new `mmctl roles` command and subcommands and polishes a bit the way the command filters the roles and prints output instead of returning errors.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19060
