### PR TITLE
[GH-15945] Add end to end tests to the "pluginMarketplaceListCmdF" mmctl command

### DIFF
--- a/commands/plugin_marketplace_e2e_test.go
+++ b/commands/plugin_marketplace_e2e_test.go
@@ -141,3 +141,27 @@ func removePluginIfInstalled(s *MmctlE2ETestSuite, pluginID string) {
 		s.Require().Contains(appErr.Error(), "Plugin is not installed.")
 	}
 }
+
+func (s *MmctlE2ETestSuite) TestPluginMarketplaceListCmd() {
+	s.SetupTestHelper().InitBasic()
+
+	s.RunForSystemAdminAndLocal("List Marketplace Plugins for Admin User", func(c client.Client) {
+		printer.Clean()
+
+		err := pluginMarketplaceListCmdF(c, &cobra.Command{}, nil)
+
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.Run("List Marketplace Plugins for non-admin User", func() {
+		printer.Clean()
+
+		err := pluginMarketplaceListCmdF(s.th.Client, &cobra.Command{}, nil)
+
+		s.Require().NotNil(err)
+		s.Require().Contains(err.Error(), "You do not have the appropriate permissions.")
+		s.Require().Len(printer.GetErrorLines(), 0)
+		s.Require().Len(printer.GetLines(), 0)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/mattermost/mmctl
 go 1.13
 
 require (
-	github.com/blevesearch/zap/v15 v15.0.1
 	github.com/go-gorp/gorp v2.2.0+incompatible // indirect
 	github.com/golang/mock v1.3.1
 	github.com/magefile/mage v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mattermost/mmctl
 go 1.13
 
 require (
+	github.com/blevesearch/zap/v15 v15.0.1
 	github.com/go-gorp/gorp v2.2.0+incompatible // indirect
 	github.com/golang/mock v1.3.1
 	github.com/magefile/mage v1.9.0


### PR DESCRIPTION

#### Summary
<!--
This PR adds  end to end tests to the "pluginMarketplaceListCmdF" mmctl command
-->

#### Ticket Link


 Fixes https://github.com/mattermost/mattermost-server/issues/15945


