### PR TITLE
[MM-28592] add minimum tls version 1.2 check and a flag to ignore min required version

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -136,7 +136,8 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	allowInsecure := viper.GetBool("insecure-sha1-intermediate")
+	allowInsecureSHA1 := viper.GetBool("insecure-sha1-intermediate")
+	allowInsecureTLS := viper.GetBool("insecure-tls-version")
 
 	url := strings.TrimRight(args[0], "/")
 	method := MethodPassword
@@ -178,10 +179,10 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 		var c *model.Client4
 		var err error
 		if mfaToken != "" {
-			c, _, err = InitClientWithMFA(username, password, mfaToken, url, allowInsecure)
+			c, _, err = InitClientWithMFA(username, password, mfaToken, url, allowInsecureSHA1, allowInsecureTLS)
 			method = MethodMFA
 		} else {
-			c, _, err = InitClientWithUsernameAndPassword(username, password, url, allowInsecure)
+			c, _, err = InitClientWithUsernameAndPassword(username, password, url, allowInsecureSHA1, allowInsecureTLS)
 		}
 		if err != nil {
 			printer.PrintError(err.Error())
@@ -196,7 +197,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 			InstanceURL: url,
 			AuthToken:   accessToken,
 		}
-		if _, _, err := InitClientWithCredentials(&credentials, allowInsecure); err != nil {
+		if _, _, err := InitClientWithCredentials(&credentials, allowInsecureSHA1, allowInsecureTLS); err != nil {
 			printer.PrintError(err.Error())
 			// We don't want usage to be printed as the command was correctly built
 			return nil
@@ -305,7 +306,8 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 	password, _ := cmd.Flags().GetString("password")
 	accessToken, _ := cmd.Flags().GetString("access-token")
 	mfaToken, _ := cmd.Flags().GetString("mfa-token")
-	allowInsecure := viper.GetBool("insecure-sha1-intermediate")
+	allowInsecureSHA1 := viper.GetBool("insecure-sha1-intermediate")
+	allowInsecureTLS := viper.GetBool("insecure-tls-version")
 
 	credentials, err := GetCredentials(args[0])
 	if err != nil {
@@ -325,7 +327,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 
 	switch credentials.AuthMethod {
 	case MethodPassword:
-		c, _, err := InitClientWithUsernameAndPassword(credentials.Username, password, credentials.InstanceURL, allowInsecure)
+		c, _, err := InitClientWithUsernameAndPassword(credentials.Username, password, credentials.InstanceURL, allowInsecureSHA1, allowInsecureTLS)
 		if err != nil {
 			return err
 		}
@@ -338,7 +340,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 		}
 
 		credentials.AuthToken = accessToken
-		if _, _, err := InitClientWithCredentials(credentials, allowInsecure); err != nil {
+		if _, _, err := InitClientWithCredentials(credentials, allowInsecureSHA1, allowInsecureTLS); err != nil {
 			return err
 		}
 
@@ -347,7 +349,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 			return errors.New("requires the --mfa-token parameter to be set")
 		}
 
-		c, _, err := InitClientWithMFA(credentials.Username, password, mfaToken, credentials.InstanceURL, allowInsecure)
+		c, _, err := InitClientWithMFA(credentials.Username, password, mfaToken, credentials.InstanceURL, allowInsecureSHA1, allowInsecureTLS)
 		if err != nil {
 			return err
 		}

--- a/commands/init.go
+++ b/commands/init.go
@@ -48,7 +48,7 @@ func withClient(fn func(c client.Client, cmd *cobra.Command, args []string) erro
 			return fn(c, cmd, args)
 		}
 
-		c, serverVersion, err := InitClient(viper.GetBool("insecure-sha1-intermediate"))
+		c, serverVersion, err := InitClient(viper.GetBool("insecure-sha1-intermediate"), viper.GetBool("insecure-tls-version"))
 		if err != nil {
 			return err
 		}
@@ -103,27 +103,34 @@ func VerifyCertificates(rawCerts [][]byte, verifiedChains [][]*x509.Certificate)
 	return fmt.Errorf("insecure algorithm found in the certificate chain. Use --insecure-sha1-intermediate flag to ignore. Aborting")
 }
 
-func NewAPIv4Client(instanceURL string, allowInsecure bool) *model.Client4 {
+func NewAPIv4Client(instanceURL string, allowInsecureSHA1, allowInsecureTLS bool) *model.Client4 {
 	client := model.NewAPIv4Client(instanceURL)
 	userAgent := fmt.Sprintf("mmctl/%s (%s)", Version, runtime.GOOS)
 	client.HttpHeader = map[string]string{"User-Agent": userAgent}
 
-	if !allowInsecure {
-		transport := &http.Transport{
-			//nolint:gosec
-			TLSClientConfig: &tls.Config{
-				VerifyPeerCertificate: VerifyCertificates,
-			},
-		}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
-		client.HttpClient = &http.Client{Transport: transport}
+	if allowInsecureTLS {
+		tlsConfig.MinVersion = tls.VersionTLS10
+	}
+
+	if !allowInsecureSHA1 {
+		tlsConfig.VerifyPeerCertificate = VerifyCertificates
+	}
+
+	client.HttpClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
 	}
 
 	return client
 }
 
-func InitClientWithUsernameAndPassword(username, password, instanceURL string, allowInsecure bool) (*model.Client4, string, error) {
-	client := NewAPIv4Client(instanceURL, allowInsecure)
+func InitClientWithUsernameAndPassword(username, password, instanceURL string, allowInsecureSHA1, allowInsecureTLS bool) (*model.Client4, string, error) {
+	client := NewAPIv4Client(instanceURL, allowInsecureSHA1, allowInsecureTLS)
 
 	_, response := client.Login(username, password)
 	if response.Error != nil {
@@ -132,8 +139,8 @@ func InitClientWithUsernameAndPassword(username, password, instanceURL string, a
 	return client, response.ServerVersion, nil
 }
 
-func InitClientWithMFA(username, password, mfaToken, instanceURL string, allowInsecure bool) (*model.Client4, string, error) {
-	client := NewAPIv4Client(instanceURL, allowInsecure)
+func InitClientWithMFA(username, password, mfaToken, instanceURL string, allowInsecureSHA1, allowInsecureTLS bool) (*model.Client4, string, error) {
+	client := NewAPIv4Client(instanceURL, allowInsecureSHA1, allowInsecureTLS)
 	_, response := client.LoginWithMFA(username, password, mfaToken)
 	if response.Error != nil {
 		return nil, "", response.Error
@@ -141,26 +148,28 @@ func InitClientWithMFA(username, password, mfaToken, instanceURL string, allowIn
 	return client, response.ServerVersion, nil
 }
 
-func InitClientWithCredentials(credentials *Credentials, allowInsecure bool) (*model.Client4, string, error) {
-	client := NewAPIv4Client(credentials.InstanceURL, allowInsecure)
+func InitClientWithCredentials(credentials *Credentials, allowInsecureSHA1, allowInsecureTLS bool) (*model.Client4, string, error) {
+	client := NewAPIv4Client(credentials.InstanceURL, allowInsecureSHA1, allowInsecureTLS)
 
 	client.AuthType = model.HEADER_BEARER
 	client.AuthToken = credentials.AuthToken
 
 	_, response := client.GetMe("")
-	if response.Error != nil {
+	if response.Error != nil && strings.Contains(response.Error.DetailedError, "tls: protocol version not supported") && !allowInsecureTLS {
+		return nil, "", errors.New("won't perform action through an insecure TLS connection. Please add --insecure-tls-version to bypass this check")
+	} else if response.Error != nil {
 		return nil, "", response.Error
 	}
 
 	return client, response.ServerVersion, nil
 }
 
-func InitClient(allowInsecure bool) (*model.Client4, string, error) {
+func InitClient(allowInsecureSHA1, allowInsecureTLS bool) (*model.Client4, string, error) {
 	credentials, err := GetCurrentCredentials()
 	if err != nil {
 		return nil, "", err
 	}
-	return InitClientWithCredentials(credentials, allowInsecure)
+	return InitClientWithCredentials(credentials, allowInsecureSHA1, allowInsecureTLS)
 }
 
 func InitWebSocketClient() (*model.WebSocketClient, error) {

--- a/commands/root.go
+++ b/commands/root.go
@@ -29,6 +29,8 @@ func Run(args []string) error {
 	_ = viper.BindPFlag("strict", RootCmd.PersistentFlags().Lookup("strict"))
 	RootCmd.PersistentFlags().Bool("insecure-sha1-intermediate", false, "allows to use insecure TLS protocols, such as SHA-1")
 	_ = viper.BindPFlag("insecure-sha1-intermediate", RootCmd.PersistentFlags().Lookup("insecure-sha1-intermediate"))
+	RootCmd.PersistentFlags().Bool("insecure-tls-version", false, "allows to use TLS versions 1.0 and 1.1")
+	_ = viper.BindPFlag("insecure-tls-version", RootCmd.PersistentFlags().Lookup("insecure-tls-version"))
 	RootCmd.PersistentFlags().Bool("local", false, "allows communicating with the server through a unix socket")
 	_ = viper.BindPFlag("local", RootCmd.PersistentFlags().Lookup("local"))
 

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -20,6 +20,7 @@ Options
       --format string                the format of the command output [plain, json] (default "plain")
   -h, --help                         help for mmctl
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_auth.rst
+++ b/docs/mmctl_auth.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_auth_clean.rst
+++ b/docs/mmctl_auth_clean.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_auth_current.rst
+++ b/docs/mmctl_auth_current.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_auth_delete.rst
+++ b/docs/mmctl_auth_delete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_auth_list.rst
+++ b/docs/mmctl_auth_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_auth_login.rst
+++ b/docs/mmctl_auth_login.rst
@@ -46,6 +46,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_auth_renew.rst
+++ b/docs/mmctl_auth_renew.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_auth_set.rst
+++ b/docs/mmctl_auth_set.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_bot.rst
+++ b/docs/mmctl_bot.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_bot_assign.rst
+++ b/docs/mmctl_bot_assign.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_bot_create.rst
+++ b/docs/mmctl_bot_create.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_bot_disable.rst
+++ b/docs/mmctl_bot_disable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_bot_enable.rst
+++ b/docs/mmctl_bot_enable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_bot_list.rst
+++ b/docs/mmctl_bot_list.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_bot_update.rst
+++ b/docs/mmctl_bot_update.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel.rst
+++ b/docs/mmctl_channel.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_archive.rst
+++ b/docs/mmctl_channel_archive.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_create.rst
+++ b/docs/mmctl_channel_create.rst
@@ -44,6 +44,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_delete.rst
+++ b/docs/mmctl_channel_delete.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_list.rst
+++ b/docs/mmctl_channel_list.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_make_private.rst
+++ b/docs/mmctl_channel_make_private.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_modify.rst
+++ b/docs/mmctl_channel_modify.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_move.rst
+++ b/docs/mmctl_channel_move.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_rename.rst
+++ b/docs/mmctl_channel_rename.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_search.rst
+++ b/docs/mmctl_channel_search.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_unarchive.rst
+++ b/docs/mmctl_channel_unarchive.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_users.rst
+++ b/docs/mmctl_channel_users.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_users_add.rst
+++ b/docs/mmctl_channel_users_add.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_channel_users_remove.rst
+++ b/docs/mmctl_channel_users_remove.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_command.rst
+++ b/docs/mmctl_command.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_command_archive.rst
+++ b/docs/mmctl_command_archive.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_command_create.rst
+++ b/docs/mmctl_command_create.rst
@@ -48,6 +48,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_command_list.rst
+++ b/docs/mmctl_command_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_command_modify.rst
+++ b/docs/mmctl_command_modify.rst
@@ -48,6 +48,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_command_move.rst
+++ b/docs/mmctl_command_move.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_command_show.rst
+++ b/docs/mmctl_command_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_completion.rst
+++ b/docs/mmctl_completion.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_completion_bash.rst
+++ b/docs/mmctl_completion_bash.rst
@@ -35,6 +35,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_completion_zsh.rst
+++ b/docs/mmctl_completion_zsh.rst
@@ -35,6 +35,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config.rst
+++ b/docs/mmctl_config.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config_edit.rst
+++ b/docs/mmctl_config_edit.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config_get.rst
+++ b/docs/mmctl_config_get.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config_migrate.rst
+++ b/docs/mmctl_config_migrate.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config_reload.rst
+++ b/docs/mmctl_config_reload.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config_reset.rst
+++ b/docs/mmctl_config_reset.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config_set.rst
+++ b/docs/mmctl_config_set.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config_show.rst
+++ b/docs/mmctl_config_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_config_subpath.rst
+++ b/docs/mmctl_config_subpath.rst
@@ -46,6 +46,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_docs.rst
+++ b/docs/mmctl_docs.rst
@@ -31,6 +31,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group.rst
+++ b/docs/mmctl_group.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_channel.rst
+++ b/docs/mmctl_group_channel.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_channel_disable.rst
+++ b/docs/mmctl_group_channel_disable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_channel_enable.rst
+++ b/docs/mmctl_group_channel_enable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_channel_list.rst
+++ b/docs/mmctl_group_channel_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_channel_status.rst
+++ b/docs/mmctl_group_channel_status.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_list-ldap.rst
+++ b/docs/mmctl_group_list-ldap.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_team.rst
+++ b/docs/mmctl_group_team.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_team_disable.rst
+++ b/docs/mmctl_group_team_disable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_team_enable.rst
+++ b/docs/mmctl_group_team_enable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_team_list.rst
+++ b/docs/mmctl_group_team_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_group_team_status.rst
+++ b/docs/mmctl_group_team_status.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import.rst
+++ b/docs/mmctl_import.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import_job.rst
+++ b/docs/mmctl_import_job.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import_job_list.rst
+++ b/docs/mmctl_import_job_list.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import_job_show.rst
+++ b/docs/mmctl_import_job_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import_list.rst
+++ b/docs/mmctl_import_list.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import_list_available.rst
+++ b/docs/mmctl_import_list_available.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import_list_incomplete.rst
+++ b/docs/mmctl_import_list_incomplete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import_process.rst
+++ b/docs/mmctl_import_process.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_import_upload.rst
+++ b/docs/mmctl_import_upload.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_integrity.rst
+++ b/docs/mmctl_integrity.rst
@@ -32,6 +32,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_ldap.rst
+++ b/docs/mmctl_ldap.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_ldap_idmigrate.rst
+++ b/docs/mmctl_ldap_idmigrate.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_ldap_sync.rst
+++ b/docs/mmctl_ldap_sync.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_license.rst
+++ b/docs/mmctl_license.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_license_remove.rst
+++ b/docs/mmctl_license_remove.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_license_upload.rst
+++ b/docs/mmctl_license_upload.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_logs.rst
+++ b/docs/mmctl_logs.rst
@@ -32,6 +32,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_permissions.rst
+++ b/docs/mmctl_permissions.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_permissions_add.rst
+++ b/docs/mmctl_permissions_add.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_permissions_remove.rst
+++ b/docs/mmctl_permissions_remove.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_permissions_reset.rst
+++ b/docs/mmctl_permissions_reset.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_permissions_role.rst
+++ b/docs/mmctl_permissions_role.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_permissions_role_assign.rst
+++ b/docs/mmctl_permissions_role_assign.rst
@@ -43,6 +43,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_permissions_role_show.rst
+++ b/docs/mmctl_permissions_role_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_permissions_role_unassign.rst
+++ b/docs/mmctl_permissions_role_unassign.rst
@@ -43,6 +43,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin.rst
+++ b/docs/mmctl_plugin.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_add.rst
+++ b/docs/mmctl_plugin_add.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_delete.rst
+++ b/docs/mmctl_plugin_delete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_disable.rst
+++ b/docs/mmctl_plugin_disable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_enable.rst
+++ b/docs/mmctl_plugin_enable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_install-url.rst
+++ b/docs/mmctl_plugin_install-url.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_list.rst
+++ b/docs/mmctl_plugin_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_marketplace.rst
+++ b/docs/mmctl_plugin_marketplace.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_marketplace_install.rst
+++ b/docs/mmctl_plugin_marketplace_install.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_plugin_marketplace_list.rst
+++ b/docs/mmctl_plugin_marketplace_list.rst
@@ -52,6 +52,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_post.rst
+++ b/docs/mmctl_post.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_post_create.rst
+++ b/docs/mmctl_post_create.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_post_list.rst
+++ b/docs/mmctl_post_list.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_roles.rst
+++ b/docs/mmctl_roles.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_roles_member.rst
+++ b/docs/mmctl_roles_member.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_roles_system_admin.rst
+++ b/docs/mmctl_roles_system_admin.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_system.rst
+++ b/docs/mmctl_system.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_system_clearbusy.rst
+++ b/docs/mmctl_system_clearbusy.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_system_getbusy.rst
+++ b/docs/mmctl_system_getbusy.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_system_setbusy.rst
+++ b/docs/mmctl_system_setbusy.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_system_status.rst
+++ b/docs/mmctl_system_status.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_system_version.rst
+++ b/docs/mmctl_system_version.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team.rst
+++ b/docs/mmctl_team.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_archive.rst
+++ b/docs/mmctl_team_archive.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_create.rst
+++ b/docs/mmctl_team_create.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_delete.rst
+++ b/docs/mmctl_team_delete.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_list.rst
+++ b/docs/mmctl_team_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_modify.rst
+++ b/docs/mmctl_team_modify.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_rename.rst
+++ b/docs/mmctl_team_rename.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_restore.rst
+++ b/docs/mmctl_team_restore.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_search.rst
+++ b/docs/mmctl_team_search.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_users.rst
+++ b/docs/mmctl_team_users.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_users_add.rst
+++ b/docs/mmctl_team_users_add.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_team_users_remove.rst
+++ b/docs/mmctl_team_users_remove.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_token.rst
+++ b/docs/mmctl_token.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_token_generate.rst
+++ b/docs/mmctl_token_generate.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_token_list.rst
+++ b/docs/mmctl_token_list.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_token_revoke.rst
+++ b/docs/mmctl_token_revoke.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_activate.rst
+++ b/docs/mmctl_user_activate.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_change-password.rst
+++ b/docs/mmctl_user_change-password.rst
@@ -54,6 +54,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_convert.rst
+++ b/docs/mmctl_user_convert.rst
@@ -54,6 +54,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_create.rst
+++ b/docs/mmctl_user_create.rst
@@ -56,6 +56,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_deactivate.rst
+++ b/docs/mmctl_user_deactivate.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_delete.rst
+++ b/docs/mmctl_user_delete.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_deleteall.rst
+++ b/docs/mmctl_user_deleteall.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_email.rst
+++ b/docs/mmctl_user_email.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_invite.rst
+++ b/docs/mmctl_user_invite.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_list.rst
+++ b/docs/mmctl_user_list.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_migrate_auth.rst
+++ b/docs/mmctl_user_migrate_auth.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_reset_password.rst
+++ b/docs/mmctl_user_reset_password.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_resetmfa.rst
+++ b/docs/mmctl_user_resetmfa.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_search.rst
+++ b/docs/mmctl_user_search.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_user_verify.rst
+++ b/docs/mmctl_user_verify.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_version.rst
+++ b/docs/mmctl_version.rst
@@ -30,6 +30,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_webhook.rst
+++ b/docs/mmctl_webhook.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_webhook_create-incoming.rst
+++ b/docs/mmctl_webhook_create-incoming.rst
@@ -43,6 +43,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_webhook_create-outgoing.rst
+++ b/docs/mmctl_webhook_create-outgoing.rst
@@ -48,6 +48,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_webhook_delete.rst
+++ b/docs/mmctl_webhook_delete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_webhook_list.rst
+++ b/docs/mmctl_webhook_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_webhook_modify-incoming.rst
+++ b/docs/mmctl_webhook_modify-incoming.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_webhook_modify-outgoing.rst
+++ b/docs/mmctl_webhook_modify-outgoing.rst
@@ -45,6 +45,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_webhook_show.rst
+++ b/docs/mmctl_webhook_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/docs/mmctl_websocket.rst
+++ b/docs/mmctl_websocket.rst
@@ -30,6 +30,7 @@ Options inherited from parent commands
       --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
       --format string                the format of the command output [plain, json] (default "plain")
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --local                        allows communicating with the server through a unix socket
       --strict                       will only run commands if the mmctl version matches the server one
 

--- a/go.sum
+++ b/go.sum
@@ -510,8 +510,6 @@ github.com/mattermost/ldap v0.0.0-20191128190019-9f62ba4b8d4d h1:2DV7VIlEv6J5R5o
 github.com/mattermost/ldap v0.0.0-20191128190019-9f62ba4b8d4d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20201203103800-df906cad9d9f h1:30dc/sNNx5PvvsgVwt7fSNtI2pZENkryYw0WX9peE4s=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20201203103800-df906cad9d9f/go.mod h1:RPc/J9C/hGeXvzW4pTVOd15VJIvGUK5UQuIx+T2Df34=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20201204150807-d137cf0aa5b2 h1:lCEk+ktwowDmAMQIx0AyzPawXmt46Yp8Y2VE0oSiUTg=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20201204150807-d137cf0aa5b2/go.mod h1:RPc/J9C/hGeXvzW4pTVOd15VJIvGUK5UQuIx+T2Df34=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=


### PR DESCRIPTION

#### Summary
This PR sets minimum `TLS` version to `1.2` and allow to use insecure versions (i.e.  versions `1.0` and `1.1`) via `--insecure-tls-version` flag. In higher `go` versions, there is a `VerifyConnection` option for the `tls.Config` that can be used for several checks e.g. minimum TLS version requirement. We can consider to use it when we decide to bump supported compiler version.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28592
