### PR TITLE
[MM-30298] commands/permissions_role: add e2e test

### DIFF
--- a/commands/permissions_role_e2e_test.go
+++ b/commands/permissions_role_e2e_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/printer"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlE2ETestSuite) TestAssignUsersCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+
+	user, appErr := s.th.App.CreateUser(&model.User{Email: s.th.GenerateTestEmail(), Username: model.NewId(), Password: model.NewId()})
+	s.Require().Nil(appErr)
+	defer func() {
+		err := s.th.App.PermanentDeleteUser(user)
+		s.Assert().Nil(err)
+	}()
+
+	s.Run("Should not allow normal user to assign a role", func() {
+		printer.Clean()
+
+		err := assignUsersCmdF(s.th.Client, &cobra.Command{}, []string{model.SYSTEM_ADMIN_ROLE_ID, user.Email})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Assigning a user to a non-existent role", func(c client.Client) {
+		printer.Clean()
+
+		err := assignUsersCmdF(c, &cobra.Command{}, []string{"not_a_role", user.Email})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Assigning a user to a role", func(c client.Client) {
+		printer.Clean()
+
+		err := assignUsersCmdF(c, &cobra.Command{}, []string{model.SYSTEM_MANAGER_ROLE_ID, user.Email})
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/permissions_role_e2e_test.go
+++ b/commands/permissions_role_e2e_test.go
@@ -17,10 +17,6 @@ func (s *MmctlE2ETestSuite) TestAssignUsersCmd() {
 
 	user, appErr := s.th.App.CreateUser(&model.User{Email: s.th.GenerateTestEmail(), Username: model.NewId(), Password: model.NewId()})
 	s.Require().Nil(appErr)
-	defer func() {
-		err := s.th.App.PermanentDeleteUser(user)
-		s.Assert().Nil(err)
-	}()
 
 	s.Run("Should not allow normal user to assign a role", func() {
 		printer.Clean()
@@ -47,5 +43,14 @@ func (s *MmctlE2ETestSuite) TestAssignUsersCmd() {
 		s.Require().NoError(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 0)
+
+		roles := user.Roles
+
+		u, err2 := s.th.App.GetUser(user.Id)
+		s.Require().Nil(err2)
+		s.Require().True(u.IsInRole(model.SYSTEM_MANAGER_ROLE_ID))
+
+		_, err2 = s.th.App.UpdateUserRoles(user.Id, roles, false)
+		s.Require().Nil(err2)
 	})
 }


### PR DESCRIPTION

#### Summary
Add `commands/permissions_role` to E2E tests. 

Blocked by #280 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30298
