### PR TITLE
[MM-30093] enable enterprise tests for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ all: build
 -include config.override.mk
 include config.mk
 
+ifneq ($(wildcard ${MM_SERVER_PATH}/../enterprise/.*),)
+	TESTFLAGS += -ldflags '-X "github.com/mattermost/mmctl/commands.EnableEnterpriseTests=true"'
+endif
+
 .PHONY: build
 build: vendor check
 	go build -ldflags '$(LDFLAGS)' -mod=vendor

--- a/commands/mmctl_test.go
+++ b/commands/mmctl_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/mattermost/mattermost-server/v5/api4"
 )
 
+var EnableEnterpriseTests string
+
 type MmctlUnitTestSuite struct {
 	suite.Suite
 	mockCtrl *gomock.Controller
@@ -58,6 +60,9 @@ func (s *MmctlE2ETestSuite) SetupTestHelper() *api4.TestHelper {
 }
 
 func (s *MmctlE2ETestSuite) SetupEnterpriseTestHelper() *api4.TestHelper {
+	if EnableEnterpriseTests != "true" {
+		s.T().SkipNow()
+	}
 	s.th = api4.SetupEnterprise(s.T())
 	return s.th
 }


### PR DESCRIPTION

#### Summary
Detect if there is a `/enterprise` directory next to `MM_SERVER_PATH` and enable to use `SetupEnterpriseTestHelper`. If there isn't a enterprise directory the suite will simply skip the test case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30093

