### PR TITLE
[MM-30435] commands/auth: use XDG_CONFIG_HOME only if it is set already

### DIFF
--- a/commands/auth_utils_test.go
+++ b/commands/auth_utils_test.go
@@ -26,25 +26,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 		panic(err)
 	}
 
-	t.Run("should return the default xdg config location if it exists and nothing else is set", func(t *testing.T) {
-		tmp, _ := ioutil.TempDir("", "mmctl-")
-		defer os.RemoveAll(tmp)
-		testUser.HomeDir = tmp
-		SetUser(testUser)
-
-		expected := fmt.Sprintf("%s/.config/mmctl/.mmctl", testUser.HomeDir)
-
-		viper.Set("config", getDefaultConfigPath())
-		if err := createFile(expected); err != nil {
-			panic(err)
-		}
-
-		p, err := resolveConfigFilePath()
-		require.Nil(t, err)
-		require.Equal(t, expected, p)
-	})
-
-	t.Run("should return legacy config location if default one does not exists", func(t *testing.T) {
+	t.Run("should return the default config location if nothing else is set", func(t *testing.T) {
 		tmp, _ := ioutil.TempDir("", "mmctl-")
 		defer os.RemoveAll(tmp)
 		testUser.HomeDir = tmp
@@ -52,7 +34,10 @@ func TestResolveConfigFilePath(t *testing.T) {
 
 		expected := fmt.Sprintf("%s/.mmctl", testUser.HomeDir)
 
-		viper.Set("config", getDefaultConfigPath())
+		viper.Set("config-path", getDefaultConfigPath())
+		if err := createFile(expected); err != nil {
+			panic(err)
+		}
 
 		p, err := resolveConfigFilePath()
 		require.Nil(t, err)
@@ -65,10 +50,10 @@ func TestResolveConfigFilePath(t *testing.T) {
 		testUser.HomeDir = tmp
 		SetUser(testUser)
 
-		expected := fmt.Sprintf("%s/test/.mmctl", testUser.HomeDir)
+		expected := filepath.Join(testUser.HomeDir, ".config", "mmctl", ".mmctl")
 
-		_ = os.Setenv("XDG_CONFIG_HOME", filepath.Dir(expected))
-		viper.Set("config", getDefaultConfigPath())
+		_ = os.Setenv("XDG_CONFIG_HOME", filepath.Join(testUser.HomeDir, ".config"))
+		viper.Set("config-path", getDefaultConfigPath())
 		if err := createFile(expected); err != nil {
 			panic(err)
 		}
@@ -88,7 +73,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 		expected := fmt.Sprintf("%s/.mmctl", tmp)
 
 		_ = os.Setenv("XDG_CONFIG_HOME", "path/should/be/ignored")
-		viper.Set("config", tmp)
+		viper.Set("config-path", tmp)
 		if err := createFile(expected); err != nil {
 			panic(err)
 		}

--- a/commands/auth_utils_test.go
+++ b/commands/auth_utils_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -32,13 +31,12 @@ func TestResolveConfigFilePath(t *testing.T) {
 
 		viper.Set("config-path", getDefaultConfigPath())
 
-		expected := filepath.Join(testUser.HomeDir, ".config", "mmctl", configFileName)
+		expected := filepath.Join(testUser.HomeDir, ".config", configFileName)
 
 		err := createFile(expected)
 		require.NoError(t, err)
 
-		p, err := resolveConfigFilePath()
-		require.NoError(t, err)
+		p := resolveConfigFilePath()
 		require.Equal(t, expected, p)
 	})
 
@@ -48,15 +46,14 @@ func TestResolveConfigFilePath(t *testing.T) {
 		testUser.HomeDir = tmp
 		SetUser(testUser)
 
-		expected := filepath.Join(testUser.HomeDir, configFileName)
+		expected := filepath.Join(testUser.HomeDir, "."+configFileName)
 		// create $HOME/.mmctl
 		err := createFile(expected)
 		require.NoError(t, err)
 
 		viper.Set("config-path", getDefaultConfigPath())
 
-		p, err := resolveConfigFilePath()
-		require.NoError(t, err)
+		p := resolveConfigFilePath()
 		require.Equal(t, expected, p)
 	})
 
@@ -66,7 +63,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 		testUser.HomeDir = tmp
 		SetUser(testUser)
 
-		expected := filepath.Join(testUser.HomeDir, ".config", "mmctl", ".mmctl")
+		expected := filepath.Join(testUser.HomeDir, ".config", "mmctl")
 
 		_ = os.Setenv("XDG_CONFIG_HOME", filepath.Join(testUser.HomeDir, ".config"))
 		viper.Set("config-path", getDefaultConfigPath())
@@ -74,8 +71,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 		err := createFile(expected)
 		require.NoError(t, err)
 
-		p, err := resolveConfigFilePath()
-		require.NoError(t, err)
+		p := resolveConfigFilePath()
 		require.Equal(t, expected, p)
 	})
 
@@ -86,7 +82,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 		testUser.HomeDir = "path/should/be/ignored"
 		SetUser(testUser)
 
-		expected := fmt.Sprintf("%s/.mmctl", tmp)
+		expected := filepath.Join(tmp, configFileName)
 
 		err := os.Setenv("XDG_CONFIG_HOME", "path/should/be/ignored")
 		require.NoError(t, err)
@@ -95,8 +91,7 @@ func TestResolveConfigFilePath(t *testing.T) {
 		err = createFile(expected)
 		require.NoError(t, err)
 
-		p, err := resolveConfigFilePath()
-		require.NoError(t, err)
+		p := resolveConfigFilePath()
 		require.Equal(t, expected, p)
 	})
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -21,8 +21,8 @@ func Run(args []string) error {
 	viper.SetDefault("local-socket-path", model.LOCAL_MODE_SOCKET_PATH)
 	viper.AutomaticEnv()
 
-	RootCmd.PersistentFlags().String("config", getDefaultConfigPath(), fmt.Sprintf("path to search for '%s' configuration file", configFileName))
-	_ = viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
+	RootCmd.PersistentFlags().String("config-path", getDefaultConfigPath(), fmt.Sprintf("path to search for '%s' configuration file", configFileName))
+	_ = viper.BindPFlag("config-path", RootCmd.PersistentFlags().Lookup("config-path"))
 	RootCmd.PersistentFlags().String("format", "plain", "the format of the command output [plain, json]")
 	_ = viper.BindPFlag("format", RootCmd.PersistentFlags().Lookup("format"))
 	RootCmd.PersistentFlags().Bool("strict", false, "will only run commands if the mmctl version matches the server one")

--- a/commands/root.go
+++ b/commands/root.go
@@ -21,7 +21,7 @@ func Run(args []string) error {
 	viper.SetDefault("local-socket-path", model.LOCAL_MODE_SOCKET_PATH)
 	viper.AutomaticEnv()
 
-	RootCmd.PersistentFlags().String("config-path", getDefaultConfigPath(), fmt.Sprintf("path to search for '%s' configuration file", configFileName))
+	RootCmd.PersistentFlags().String("config-path", xdgConfigHomeVar, fmt.Sprintf("path to the configuration directory. If \"%s/.%s\" exists it will take precedence over the default value", userHomeVar, configFileName))
 	_ = viper.BindPFlag("config-path", RootCmd.PersistentFlags().Lookup("config-path"))
 	RootCmd.PersistentFlags().String("format", "plain", "the format of the command output [plain, json]")
 	_ = viper.BindPFlag("format", RootCmd.PersistentFlags().Lookup("format"))

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -16,7 +16,7 @@ Options
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
   -h, --help                         help for mmctl
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -16,7 +16,7 @@ Options
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
   -h, --help                         help for mmctl
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -16,7 +16,7 @@ Options
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
   -h, --help                         help for mmctl
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1

--- a/docs/mmctl_auth.rst
+++ b/docs/mmctl_auth.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth.rst
+++ b/docs/mmctl_auth.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth.rst
+++ b/docs/mmctl_auth.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_clean.rst
+++ b/docs/mmctl_auth_clean.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_clean.rst
+++ b/docs/mmctl_auth_clean.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_clean.rst
+++ b/docs/mmctl_auth_clean.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_current.rst
+++ b/docs/mmctl_auth_current.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_current.rst
+++ b/docs/mmctl_auth_current.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_current.rst
+++ b/docs/mmctl_auth_current.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_delete.rst
+++ b/docs/mmctl_auth_delete.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_delete.rst
+++ b/docs/mmctl_auth_delete.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_delete.rst
+++ b/docs/mmctl_auth_delete.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_list.rst
+++ b/docs/mmctl_auth_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_list.rst
+++ b/docs/mmctl_auth_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_list.rst
+++ b/docs/mmctl_auth_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_login.rst
+++ b/docs/mmctl_auth_login.rst
@@ -43,7 +43,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_login.rst
+++ b/docs/mmctl_auth_login.rst
@@ -43,7 +43,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_login.rst
+++ b/docs/mmctl_auth_login.rst
@@ -43,7 +43,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_renew.rst
+++ b/docs/mmctl_auth_renew.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_renew.rst
+++ b/docs/mmctl_auth_renew.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_renew.rst
+++ b/docs/mmctl_auth_renew.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_set.rst
+++ b/docs/mmctl_auth_set.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_set.rst
+++ b/docs/mmctl_auth_set.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_set.rst
+++ b/docs/mmctl_auth_set.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot.rst
+++ b/docs/mmctl_bot.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot.rst
+++ b/docs/mmctl_bot.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot.rst
+++ b/docs/mmctl_bot.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_assign.rst
+++ b/docs/mmctl_bot_assign.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_assign.rst
+++ b/docs/mmctl_bot_assign.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_assign.rst
+++ b/docs/mmctl_bot_assign.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_create.rst
+++ b/docs/mmctl_bot_create.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_create.rst
+++ b/docs/mmctl_bot_create.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_create.rst
+++ b/docs/mmctl_bot_create.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_disable.rst
+++ b/docs/mmctl_bot_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_disable.rst
+++ b/docs/mmctl_bot_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_disable.rst
+++ b/docs/mmctl_bot_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_enable.rst
+++ b/docs/mmctl_bot_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_enable.rst
+++ b/docs/mmctl_bot_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_enable.rst
+++ b/docs/mmctl_bot_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_list.rst
+++ b/docs/mmctl_bot_list.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_list.rst
+++ b/docs/mmctl_bot_list.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_list.rst
+++ b/docs/mmctl_bot_list.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_update.rst
+++ b/docs/mmctl_bot_update.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_update.rst
+++ b/docs/mmctl_bot_update.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_update.rst
+++ b/docs/mmctl_bot_update.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel.rst
+++ b/docs/mmctl_channel.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel.rst
+++ b/docs/mmctl_channel.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel.rst
+++ b/docs/mmctl_channel.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_archive.rst
+++ b/docs/mmctl_channel_archive.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_archive.rst
+++ b/docs/mmctl_channel_archive.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_archive.rst
+++ b/docs/mmctl_channel_archive.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_create.rst
+++ b/docs/mmctl_channel_create.rst
@@ -41,7 +41,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_create.rst
+++ b/docs/mmctl_channel_create.rst
@@ -41,7 +41,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_create.rst
+++ b/docs/mmctl_channel_create.rst
@@ -41,7 +41,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_delete.rst
+++ b/docs/mmctl_channel_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_delete.rst
+++ b/docs/mmctl_channel_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_delete.rst
+++ b/docs/mmctl_channel_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_list.rst
+++ b/docs/mmctl_channel_list.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_list.rst
+++ b/docs/mmctl_channel_list.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_list.rst
+++ b/docs/mmctl_channel_list.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_make_private.rst
+++ b/docs/mmctl_channel_make_private.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_make_private.rst
+++ b/docs/mmctl_channel_make_private.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_make_private.rst
+++ b/docs/mmctl_channel_make_private.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_modify.rst
+++ b/docs/mmctl_channel_modify.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_modify.rst
+++ b/docs/mmctl_channel_modify.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_modify.rst
+++ b/docs/mmctl_channel_modify.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_move.rst
+++ b/docs/mmctl_channel_move.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_move.rst
+++ b/docs/mmctl_channel_move.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_move.rst
+++ b/docs/mmctl_channel_move.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_rename.rst
+++ b/docs/mmctl_channel_rename.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_rename.rst
+++ b/docs/mmctl_channel_rename.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_rename.rst
+++ b/docs/mmctl_channel_rename.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_search.rst
+++ b/docs/mmctl_channel_search.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_search.rst
+++ b/docs/mmctl_channel_search.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_search.rst
+++ b/docs/mmctl_channel_search.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_unarchive.rst
+++ b/docs/mmctl_channel_unarchive.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_unarchive.rst
+++ b/docs/mmctl_channel_unarchive.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_unarchive.rst
+++ b/docs/mmctl_channel_unarchive.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users.rst
+++ b/docs/mmctl_channel_users.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users.rst
+++ b/docs/mmctl_channel_users.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users.rst
+++ b/docs/mmctl_channel_users.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users_add.rst
+++ b/docs/mmctl_channel_users_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users_add.rst
+++ b/docs/mmctl_channel_users_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users_add.rst
+++ b/docs/mmctl_channel_users_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users_remove.rst
+++ b/docs/mmctl_channel_users_remove.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users_remove.rst
+++ b/docs/mmctl_channel_users_remove.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users_remove.rst
+++ b/docs/mmctl_channel_users_remove.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command.rst
+++ b/docs/mmctl_command.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command.rst
+++ b/docs/mmctl_command.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command.rst
+++ b/docs/mmctl_command.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_archive.rst
+++ b/docs/mmctl_command_archive.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_archive.rst
+++ b/docs/mmctl_command_archive.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_archive.rst
+++ b/docs/mmctl_command_archive.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_create.rst
+++ b/docs/mmctl_command_create.rst
@@ -45,7 +45,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_create.rst
+++ b/docs/mmctl_command_create.rst
@@ -45,7 +45,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_create.rst
+++ b/docs/mmctl_command_create.rst
@@ -45,7 +45,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_list.rst
+++ b/docs/mmctl_command_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_list.rst
+++ b/docs/mmctl_command_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_list.rst
+++ b/docs/mmctl_command_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_modify.rst
+++ b/docs/mmctl_command_modify.rst
@@ -45,7 +45,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_modify.rst
+++ b/docs/mmctl_command_modify.rst
@@ -45,7 +45,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_modify.rst
+++ b/docs/mmctl_command_modify.rst
@@ -45,7 +45,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_move.rst
+++ b/docs/mmctl_command_move.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_move.rst
+++ b/docs/mmctl_command_move.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_move.rst
+++ b/docs/mmctl_command_move.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_show.rst
+++ b/docs/mmctl_command_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_show.rst
+++ b/docs/mmctl_command_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_show.rst
+++ b/docs/mmctl_command_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion.rst
+++ b/docs/mmctl_completion.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion.rst
+++ b/docs/mmctl_completion.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion.rst
+++ b/docs/mmctl_completion.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion_bash.rst
+++ b/docs/mmctl_completion_bash.rst
@@ -32,7 +32,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion_bash.rst
+++ b/docs/mmctl_completion_bash.rst
@@ -32,7 +32,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion_bash.rst
+++ b/docs/mmctl_completion_bash.rst
@@ -32,7 +32,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion_zsh.rst
+++ b/docs/mmctl_completion_zsh.rst
@@ -32,7 +32,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion_zsh.rst
+++ b/docs/mmctl_completion_zsh.rst
@@ -32,7 +32,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion_zsh.rst
+++ b/docs/mmctl_completion_zsh.rst
@@ -32,7 +32,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config.rst
+++ b/docs/mmctl_config.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config.rst
+++ b/docs/mmctl_config.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config.rst
+++ b/docs/mmctl_config.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_edit.rst
+++ b/docs/mmctl_config_edit.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_edit.rst
+++ b/docs/mmctl_config_edit.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_edit.rst
+++ b/docs/mmctl_config_edit.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_get.rst
+++ b/docs/mmctl_config_get.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_get.rst
+++ b/docs/mmctl_config_get.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_get.rst
+++ b/docs/mmctl_config_get.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_migrate.rst
+++ b/docs/mmctl_config_migrate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_migrate.rst
+++ b/docs/mmctl_config_migrate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_migrate.rst
+++ b/docs/mmctl_config_migrate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_reload.rst
+++ b/docs/mmctl_config_reload.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_reload.rst
+++ b/docs/mmctl_config_reload.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_reload.rst
+++ b/docs/mmctl_config_reload.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_reset.rst
+++ b/docs/mmctl_config_reset.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_reset.rst
+++ b/docs/mmctl_config_reset.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_reset.rst
+++ b/docs/mmctl_config_reset.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_set.rst
+++ b/docs/mmctl_config_set.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_set.rst
+++ b/docs/mmctl_config_set.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_set.rst
+++ b/docs/mmctl_config_set.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_show.rst
+++ b/docs/mmctl_config_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_show.rst
+++ b/docs/mmctl_config_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_show.rst
+++ b/docs/mmctl_config_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_subpath.rst
+++ b/docs/mmctl_config_subpath.rst
@@ -43,7 +43,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_subpath.rst
+++ b/docs/mmctl_config_subpath.rst
@@ -43,7 +43,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_subpath.rst
+++ b/docs/mmctl_config_subpath.rst
@@ -43,7 +43,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_docs.rst
+++ b/docs/mmctl_docs.rst
@@ -28,7 +28,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_docs.rst
+++ b/docs/mmctl_docs.rst
@@ -28,7 +28,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_docs.rst
+++ b/docs/mmctl_docs.rst
@@ -28,7 +28,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group.rst
+++ b/docs/mmctl_group.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group.rst
+++ b/docs/mmctl_group.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group.rst
+++ b/docs/mmctl_group.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel.rst
+++ b/docs/mmctl_group_channel.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel.rst
+++ b/docs/mmctl_group_channel.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel.rst
+++ b/docs/mmctl_group_channel.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_disable.rst
+++ b/docs/mmctl_group_channel_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_disable.rst
+++ b/docs/mmctl_group_channel_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_disable.rst
+++ b/docs/mmctl_group_channel_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_enable.rst
+++ b/docs/mmctl_group_channel_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_enable.rst
+++ b/docs/mmctl_group_channel_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_enable.rst
+++ b/docs/mmctl_group_channel_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_list.rst
+++ b/docs/mmctl_group_channel_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_list.rst
+++ b/docs/mmctl_group_channel_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_list.rst
+++ b/docs/mmctl_group_channel_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_status.rst
+++ b/docs/mmctl_group_channel_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_status.rst
+++ b/docs/mmctl_group_channel_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_status.rst
+++ b/docs/mmctl_group_channel_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_list-ldap.rst
+++ b/docs/mmctl_group_list-ldap.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_list-ldap.rst
+++ b/docs/mmctl_group_list-ldap.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_list-ldap.rst
+++ b/docs/mmctl_group_list-ldap.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team.rst
+++ b/docs/mmctl_group_team.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team.rst
+++ b/docs/mmctl_group_team.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team.rst
+++ b/docs/mmctl_group_team.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_disable.rst
+++ b/docs/mmctl_group_team_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_disable.rst
+++ b/docs/mmctl_group_team_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_disable.rst
+++ b/docs/mmctl_group_team_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_enable.rst
+++ b/docs/mmctl_group_team_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_enable.rst
+++ b/docs/mmctl_group_team_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_enable.rst
+++ b/docs/mmctl_group_team_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_list.rst
+++ b/docs/mmctl_group_team_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_list.rst
+++ b/docs/mmctl_group_team_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_list.rst
+++ b/docs/mmctl_group_team_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_status.rst
+++ b/docs/mmctl_group_team_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_status.rst
+++ b/docs/mmctl_group_team_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_status.rst
+++ b/docs/mmctl_group_team_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_integrity.rst
+++ b/docs/mmctl_integrity.rst
@@ -29,7 +29,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_integrity.rst
+++ b/docs/mmctl_integrity.rst
@@ -29,7 +29,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_integrity.rst
+++ b/docs/mmctl_integrity.rst
@@ -29,7 +29,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap.rst
+++ b/docs/mmctl_ldap.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap.rst
+++ b/docs/mmctl_ldap.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap.rst
+++ b/docs/mmctl_ldap.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap_idmigrate.rst
+++ b/docs/mmctl_ldap_idmigrate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap_idmigrate.rst
+++ b/docs/mmctl_ldap_idmigrate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap_idmigrate.rst
+++ b/docs/mmctl_ldap_idmigrate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap_sync.rst
+++ b/docs/mmctl_ldap_sync.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap_sync.rst
+++ b/docs/mmctl_ldap_sync.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap_sync.rst
+++ b/docs/mmctl_ldap_sync.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license.rst
+++ b/docs/mmctl_license.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license.rst
+++ b/docs/mmctl_license.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license.rst
+++ b/docs/mmctl_license.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license_remove.rst
+++ b/docs/mmctl_license_remove.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license_remove.rst
+++ b/docs/mmctl_license_remove.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license_remove.rst
+++ b/docs/mmctl_license_remove.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license_upload.rst
+++ b/docs/mmctl_license_upload.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license_upload.rst
+++ b/docs/mmctl_license_upload.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license_upload.rst
+++ b/docs/mmctl_license_upload.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_logs.rst
+++ b/docs/mmctl_logs.rst
@@ -29,7 +29,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_logs.rst
+++ b/docs/mmctl_logs.rst
@@ -29,7 +29,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_logs.rst
+++ b/docs/mmctl_logs.rst
@@ -29,7 +29,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions.rst
+++ b/docs/mmctl_permissions.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions.rst
+++ b/docs/mmctl_permissions.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions.rst
+++ b/docs/mmctl_permissions.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_add.rst
+++ b/docs/mmctl_permissions_add.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_add.rst
+++ b/docs/mmctl_permissions_add.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_add.rst
+++ b/docs/mmctl_permissions_add.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_remove.rst
+++ b/docs/mmctl_permissions_remove.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_remove.rst
+++ b/docs/mmctl_permissions_remove.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_remove.rst
+++ b/docs/mmctl_permissions_remove.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role.rst
+++ b/docs/mmctl_permissions_role.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role.rst
+++ b/docs/mmctl_permissions_role.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role.rst
+++ b/docs/mmctl_permissions_role.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_assign.rst
+++ b/docs/mmctl_permissions_role_assign.rst
@@ -40,7 +40,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_assign.rst
+++ b/docs/mmctl_permissions_role_assign.rst
@@ -40,7 +40,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_assign.rst
+++ b/docs/mmctl_permissions_role_assign.rst
@@ -40,7 +40,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_show.rst
+++ b/docs/mmctl_permissions_role_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_show.rst
+++ b/docs/mmctl_permissions_role_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_show.rst
+++ b/docs/mmctl_permissions_role_show.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_unassign.rst
+++ b/docs/mmctl_permissions_role_unassign.rst
@@ -40,7 +40,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_unassign.rst
+++ b/docs/mmctl_permissions_role_unassign.rst
@@ -40,7 +40,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_unassign.rst
+++ b/docs/mmctl_permissions_role_unassign.rst
@@ -40,7 +40,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin.rst
+++ b/docs/mmctl_plugin.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin.rst
+++ b/docs/mmctl_plugin.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin.rst
+++ b/docs/mmctl_plugin.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_add.rst
+++ b/docs/mmctl_plugin_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_add.rst
+++ b/docs/mmctl_plugin_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_add.rst
+++ b/docs/mmctl_plugin_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_delete.rst
+++ b/docs/mmctl_plugin_delete.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_delete.rst
+++ b/docs/mmctl_plugin_delete.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_delete.rst
+++ b/docs/mmctl_plugin_delete.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_disable.rst
+++ b/docs/mmctl_plugin_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_disable.rst
+++ b/docs/mmctl_plugin_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_disable.rst
+++ b/docs/mmctl_plugin_disable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_enable.rst
+++ b/docs/mmctl_plugin_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_enable.rst
+++ b/docs/mmctl_plugin_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_enable.rst
+++ b/docs/mmctl_plugin_enable.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_install-url.rst
+++ b/docs/mmctl_plugin_install-url.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_install-url.rst
+++ b/docs/mmctl_plugin_install-url.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_install-url.rst
+++ b/docs/mmctl_plugin_install-url.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_list.rst
+++ b/docs/mmctl_plugin_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_list.rst
+++ b/docs/mmctl_plugin_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_list.rst
+++ b/docs/mmctl_plugin_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace.rst
+++ b/docs/mmctl_plugin_marketplace.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace.rst
+++ b/docs/mmctl_plugin_marketplace.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace.rst
+++ b/docs/mmctl_plugin_marketplace.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace_install.rst
+++ b/docs/mmctl_plugin_marketplace_install.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace_install.rst
+++ b/docs/mmctl_plugin_marketplace_install.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace_install.rst
+++ b/docs/mmctl_plugin_marketplace_install.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace_list.rst
+++ b/docs/mmctl_plugin_marketplace_list.rst
@@ -49,7 +49,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace_list.rst
+++ b/docs/mmctl_plugin_marketplace_list.rst
@@ -49,7 +49,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace_list.rst
+++ b/docs/mmctl_plugin_marketplace_list.rst
@@ -49,7 +49,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post.rst
+++ b/docs/mmctl_post.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post.rst
+++ b/docs/mmctl_post.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post.rst
+++ b/docs/mmctl_post.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post_create.rst
+++ b/docs/mmctl_post_create.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post_create.rst
+++ b/docs/mmctl_post_create.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post_create.rst
+++ b/docs/mmctl_post_create.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post_list.rst
+++ b/docs/mmctl_post_list.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post_list.rst
+++ b/docs/mmctl_post_list.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post_list.rst
+++ b/docs/mmctl_post_list.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles.rst
+++ b/docs/mmctl_roles.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles.rst
+++ b/docs/mmctl_roles.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles.rst
+++ b/docs/mmctl_roles.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles_member.rst
+++ b/docs/mmctl_roles_member.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles_member.rst
+++ b/docs/mmctl_roles_member.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles_member.rst
+++ b/docs/mmctl_roles_member.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles_system_admin.rst
+++ b/docs/mmctl_roles_system_admin.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles_system_admin.rst
+++ b/docs/mmctl_roles_system_admin.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles_system_admin.rst
+++ b/docs/mmctl_roles_system_admin.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system.rst
+++ b/docs/mmctl_system.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system.rst
+++ b/docs/mmctl_system.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system.rst
+++ b/docs/mmctl_system.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_clearbusy.rst
+++ b/docs/mmctl_system_clearbusy.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_clearbusy.rst
+++ b/docs/mmctl_system_clearbusy.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_clearbusy.rst
+++ b/docs/mmctl_system_clearbusy.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_getbusy.rst
+++ b/docs/mmctl_system_getbusy.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_getbusy.rst
+++ b/docs/mmctl_system_getbusy.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_getbusy.rst
+++ b/docs/mmctl_system_getbusy.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_setbusy.rst
+++ b/docs/mmctl_system_setbusy.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_setbusy.rst
+++ b/docs/mmctl_system_setbusy.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_setbusy.rst
+++ b/docs/mmctl_system_setbusy.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_status.rst
+++ b/docs/mmctl_system_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_status.rst
+++ b/docs/mmctl_system_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_status.rst
+++ b/docs/mmctl_system_status.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_version.rst
+++ b/docs/mmctl_system_version.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_version.rst
+++ b/docs/mmctl_system_version.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_version.rst
+++ b/docs/mmctl_system_version.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team.rst
+++ b/docs/mmctl_team.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team.rst
+++ b/docs/mmctl_team.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team.rst
+++ b/docs/mmctl_team.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_archive.rst
+++ b/docs/mmctl_team_archive.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_archive.rst
+++ b/docs/mmctl_team_archive.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_archive.rst
+++ b/docs/mmctl_team_archive.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_create.rst
+++ b/docs/mmctl_team_create.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_create.rst
+++ b/docs/mmctl_team_create.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_create.rst
+++ b/docs/mmctl_team_create.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_delete.rst
+++ b/docs/mmctl_team_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_delete.rst
+++ b/docs/mmctl_team_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_delete.rst
+++ b/docs/mmctl_team_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_list.rst
+++ b/docs/mmctl_team_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_list.rst
+++ b/docs/mmctl_team_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_list.rst
+++ b/docs/mmctl_team_list.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_modify.rst
+++ b/docs/mmctl_team_modify.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_modify.rst
+++ b/docs/mmctl_team_modify.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_modify.rst
+++ b/docs/mmctl_team_modify.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_rename.rst
+++ b/docs/mmctl_team_rename.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_rename.rst
+++ b/docs/mmctl_team_rename.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_rename.rst
+++ b/docs/mmctl_team_rename.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_restore.rst
+++ b/docs/mmctl_team_restore.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_restore.rst
+++ b/docs/mmctl_team_restore.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_restore.rst
+++ b/docs/mmctl_team_restore.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_search.rst
+++ b/docs/mmctl_team_search.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_search.rst
+++ b/docs/mmctl_team_search.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_search.rst
+++ b/docs/mmctl_team_search.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users.rst
+++ b/docs/mmctl_team_users.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users.rst
+++ b/docs/mmctl_team_users.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users.rst
+++ b/docs/mmctl_team_users.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users_add.rst
+++ b/docs/mmctl_team_users_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users_add.rst
+++ b/docs/mmctl_team_users_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users_add.rst
+++ b/docs/mmctl_team_users_add.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users_remove.rst
+++ b/docs/mmctl_team_users_remove.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users_remove.rst
+++ b/docs/mmctl_team_users_remove.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users_remove.rst
+++ b/docs/mmctl_team_users_remove.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token.rst
+++ b/docs/mmctl_token.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token.rst
+++ b/docs/mmctl_token.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token.rst
+++ b/docs/mmctl_token.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_generate.rst
+++ b/docs/mmctl_token_generate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_generate.rst
+++ b/docs/mmctl_token_generate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_generate.rst
+++ b/docs/mmctl_token_generate.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_list.rst
+++ b/docs/mmctl_token_list.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_list.rst
+++ b/docs/mmctl_token_list.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_list.rst
+++ b/docs/mmctl_token_list.rst
@@ -39,7 +39,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_revoke.rst
+++ b/docs/mmctl_token_revoke.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_revoke.rst
+++ b/docs/mmctl_token_revoke.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_revoke.rst
+++ b/docs/mmctl_token_revoke.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -23,7 +23,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_activate.rst
+++ b/docs/mmctl_user_activate.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_activate.rst
+++ b/docs/mmctl_user_activate.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_activate.rst
+++ b/docs/mmctl_user_activate.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_change-password.rst
+++ b/docs/mmctl_user_change-password.rst
@@ -51,7 +51,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_change-password.rst
+++ b/docs/mmctl_user_change-password.rst
@@ -51,7 +51,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_change-password.rst
+++ b/docs/mmctl_user_change-password.rst
@@ -51,7 +51,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_convert.rst
+++ b/docs/mmctl_user_convert.rst
@@ -51,7 +51,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_convert.rst
+++ b/docs/mmctl_user_convert.rst
@@ -51,7 +51,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_convert.rst
+++ b/docs/mmctl_user_convert.rst
@@ -51,7 +51,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_create.rst
+++ b/docs/mmctl_user_create.rst
@@ -53,7 +53,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_create.rst
+++ b/docs/mmctl_user_create.rst
@@ -53,7 +53,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_create.rst
+++ b/docs/mmctl_user_create.rst
@@ -53,7 +53,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_deactivate.rst
+++ b/docs/mmctl_user_deactivate.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_deactivate.rst
+++ b/docs/mmctl_user_deactivate.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_deactivate.rst
+++ b/docs/mmctl_user_deactivate.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_delete.rst
+++ b/docs/mmctl_user_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_delete.rst
+++ b/docs/mmctl_user_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_delete.rst
+++ b/docs/mmctl_user_delete.rst
@@ -36,7 +36,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_deleteall.rst
+++ b/docs/mmctl_user_deleteall.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_deleteall.rst
+++ b/docs/mmctl_user_deleteall.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_deleteall.rst
+++ b/docs/mmctl_user_deleteall.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_email.rst
+++ b/docs/mmctl_user_email.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_email.rst
+++ b/docs/mmctl_user_email.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_email.rst
+++ b/docs/mmctl_user_email.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_invite.rst
+++ b/docs/mmctl_user_invite.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_invite.rst
+++ b/docs/mmctl_user_invite.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_invite.rst
+++ b/docs/mmctl_user_invite.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_list.rst
+++ b/docs/mmctl_user_list.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_list.rst
+++ b/docs/mmctl_user_list.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_list.rst
+++ b/docs/mmctl_user_list.rst
@@ -38,7 +38,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_migrate_auth.rst
+++ b/docs/mmctl_user_migrate_auth.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_migrate_auth.rst
+++ b/docs/mmctl_user_migrate_auth.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_migrate_auth.rst
+++ b/docs/mmctl_user_migrate_auth.rst
@@ -37,7 +37,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_reset_password.rst
+++ b/docs/mmctl_user_reset_password.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_reset_password.rst
+++ b/docs/mmctl_user_reset_password.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_reset_password.rst
+++ b/docs/mmctl_user_reset_password.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_resetmfa.rst
+++ b/docs/mmctl_user_resetmfa.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_resetmfa.rst
+++ b/docs/mmctl_user_resetmfa.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_resetmfa.rst
+++ b/docs/mmctl_user_resetmfa.rst
@@ -35,7 +35,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_search.rst
+++ b/docs/mmctl_user_search.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_search.rst
+++ b/docs/mmctl_user_search.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_search.rst
+++ b/docs/mmctl_user_search.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_verify.rst
+++ b/docs/mmctl_user_verify.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_verify.rst
+++ b/docs/mmctl_user_verify.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_verify.rst
+++ b/docs/mmctl_user_verify.rst
@@ -34,7 +34,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_version.rst
+++ b/docs/mmctl_version.rst
@@ -27,7 +27,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_version.rst
+++ b/docs/mmctl_version.rst
@@ -27,7 +27,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_version.rst
+++ b/docs/mmctl_version.rst
@@ -27,7 +27,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_websocket.rst
+++ b/docs/mmctl_websocket.rst
@@ -27,7 +27,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_websocket.rst
+++ b/docs/mmctl_websocket.rst
@@ -27,7 +27,7 @@ Options inherited from parent commands
 
 ::
 
-      --config string                path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to search for '.mmctl' configuration file (default "$HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_websocket.rst
+++ b/docs/mmctl_websocket.rst
@@ -27,7 +27,7 @@ Options inherited from parent commands
 
 ::
 
-      --config-path string           path to search for '.mmctl' configuration file (default "$HOME/.config/mmctl")
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --local                        allows communicating with the server through a unix socket


### PR DESCRIPTION

#### Summary
Use `$XDG_CONFIG_HOME` only if the corresponding env var is available. If not, fallback to `$HOME` as usual. Since we are here, `config-path` seemed more convenient to me 0/5 though.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30435

