### PR TITLE
Add examples to roles subcommands

### DIFF
--- a/commands/roles.go
+++ b/commands/roles.go
@@ -23,7 +23,7 @@ var RolesCmd = &cobra.Command{
 var RolesSystemAdminCmd = &cobra.Command{
 	Use:   "system_admin [users]",
 	Short: "Set a user as system admin",
-	Long:  "Make some users system admins",
+	Long:  "Make some users system admins.",
 	Example: `  # You can make one user a sysadmin
   $ mmctl roles system_admin john_doe
 

--- a/commands/roles.go
+++ b/commands/roles.go
@@ -17,25 +17,33 @@ import (
 
 var RolesCmd = &cobra.Command{
 	Use:   "roles",
-	Short: "Management of user roles",
+	Short: "Manage user roles",
 }
 
 var RolesSystemAdminCmd = &cobra.Command{
-	Use:     "system_admin [users]",
-	Short:   "Set a user as system admin",
-	Long:    "Make some users system admins",
-	Example: "  roles system_admin user1",
-	RunE:    withClient(rolesSystemAdminCmdF),
-	Args:    cobra.MinimumNArgs(1),
+	Use:   "system_admin [users]",
+	Short: "Set a user as system admin",
+	Long:  "Make some users system admins",
+	Example: `  # You can make one user a sysadmin
+  $ mmctl roles system_admin john_doe
+
+  # Or promote multiple users at the same time
+  $ mmctl roles system_admin john_doe jane_doe`,
+	RunE: withClient(rolesSystemAdminCmdF),
+	Args: cobra.MinimumNArgs(1),
 }
 
 var RolesMemberCmd = &cobra.Command{
-	Use:     "member [users]",
-	Short:   "Remove system admin privileges",
-	Long:    "Remove system admin privileges from some users.",
-	Example: "  roles member user1",
-	RunE:    withClient(rolesMemberCmdF),
-	Args:    cobra.MinimumNArgs(1),
+	Use:   "member [users]",
+	Short: "Remove system admin privileges",
+	Long:  "Remove system admin privileges from some users.",
+	Example: `  # You can remove admin privileges from one user
+  $ mmctl roles member john_doe
+
+  # Or demote multiple users at the same time
+  $ mmctl roles member john_doe jane_doe`,
+	RunE: withClient(rolesMemberCmdF),
+	Args: cobra.MinimumNArgs(1),
 }
 
 func init() {

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -43,7 +43,7 @@ SEE ALSO
 * `mmctl permissions <mmctl_permissions.rst>`_ 	 - Management of permissions
 * `mmctl plugin <mmctl_plugin.rst>`_ 	 - Management of plugins
 * `mmctl post <mmctl_post.rst>`_ 	 - Management of posts
-* `mmctl roles <mmctl_roles.rst>`_ 	 - Management of user roles
+* `mmctl roles <mmctl_roles.rst>`_ 	 - Manage user roles
 * `mmctl system <mmctl_system.rst>`_ 	 - System management
 * `mmctl team <mmctl_team.rst>`_ 	 - Management of teams
 * `mmctl token <mmctl_token.rst>`_ 	 - manage users' access tokens

--- a/docs/mmctl_roles.rst
+++ b/docs/mmctl_roles.rst
@@ -3,13 +3,13 @@
 mmctl roles
 -----------
 
-Management of user roles
+Manage user roles
 
 Synopsis
 ~~~~~~~~
 
 
-Management of user roles
+Manage user roles
 
 Options
 ~~~~~~~

--- a/docs/mmctl_roles_member.rst
+++ b/docs/mmctl_roles_member.rst
@@ -20,7 +20,11 @@ Examples
 
 ::
 
-    roles member user1
+    # You can remove admin privileges from one user
+    $ mmctl roles member john_doe
+
+    # Or demote multiple users at the same time
+    $ mmctl roles member john_doe jane_doe
 
 Options
 ~~~~~~~
@@ -44,5 +48,5 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl roles <mmctl_roles.rst>`_ 	 - Management of user roles
+* `mmctl roles <mmctl_roles.rst>`_ 	 - Manage user roles
 

--- a/docs/mmctl_roles_system_admin.rst
+++ b/docs/mmctl_roles_system_admin.rst
@@ -9,7 +9,7 @@ Synopsis
 ~~~~~~~~
 
 
-Make some users system admins
+Make some users system admins.
 
 ::
 

--- a/docs/mmctl_roles_system_admin.rst
+++ b/docs/mmctl_roles_system_admin.rst
@@ -20,7 +20,11 @@ Examples
 
 ::
 
-    roles system_admin user1
+    # You can make one user a sysadmin
+    $ mmctl roles system_admin john_doe
+
+    # Or promote multiple users at the same time
+    $ mmctl roles system_admin john_doe jane_doe
 
 Options
 ~~~~~~~
@@ -44,5 +48,5 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl roles <mmctl_roles.rst>`_ 	 - Management of user roles
+* `mmctl roles <mmctl_roles.rst>`_ 	 - Manage user roles
 


### PR DESCRIPTION
#### Summary

Adds examples with the new format to the `mmctl roles` subcommands.

##### roles system_admin

```
$ mmctl roles system_admin -h
Make some users system admins.

Usage:
  mmctl roles system_admin [users] [flags]

Examples:
  # You can make one user a sysadmin
  $ mmctl roles system_admin john_doe

  # Or promote multiple users at the same time
  $ mmctl roles system_admin john_doe jane_doe
```

##### roles member

```
$ mmctl roles member -h
Remove system admin privileges from some users.

Usage:
  mmctl roles member [users] [flags]

Examples:
  # You can remove admin privileges from one user
  $ mmctl roles member john_doe

  # Or demote multiple users at the same time
  $ mmctl roles member john_doe jane_doe
```