### PR TITLE
commands/group, commands/ldap: add e2e tests batch 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifneq ($(wildcard ${ENTERPRISE_DIR}/.*),)
 	IGNORE:=$(shell echo Enterprise build selected, preparing)
 	IGNORE:=$(shell rm -rf $(VENDOR_MM_SERVER_DIR)/enterprise)
 	IGNORE:=$(shell cp -R $(ENTERPRISE_DIR) $(VENDOR_MM_SERVER_DIR))
-	IGNORE:=$(shell git -C $(VENDOR_MM_SERVER_DIR)/enterprise checkout $(ENTERPRISE_HASH))
+	IGNORE:=$(shell git -C $(VENDOR_MM_SERVER_DIR)/enterprise checkout $(ENTERPRISE_HASH) --quiet)
 	IGNORE:=$(shell rm -f $(VENDOR_MM_SERVER_DIR)/imports/imports.go)
 	IGNORE:=$(shell cp $(VENDOR_MM_SERVER_DIR)/enterprise/imports/imports.go $(VENDOR_MM_SERVER_DIR)/imports/)
 endif

--- a/commands/group_e2e_test.go
+++ b/commands/group_e2e_test.go
@@ -164,7 +164,7 @@ func (s *MmctlE2ETestSuite) TestListLdapGroupsCmd() {
 	s.SetupEnterpriseTestHelper().InitBasic()
 	configForLdap(s.th)
 
-	s.Run("Should not allow regular user to list LDAP groups", func() {
+	s.Run("MM-T3977 Should not allow regular user to list LDAP groups", func() {
 		printer.Clean()
 
 		err := listLdapGroupsCmdF(s.th.Client, &cobra.Command{}, nil)
@@ -173,7 +173,7 @@ func (s *MmctlE2ETestSuite) TestListLdapGroupsCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForSystemAdminAndLocal("Should list LDAP groups", func(c client.Client) {
+	s.RunForSystemAdminAndLocal("MM-T3976 Should list LDAP groups", func(c client.Client) {
 		printer.Clean()
 
 		// we rely on the test data generated for the openldap server
@@ -215,7 +215,7 @@ func (s *MmctlE2ETestSuite) TestChannelGroupStatusCmd() {
 		s.Require().Nil(err)
 	}()
 
-	s.RunForAllClients("Should allow to get status of a group constrained channel", func(c client.Client) {
+	s.RunForAllClients("MM-T3974 Should allow to get status of a group constrained channel", func(c client.Client) {
 		printer.Clean()
 
 		err := channelGroupStatusCmdF(c, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName})
@@ -226,7 +226,7 @@ func (s *MmctlE2ETestSuite) TestChannelGroupStatusCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForAllClients("Should allow to get status of a regular channel", func(c client.Client) {
+	s.RunForAllClients("MM-T3975 Should allow to get status of a regular channel", func(c client.Client) {
 		printer.Clean()
 
 		err := channelGroupStatusCmdF(c, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName2})
@@ -279,7 +279,7 @@ func (s *MmctlE2ETestSuite) TestChannelGroupListCmd() {
 		s.Require().Nil(err)
 	}()
 
-	s.Run("Should not allow regular user to get list of LDAP groups in a channel", func() {
+	s.Run("MM-T3970 Should not allow regular user to get list of LDAP groups in a channel", func() {
 		printer.Clean()
 
 		err := channelGroupListCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName})
@@ -288,7 +288,7 @@ func (s *MmctlE2ETestSuite) TestChannelGroupListCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForSystemAdminAndLocal("Should allow to get list of LDAP groups in a channel", func(c client.Client) {
+	s.RunForSystemAdminAndLocal("MM-T3969 Should allow to get list of LDAP groups in a channel", func(c client.Client) {
 		printer.Clean()
 
 		err := channelGroupListCmdF(c, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName})

--- a/commands/group_e2e_test.go
+++ b/commands/group_e2e_test.go
@@ -159,3 +159,145 @@ func (s *MmctlE2ETestSuite) TestChannelGroupDisableCmd() {
 		s.Require().False(ch.IsGroupConstrained())
 	})
 }
+
+func (s *MmctlE2ETestSuite) TestListLdapGroupsCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+	configForLdap(s.th)
+
+	s.Run("Should not allow regular user to list LDAP groups", func() {
+		printer.Clean()
+
+		err := listLdapGroupsCmdF(s.th.Client, &cobra.Command{}, nil)
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Should list LDAP groups", func(c client.Client) {
+		printer.Clean()
+
+		// we rely on the test data generated for the openldap server
+		// i.e. "test-data.ldif" script
+		err := listLdapGroupsCmdF(c, &cobra.Command{}, nil)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(printer.GetLines())
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestChannelGroupStatusCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+
+	channelName := api4.GenerateTestChannelName()
+	channel, appErr := s.th.App.CreateChannel(&model.Channel{
+		TeamId:           s.th.BasicTeam.Id,
+		Name:             channelName,
+		DisplayName:      "dn_" + channelName,
+		Type:             model.CHANNEL_OPEN,
+		GroupConstrained: model.NewBool(true),
+	}, false)
+	s.Require().Nil(appErr)
+	defer func() {
+		err := s.th.App.DeleteChannel(channel, "")
+		s.Require().Nil(err)
+	}()
+
+	channelName2 := api4.GenerateTestChannelName()
+	channel2, appErr := s.th.App.CreateChannel(&model.Channel{
+		TeamId:      s.th.BasicTeam.Id,
+		Name:        channelName2,
+		DisplayName: "dn_" + channelName2,
+		Type:        model.CHANNEL_OPEN,
+	}, false)
+	s.Require().Nil(appErr)
+	defer func() {
+		err := s.th.App.DeleteChannel(channel2, "")
+		s.Require().Nil(err)
+	}()
+
+	s.RunForAllClients("Should allow to get status of a group constrained channel", func(c client.Client) {
+		printer.Clean()
+
+		err := channelGroupStatusCmdF(c, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName})
+		s.Require().NoError(err)
+
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Enabled")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForAllClients("Should allow to get status of a regular channel", func(c client.Client) {
+		printer.Clean()
+
+		err := channelGroupStatusCmdF(c, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName2})
+		s.Require().NoError(err)
+
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Disabled")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestChannelGroupListCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+
+	channelName := api4.GenerateTestChannelName()
+	channel, appErr := s.th.App.CreateChannel(&model.Channel{
+		TeamId:      s.th.BasicTeam.Id,
+		Name:        channelName,
+		DisplayName: "dn_" + channelName,
+		Type:        model.CHANNEL_OPEN,
+	}, false)
+	s.Require().Nil(appErr)
+	defer func() {
+		err := s.th.App.DeleteChannel(channel, "")
+		s.Require().Nil(err)
+	}()
+
+	id := model.NewId()
+	group, appErr := s.th.App.CreateGroup(&model.Group{
+		DisplayName: "dn_" + id,
+		Name:        model.NewString("name" + id),
+		Source:      model.GroupSourceLdap,
+		Description: "description_" + id,
+		RemoteId:    model.NewId(),
+	})
+	s.Require().Nil(appErr)
+	defer func() {
+		_, err := s.th.App.DeleteGroup(group.Id)
+		s.Require().Nil(err)
+	}()
+
+	_, appErr = s.th.App.UpsertGroupSyncable(&model.GroupSyncable{
+		GroupId:    group.Id,
+		SyncableId: channel.Id,
+		Type:       model.GroupSyncableTypeChannel,
+	})
+	s.Require().Nil(appErr)
+	defer func() {
+		_, err := s.th.App.DeleteGroupSyncable(group.Id, channel.Id, model.GroupSyncableTypeChannel)
+		s.Require().Nil(err)
+	}()
+
+	s.Run("Should not allow regular user to get list of LDAP groups in a channel", func() {
+		printer.Clean()
+
+		err := channelGroupListCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Should allow to get list of LDAP groups in a channel", func(c client.Client) {
+		printer.Clean()
+
+		err := channelGroupListCmdF(c, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName})
+		s.Require().NoError(err)
+
+		s.Require().Len(printer.GetLines(), 1)
+		gs, ok := printer.GetLines()[0].(*model.GroupWithSchemeAdmin)
+		s.Require().True(ok)
+		s.Require().Equal(gs.Group, *group)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/ldap_e2e_test.go
+++ b/commands/ldap_e2e_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"os"
+	"time"
+
+	"github.com/mattermost/mattermost-server/v5/api4"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/utils/testutils"
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/printer"
+)
+
+func configForLdap(th *api4.TestHelper) {
+	ldapHost := os.Getenv("CI_LDAP_HOST")
+	if ldapHost == "" {
+		ldapHost = testutils.GetInterface(*th.App.Config().LdapSettings.LdapPort)
+	}
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.EnableMultifactorAuthentication = true
+		*cfg.LdapSettings.Enable = true
+		*cfg.LdapSettings.EnableSync = true
+		*cfg.LdapSettings.LdapServer = "dockerhost"
+		*cfg.LdapSettings.BaseDN = "dc=mm,dc=test,dc=com"
+		*cfg.LdapSettings.LdapServer = ldapHost
+		*cfg.LdapSettings.BindUsername = "cn=admin,dc=mm,dc=test,dc=com"
+		*cfg.LdapSettings.BindPassword = "mostest"
+		*cfg.LdapSettings.FirstNameAttribute = "cn"
+		*cfg.LdapSettings.LastNameAttribute = "sn"
+		*cfg.LdapSettings.NicknameAttribute = "cn"
+		*cfg.LdapSettings.EmailAttribute = "mail"
+		*cfg.LdapSettings.UsernameAttribute = "uid"
+		*cfg.LdapSettings.IdAttribute = "cn"
+		*cfg.LdapSettings.LoginIdAttribute = "uid"
+		*cfg.LdapSettings.SkipCertificateVerification = true
+		*cfg.LdapSettings.GroupFilter = ""
+		*cfg.LdapSettings.GroupDisplayNameAttribute = "cN"
+		*cfg.LdapSettings.GroupIdAttribute = "entRyUuId"
+		*cfg.LdapSettings.MaxPageSize = 0
+	})
+
+	th.App.Srv().SetLicense(model.NewTestLicense("ldap"))
+}
+
+func (s *MmctlE2ETestSuite) TestLdapSyncCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+	configForLdap(s.th)
+
+	s.Run("Should not allow regular user to sync LDAP groups", func() {
+		printer.Clean()
+
+		err := ldapSyncCmdF(s.th.Client, &cobra.Command{}, nil)
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Should sync LDAP groups", func(c client.Client) {
+		printer.Clean()
+
+		jobs, appErr := s.th.App.GetJobsByTypePage(model.JOB_TYPE_LDAP_SYNC, 0, 100)
+		s.Require().Nil(appErr)
+		initialNumJobs := len(jobs)
+
+		err := ldapSyncCmdF(c, &cobra.Command{}, nil)
+		s.Require().NoError(err)
+
+		s.Require().NotEmpty(printer.GetLines())
+		s.Require().Equal(printer.GetLines()[0], map[string]interface{}{"status": "ok"})
+		s.Require().Len(printer.GetErrorLines(), 0)
+
+		// we need to wait a bit for job creation
+		time.Sleep(time.Second)
+
+		jobs, appErr = s.th.App.GetJobsByTypePage(model.JOB_TYPE_LDAP_SYNC, 0, 100)
+		s.Require().Nil(appErr)
+		s.Require().NotEmpty(jobs)
+		s.Assert().Greater(len(jobs), initialNumJobs)
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestLdapIDMigrateCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+	configForLdap(s.th)
+	s.th.App.UpdateConfig(func(cfg *model.Config) { *cfg.LdapSettings.IdAttribute = "uid" })
+
+	// use existing ldap user from the test-data.ldif script
+	// dn: uid=dev.one,ou=testusers,dc=mm,dc=test,dc=com
+	// cn: Dev1
+	// userPassword: Password1
+	ldapUser, appErr := s.th.App.AuthenticateUserForLogin("", "dev.one", "Password1", "", "", true)
+	s.Require().Nil(appErr)
+	s.Require().NotNil(ldapUser)
+	s.Require().Equal(model.USER_AUTH_SERVICE_LDAP, ldapUser.AuthService)
+	s.Require().Equal("dev.one", *ldapUser.AuthData)
+
+	s.Run("Should not allow regular user to migrate LDAP ID attribute", func() {
+		printer.Clean()
+
+		err := ldapIDMigrateCmdF(s.th.Client, &cobra.Command{}, []string{"objectGUID"})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Should migrate LDAP ID attribute", func(c client.Client) {
+		printer.Clean()
+
+		err := ldapIDMigrateCmdF(c, &cobra.Command{}, []string{"cn"})
+		s.Require().NoError(err)
+		defer func() {
+			s.Require().Nil(s.th.App.MigrateIdLDAP("uid"))
+		}()
+
+		s.Require().NotEmpty(printer.GetLines())
+		s.Require().Equal(printer.GetLines()[0], "AD/LDAP IdAttribute migration complete. You can now change your IdAttribute to: "+"cn")
+		s.Require().Len(printer.GetErrorLines(), 0)
+
+		updatedUser, appErr := s.th.App.GetUser(ldapUser.Id)
+		s.Require().Nil(appErr)
+		s.Require().Equal("Dev1", *updatedUser.AuthData)
+	})
+}

--- a/commands/ldap_e2e_test.go
+++ b/commands/ldap_e2e_test.go
@@ -81,7 +81,7 @@ func (s *MmctlE2ETestSuite) TestLdapSyncCmd() {
 		jobs, appErr = s.th.App.GetJobsByTypePage(model.JOB_TYPE_LDAP_SYNC, 0, 100)
 		s.Require().Nil(appErr)
 		s.Require().NotEmpty(jobs)
-		s.Assert().Greater(len(jobs), initialNumJobs)
+		s.Assert().Equal(initialNumJobs+1, len(jobs))
 	})
 }
 

--- a/commands/ldap_e2e_test.go
+++ b/commands/ldap_e2e_test.go
@@ -52,7 +52,7 @@ func (s *MmctlE2ETestSuite) TestLdapSyncCmd() {
 	s.SetupEnterpriseTestHelper().InitBasic()
 	configForLdap(s.th)
 
-	s.Run("Should not allow regular user to sync LDAP groups", func() {
+	s.Run("MM-T3971 Should not allow regular user to sync LDAP groups", func() {
 		printer.Clean()
 
 		err := ldapSyncCmdF(s.th.Client, &cobra.Command{}, nil)
@@ -61,7 +61,7 @@ func (s *MmctlE2ETestSuite) TestLdapSyncCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForSystemAdminAndLocal("Should sync LDAP groups", func(c client.Client) {
+	s.RunForSystemAdminAndLocal("MM-T2529 Should sync LDAP groups", func(c client.Client) {
 		printer.Clean()
 
 		jobs, appErr := s.th.App.GetJobsByTypePage(model.JOB_TYPE_LDAP_SYNC, 0, 100)
@@ -100,7 +100,7 @@ func (s *MmctlE2ETestSuite) TestLdapIDMigrateCmd() {
 	s.Require().Equal(model.USER_AUTH_SERVICE_LDAP, ldapUser.AuthService)
 	s.Require().Equal("dev.one", *ldapUser.AuthData)
 
-	s.Run("Should not allow regular user to migrate LDAP ID attribute", func() {
+	s.Run("MM-T3973 Should not allow regular user to migrate LDAP ID attribute", func() {
 		printer.Clean()
 
 		err := ldapIDMigrateCmdF(s.th.Client, &cobra.Command{}, []string{"objectGUID"})
@@ -109,7 +109,7 @@ func (s *MmctlE2ETestSuite) TestLdapIDMigrateCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForSystemAdminAndLocal("Should migrate LDAP ID attribute", func(c client.Client) {
+	s.RunForSystemAdminAndLocal("MM-T3972 Should migrate LDAP ID attribute", func(c client.Client) {
 		printer.Clean()
 
 		err := ldapIDMigrateCmdF(c, &cobra.Command{}, []string{"cn"})


### PR DESCRIPTION

#### Summary
Add e2e tests for:
- `listLdapGroupsCmdF`
- `channelGroupStatusCmdF`
- `channelGroupListCmdF`
- `ldapSyncCmdF`
- `ldapIDMigrateCmdF`


#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-30220
- https://mattermost.atlassian.net/browse/MM-30221
- https://mattermost.atlassian.net/browse/MM-30222
- https://mattermost.atlassian.net/browse/MM-30412
- https://mattermost.atlassian.net/browse/MM-30413

PS: will change base to `master` once we merge https://github.com/mattermost/mmctl/pull/310, alternatively we can merge to `enable_enterprise` branch.

