### PR TITLE
Add new subcommand name to the command user for changing username of a user account #248

### DIFF
--- a/commands/user.go
+++ b/commands/user.go
@@ -87,12 +87,13 @@ var UpdateUserEmailCmd = &cobra.Command{
 	RunE:    withClient(updateUserEmailCmdF),
 }
 
-var UpdateUserNameCmd = &cobra.Command{
-	Use:     "name [user] [new name]",
-	Short:   "Change name of the user",
-	Long:    "Change name of the user.",
-	Example: "  user name testuser newname",
-	RunE:    withClient(updateUserNameCmdF),
+var UpdateUsernameCmd = &cobra.Command{
+	Use:     "username [user] [new username]",
+	Short:   "Change username of the user",
+	Long:    "Change username of the user.",
+	Example: "  user username testuser newusername",
+	Args:	 cobra.ExactArgs(2),
+	RunE:    withClient(updateUsernameCmdF),
 }
 
 var ChangePasswordUserCmd = &cobra.Command{
@@ -311,7 +312,7 @@ Global Flags:
 		UserInviteCmd,
 		SendPasswordResetEmailCmd,
 		UpdateUserEmailCmd,
-		UpdateUserNameCmd,
+		UpdateUsernameCmd,
 		ChangePasswordUserCmd,
 		ResetUserMfaCmd,
 		DeleteUsersCmd,
@@ -500,17 +501,13 @@ func updateUserEmailCmdF(c client.Client, cmd *cobra.Command, args []string) err
 	return nil
 }
 
-func updateUserNameCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+func updateUsernameCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	printer.SetSingle(true)
 
-	if len(args) != 2 {
-		return errors.New("expected two arguments. See help text for details")
-	}
+	newUsername := args[1]
 
-	newName := args[1]
-
-	if !model.IsValidUsername(newName) {
-		return errors.New("invalid name: '" + newName + "'")
+	if !model.IsValidUsername(newUsername) {
+		return errors.New("invalid username: '" + newUsername + "'")
 	}
 
 	user := getUserFromUserArg(c, args[0])
@@ -518,7 +515,7 @@ func updateUserNameCmdF(c client.Client, cmd *cobra.Command, args []string) erro
 		return errors.New("unable to find user '" + args[0] + "'")
 	}
 
-	user.Username = newName
+	user.Username = newUsername
 
 	ruser, response := c.UpdateUser(user)
 	if response.Error != nil {

--- a/commands/user.go
+++ b/commands/user.go
@@ -92,7 +92,7 @@ var UpdateUsernameCmd = &cobra.Command{
 	Short:   "Change username of the user",
 	Long:    "Change username of the user.",
 	Example: "  user username testuser newusername",
-	Args:	 cobra.ExactArgs(2),
+	Args:    cobra.ExactArgs(2),
 	RunE:    withClient(updateUsernameCmdF),
 }
 

--- a/commands/user_e2e_test.go
+++ b/commands/user_e2e_test.go
@@ -567,6 +567,25 @@ func (s *MmctlE2ETestSuite) TestUpdateUserNameCmd() {
 		s.Require().Nil(err)
 		s.Require().Equal(s.th.BasicUser2.Username, u.Username)
 	})
+
+	s.Run("Can't change by a invalid username", func() {
+		printer.Clean()
+		newName := "invalid username"
+		err := updateUserNameCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicUser2.Id, newName})
+		s.Require().EqualError(err, "invalid name: '"+newName+"'")
+
+		u, err := s.th.App.GetUser(s.th.BasicUser2.Id)
+		s.Require().Nil(err)
+		s.Require().Equal(s.th.BasicUser2.Username, u.Username)
+	})
+
+	s.RunForSystemAdminAndLocal("Delete nonexistent user", func(c client.Client) {
+		printer.Clean()
+		oldName := "nonexistentuser"
+		newName := "basicusernamechange"
+		err := updateUserNameCmdF(s.th.Client, &cobra.Command{}, []string{oldName, newName})
+		s.Require().EqualError(err, "unable to find user '"+oldName+"'")
+	})
 }
 
 func (s *MmctlE2ETestSuite) TestDeleteUsersCmd() {

--- a/commands/user_e2e_test.go
+++ b/commands/user_e2e_test.go
@@ -538,6 +538,37 @@ func (s *MmctlE2ETestSuite) TestUpdateUserEmailCmd() {
 	})
 }
 
+func (s *MmctlE2ETestSuite) TestUpdateUserNameCmd() {
+	s.SetupTestHelper().InitBasic()
+
+	s.RunForSystemAdminAndLocal("admin and local user can change user name", func(c client.Client) {
+		printer.Clean()
+		oldName := s.th.BasicUser2.Username
+		newName := "basicusernamechange"
+		err := updateUserNameCmdF(c, &cobra.Command{}, []string{s.th.BasicUser2.Username, newName})
+		s.Require().Nil(err)
+
+		u, err := s.th.App.GetUser(s.th.BasicUser2.Id)
+		s.Require().Nil(err)
+		s.Require().Equal(newName, u.Username)
+
+		u.Username = oldName
+		_, err = s.th.App.UpdateUser(u, false)
+		s.Require().Nil(err)
+	})
+
+	s.Run("normal user doesn't have permission to change another user's name", func() {
+		printer.Clean()
+		newName := "basicusernamechange"
+		err := updateUserNameCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicUser2.Id, newName})
+		s.Require().EqualError(err, ": You do not have the appropriate permissions., ")
+
+		u, err := s.th.App.GetUser(s.th.BasicUser2.Id)
+		s.Require().Nil(err)
+		s.Require().Equal(s.th.BasicUser2.Username, u.Username)
+	})
+}
+
 func (s *MmctlE2ETestSuite) TestDeleteUsersCmd() {
 	s.SetupTestHelper().InitBasic()
 

--- a/commands/user_e2e_test.go
+++ b/commands/user_e2e_test.go
@@ -538,14 +538,14 @@ func (s *MmctlE2ETestSuite) TestUpdateUserEmailCmd() {
 	})
 }
 
-func (s *MmctlE2ETestSuite) TestUpdateUserNameCmd() {
+func (s *MmctlE2ETestSuite) TestUpdateUsernameCmd() {
 	s.SetupTestHelper().InitBasic()
 
 	s.RunForSystemAdminAndLocal("admin and local user can change user name", func(c client.Client) {
 		printer.Clean()
 		oldName := s.th.BasicUser2.Username
 		newName := "basicusernamechange"
-		err := updateUserNameCmdF(c, &cobra.Command{}, []string{s.th.BasicUser2.Username, newName})
+		err := updateUsernameCmdF(c, &cobra.Command{}, []string{s.th.BasicUser2.Username, newName})
 		s.Require().Nil(err)
 
 		u, err := s.th.App.GetUser(s.th.BasicUser2.Id)
@@ -559,8 +559,8 @@ func (s *MmctlE2ETestSuite) TestUpdateUserNameCmd() {
 
 	s.Run("normal user doesn't have permission to change another user's name", func() {
 		printer.Clean()
-		newName := "basicusernamechange"
-		err := updateUserNameCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicUser2.Id, newName})
+		newUsername := "basicusernamechange"
+		err := updateUsernameCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicUser2.Id, newUsername})
 		s.Require().EqualError(err, ": You do not have the appropriate permissions., ")
 
 		u, err := s.th.App.GetUser(s.th.BasicUser2.Id)
@@ -570,9 +570,9 @@ func (s *MmctlE2ETestSuite) TestUpdateUserNameCmd() {
 
 	s.Run("Can't change by a invalid username", func() {
 		printer.Clean()
-		newName := "invalid username"
-		err := updateUserNameCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicUser2.Id, newName})
-		s.Require().EqualError(err, "invalid name: '"+newName+"'")
+		newUsername := "invalid username"
+		err := updateUsernameCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicUser2.Id, newUsername})
+		s.Require().EqualError(err, "invalid username: '"+newUsername+"'")
 
 		u, err := s.th.App.GetUser(s.th.BasicUser2.Id)
 		s.Require().Nil(err)
@@ -582,8 +582,8 @@ func (s *MmctlE2ETestSuite) TestUpdateUserNameCmd() {
 	s.RunForSystemAdminAndLocal("Delete nonexistent user", func(c client.Client) {
 		printer.Clean()
 		oldName := "nonexistentuser"
-		newName := "basicusernamechange"
-		err := updateUserNameCmdF(s.th.Client, &cobra.Command{}, []string{oldName, newName})
+		newUsername := "basicusernamechange"
+		err := updateUsernameCmdF(s.th.Client, &cobra.Command{}, []string{oldName, newUsername})
 		s.Require().EqualError(err, "unable to find user '"+oldName+"'")
 	})
 }

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -41,10 +41,10 @@ SEE ALSO
 * `mmctl user delete <mmctl_user_delete.rst>`_ 	 - Delete users
 * `mmctl user deleteall <mmctl_user_deleteall.rst>`_ 	 - Delete all users and all posts. Local command only.
 * `mmctl user email <mmctl_user_email.rst>`_ 	 - Change email of the user
-* `mmctl user name <mmctl_user_name.rst>`_ 	 - Change name of the user
 * `mmctl user invite <mmctl_user_invite.rst>`_ 	 - Send user an email invite to a team.
 * `mmctl user list <mmctl_user_list.rst>`_ 	 - List users
 * `mmctl user migrate_auth <mmctl_user_migrate_auth.rst>`_ 	 - Mass migrate user accounts authentication type
+* `mmctl user name <mmctl_user_name.rst>`_ 	 - Change name of the user
 * `mmctl user reset_password <mmctl_user_reset_password.rst>`_ 	 - Send users an email to reset their password
 * `mmctl user resetmfa <mmctl_user_resetmfa.rst>`_ 	 - Turn off MFA
 * `mmctl user search <mmctl_user_search.rst>`_ 	 - Search for users

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -41,7 +41,7 @@ SEE ALSO
 * `mmctl user delete <mmctl_user_delete.rst>`_ 	 - Delete users
 * `mmctl user deleteall <mmctl_user_deleteall.rst>`_ 	 - Delete all users and all posts. Local command only.
 * `mmctl user email <mmctl_user_email.rst>`_ 	 - Change email of the user
-* `mmctl user email <mmctl_user_name.rst>`_ 	 - Change name of the user
+* `mmctl user name <mmctl_user_name.rst>`_ 	 - Change name of the user
 * `mmctl user invite <mmctl_user_invite.rst>`_ 	 - Send user an email invite to a team.
 * `mmctl user list <mmctl_user_list.rst>`_ 	 - List users
 * `mmctl user migrate_auth <mmctl_user_migrate_auth.rst>`_ 	 - Mass migrate user accounts authentication type

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -44,9 +44,9 @@ SEE ALSO
 * `mmctl user invite <mmctl_user_invite.rst>`_ 	 - Send user an email invite to a team.
 * `mmctl user list <mmctl_user_list.rst>`_ 	 - List users
 * `mmctl user migrate_auth <mmctl_user_migrate_auth.rst>`_ 	 - Mass migrate user accounts authentication type
-* `mmctl user name <mmctl_user_name.rst>`_ 	 - Change name of the user
 * `mmctl user reset_password <mmctl_user_reset_password.rst>`_ 	 - Send users an email to reset their password
 * `mmctl user resetmfa <mmctl_user_resetmfa.rst>`_ 	 - Turn off MFA
 * `mmctl user search <mmctl_user_search.rst>`_ 	 - Search for users
+* `mmctl user username <mmctl_user_username.rst>`_ 	 - Change username of the user
 * `mmctl user verify <mmctl_user_verify.rst>`_ 	 - Verify email of users
 

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -41,6 +41,7 @@ SEE ALSO
 * `mmctl user delete <mmctl_user_delete.rst>`_ 	 - Delete users
 * `mmctl user deleteall <mmctl_user_deleteall.rst>`_ 	 - Delete all users and all posts. Local command only.
 * `mmctl user email <mmctl_user_email.rst>`_ 	 - Change email of the user
+* `mmctl user email <mmctl_user_name.rst>`_ 	 - Change name of the user
 * `mmctl user invite <mmctl_user_invite.rst>`_ 	 - Send user an email invite to a team.
 * `mmctl user list <mmctl_user_list.rst>`_ 	 - List users
 * `mmctl user migrate_auth <mmctl_user_migrate_auth.rst>`_ 	 - Mass migrate user accounts authentication type

--- a/docs/mmctl_user_name.rst
+++ b/docs/mmctl_user_name.rst
@@ -1,0 +1,47 @@
+.. _mmctl_user_name:
+
+mmctl user name
+----------------
+
+Change name of the user
+
+Synopsis
+~~~~~~~~
+
+
+Change name of the user.
+
+::
+
+  mmctl user name [user] [new name] [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    user name testuser newname
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for name
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --local                        allows communicating with the server through a unix socket
+      --strict                       will only run commands if the mmctl version matches the server one
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl user <mmctl_user.rst>`_ 	 - Management of users
+

--- a/docs/mmctl_user_name.rst
+++ b/docs/mmctl_user_name.rst
@@ -1,7 +1,7 @@
 .. _mmctl_user_name:
 
 mmctl user name
-----------------
+---------------
 
 Change name of the user
 

--- a/docs/mmctl_user_username.rst
+++ b/docs/mmctl_user_username.rst
@@ -1,33 +1,33 @@
-.. _mmctl_user_name:
+.. _mmctl_user_username:
 
-mmctl user name
----------------
+mmctl user username
+-------------------
 
-Change name of the user
+Change username of the user
 
 Synopsis
 ~~~~~~~~
 
 
-Change name of the user.
+Change username of the user.
 
 ::
 
-  mmctl user name [user] [new name] [flags]
+  mmctl user username [user] [new username] [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    user name testuser newname
+    user username testuser newusername
 
 Options
 ~~~~~~~
 
 ::
 
-  -h, --help   help for name
+  -h, --help   help for username
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
Add new subcommand `name` to the command `user` for changing username of a user account.

#### Ticket Link
Fixes https://github.com/mattermost/mmctl/issues/248

