### PR TITLE
commands/group: add e2e tests batch 2

### DIFF
--- a/commands/group_e2e_test.go
+++ b/commands/group_e2e_test.go
@@ -312,7 +312,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupDisableCmd() {
 	_, err := s.th.App.UpdateTeam(team)
 	s.Require().Nil(err)
 
-	s.Run("Should not allow regular user to disable group for team", func() {
+	s.Run("MM-T3919 Should not allow regular user to disable group for team", func() {
 		printer.Clean()
 
 		err := teamGroupDisableCmdF(s.th.Client, &cobra.Command{}, []string{team.Name})
@@ -321,7 +321,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupDisableCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForSystemAdminAndLocal("Should disable group sync for the team", func(c client.Client) {
+	s.RunForSystemAdminAndLocal("MM-T3920 Should disable group sync for the team", func(c client.Client) {
 		printer.Clean()
 
 		err := teamGroupDisableCmdF(c, &cobra.Command{}, []string{team.Name})
@@ -348,7 +348,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupEnableCmd() {
 	team, _, cleanUpFn := createTestGroupTeam(s)
 	defer cleanUpFn()
 
-	s.Run("Should not allow regular user to enable group for team", func() {
+	s.Run("MM-T3917 Should not allow regular user to enable group for team", func() {
 		printer.Clean()
 
 		err := teamGroupEnableCmdF(s.th.Client, &cobra.Command{}, []string{team.Name})
@@ -357,7 +357,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupEnableCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForSystemAdminAndLocal("Should enable group sync for the team", func(c client.Client) {
+	s.RunForSystemAdminAndLocal("MM-T3918 Should enable group sync for the team", func(c client.Client) {
 		printer.Clean()
 
 		err := teamGroupEnableCmdF(c, &cobra.Command{}, []string{team.Name})
@@ -398,7 +398,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupStatusCmd() {
 		s.Require().Nil(err)
 	}()
 
-	s.Run("Should not allow regular user to get status of LDAP groups in a team where they are not a member of", func() {
+	s.Run("MM-T3921 Should not allow regular user to get status of LDAP groups in a team where they are not a member of", func() {
 		printer.Clean()
 
 		err := teamGroupStatusCmdF(s.th.Client, &cobra.Command{}, []string{team.Name})
@@ -413,7 +413,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupStatusCmd() {
 	_, appErr = s.th.App.AddUserToTeam(team2.Id, s.th.BasicUser.Id, s.th.SystemAdminUser.Id)
 	s.Require().Nil(appErr)
 
-	s.RunForAllClients("Should allow to get status of a group constrained team", func(c client.Client) {
+	s.RunForAllClients("MM-T3922 Should allow to get status of a group constrained team", func(c client.Client) {
 		printer.Clean()
 
 		err := teamGroupStatusCmdF(c, &cobra.Command{}, []string{team.Name})
@@ -424,7 +424,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupStatusCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForAllClients("Should allow to get status of a regular team", func(c client.Client) {
+	s.RunForAllClients("MM-T3923 Should allow to get status of a regular team", func(c client.Client) {
 		printer.Clean()
 
 		err := teamGroupStatusCmdF(c, &cobra.Command{}, []string{teamName2})
@@ -444,7 +444,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupListCmd() {
 		cleanUpFn()
 	}()
 
-	s.Run("Should not allow regular user to get list of LDAP groups in a team", func() {
+	s.Run("MM-T3924 Should not allow regular user to get list of LDAP groups in a team", func() {
 		printer.Clean()
 
 		err := teamGroupListCmdF(s.th.Client, &cobra.Command{}, []string{team.Name})
@@ -453,7 +453,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupListCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
-	s.RunForSystemAdminAndLocal("Should allow to get list of LDAP groups in a team", func(c client.Client) {
+	s.RunForSystemAdminAndLocal("MM-T3925 Should allow to get list of LDAP groups in a team", func(c client.Client) {
 		printer.Clean()
 
 		err := teamGroupListCmdF(c, &cobra.Command{}, []string{team.Name})

--- a/commands/group_e2e_test.go
+++ b/commands/group_e2e_test.go
@@ -133,7 +133,7 @@ func (s *MmctlE2ETestSuite) TestChannelGroupDisableCmd() {
 	s.Run("Should not allow regular user to disable group for channel", func() {
 		printer.Clean()
 
-		err := channelGroupEnableCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName})
+		err := channelGroupDisableCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicTeam.Name + ":" + channelName})
 		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 0)
@@ -302,7 +302,7 @@ func (s *MmctlE2ETestSuite) TestChannelGroupListCmd() {
 	})
 }
 
-func (s *MmctlE2ETestSuite) TestTeamGroupEnableCmd() {
+func (s *MmctlE2ETestSuite) TestTeamGroupDisableCmd() {
 	s.SetupEnterpriseTestHelper().InitBasic()
 
 	team, _, cleanUpFn := createTestGroupTeam(s)
@@ -342,7 +342,7 @@ func (s *MmctlE2ETestSuite) TestTeamGroupEnableCmd() {
 	})
 }
 
-func (s *MmctlE2ETestSuite) TestTeamGroupDisableCmd() {
+func (s *MmctlE2ETestSuite) TestTeamGroupEnableCmd() {
 	s.SetupEnterpriseTestHelper().InitBasic()
 
 	team, _, cleanUpFn := createTestGroupTeam(s)

--- a/commands/group_e2e_test.go
+++ b/commands/group_e2e_test.go
@@ -301,3 +301,209 @@ func (s *MmctlE2ETestSuite) TestChannelGroupListCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 }
+
+func (s *MmctlE2ETestSuite) TestTeamGroupEnableCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+
+	team, _, cleanUpFn := createTestGroupTeam(s)
+	defer cleanUpFn()
+
+	team.GroupConstrained = model.NewBool(true)
+	_, err := s.th.App.UpdateTeam(team)
+	s.Require().Nil(err)
+
+	s.Run("Should not allow regular user to disable group for team", func() {
+		printer.Clean()
+
+		err := teamGroupDisableCmdF(s.th.Client, &cobra.Command{}, []string{team.Name})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Should disable group sync for the team", func(c client.Client) {
+		printer.Clean()
+
+		err := teamGroupDisableCmdF(c, &cobra.Command{}, []string{team.Name})
+		s.Require().NoError(err)
+
+		team.GroupConstrained = model.NewBool(true)
+		defer func() {
+			_, err := s.th.App.UpdateTeam(team)
+			s.Require().Nil(err)
+		}()
+
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+
+		tm, appErr := s.th.App.GetTeam(team.Id)
+		s.Require().Nil(appErr)
+		s.Require().False(tm.IsGroupConstrained())
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestTeamGroupDisableCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+
+	team, _, cleanUpFn := createTestGroupTeam(s)
+	defer cleanUpFn()
+
+	s.Run("Should not allow regular user to enable group for team", func() {
+		printer.Clean()
+
+		err := teamGroupEnableCmdF(s.th.Client, &cobra.Command{}, []string{team.Name})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Should enable group sync for the team", func(c client.Client) {
+		printer.Clean()
+
+		err := teamGroupEnableCmdF(c, &cobra.Command{}, []string{team.Name})
+		s.Require().NoError(err)
+
+		team.GroupConstrained = model.NewBool(false)
+		defer func() {
+			_, err := s.th.App.UpdateTeam(team)
+			s.Require().Nil(err)
+		}()
+
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+
+		tm, appErr := s.th.App.GetTeam(team.Id)
+		s.Require().Nil(appErr)
+		s.Require().True(tm.IsGroupConstrained())
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestTeamGroupStatusCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+
+	team, _, cleanUpFn := createTestGroupTeam(s)
+	defer func() {
+		cleanUpFn()
+	}()
+
+	teamName2 := api4.GenerateTestTeamName()
+	team2, appErr := s.th.App.CreateTeam(&model.Team{
+		Name:        teamName2,
+		DisplayName: "dn_" + teamName2,
+		Type:        model.TEAM_INVITE,
+	})
+	s.Require().Nil(appErr)
+	defer func() {
+		err := s.th.App.PermanentDeleteTeam(team2)
+		s.Require().Nil(err)
+	}()
+
+	s.Run("Should not allow regular user to get status of LDAP groups in a team where they are not a member of", func() {
+		printer.Clean()
+
+		err := teamGroupStatusCmdF(s.th.Client, &cobra.Command{}, []string{team.Name})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	_, appErr = s.th.App.AddUserToTeam(team.Id, s.th.BasicUser.Id, s.th.SystemAdminUser.Id)
+	s.Require().Nil(appErr)
+
+	_, appErr = s.th.App.AddUserToTeam(team2.Id, s.th.BasicUser.Id, s.th.SystemAdminUser.Id)
+	s.Require().Nil(appErr)
+
+	s.RunForAllClients("Should allow to get status of a group constrained team", func(c client.Client) {
+		printer.Clean()
+
+		err := teamGroupStatusCmdF(c, &cobra.Command{}, []string{team.Name})
+		s.Require().NoError(err)
+
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Enabled")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForAllClients("Should allow to get status of a regular team", func(c client.Client) {
+		printer.Clean()
+
+		err := teamGroupStatusCmdF(c, &cobra.Command{}, []string{teamName2})
+		s.Require().NoError(err)
+
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Disabled")
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestTeamGroupListCmd() {
+	s.SetupEnterpriseTestHelper().InitBasic()
+
+	team, group, cleanUpFn := createTestGroupTeam(s)
+	defer func() {
+		cleanUpFn()
+	}()
+
+	s.Run("Should not allow regular user to get list of LDAP groups in a team", func() {
+		printer.Clean()
+
+		err := teamGroupListCmdF(s.th.Client, &cobra.Command{}, []string{team.Name})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
+	s.RunForSystemAdminAndLocal("Should allow to get list of LDAP groups in a team", func(c client.Client) {
+		printer.Clean()
+
+		err := teamGroupListCmdF(c, &cobra.Command{}, []string{team.Name})
+		s.Require().NoError(err)
+
+		s.Require().Len(printer.GetLines(), 1)
+		gs, ok := printer.GetLines()[0].(*model.GroupWithSchemeAdmin)
+		s.Require().True(ok)
+		s.Require().Equal(gs.Group, *group)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}
+
+func createTestGroupTeam(s *MmctlE2ETestSuite) (*model.Team, *model.Group, func()) {
+	teamName := api4.GenerateTestTeamName()
+	team, appErr := s.th.App.CreateTeam(&model.Team{
+		Name:             teamName,
+		DisplayName:      "dn_" + teamName,
+		Type:             model.TEAM_OPEN,
+		GroupConstrained: model.NewBool(true),
+	})
+	s.Require().Nil(appErr)
+
+	id := model.NewId()
+	group, appErr := s.th.App.CreateGroup(&model.Group{
+		DisplayName: "dn_" + id,
+		Name:        model.NewString("name" + id),
+		Source:      model.GroupSourceLdap,
+		Description: "description_" + id,
+		RemoteId:    model.NewId(),
+	})
+	s.Require().Nil(appErr)
+
+	_, appErr = s.th.App.UpsertGroupSyncable(&model.GroupSyncable{
+		GroupId:    group.Id,
+		SyncableId: team.Id,
+		Type:       model.GroupSyncableTypeTeam,
+	})
+	s.Require().Nil(appErr)
+
+	cleanUpFn := func() {
+		_, err := s.th.App.DeleteGroupSyncable(group.Id, team.Id, model.GroupSyncableTypeTeam)
+		s.Require().Nil(err)
+
+		_, err = s.th.App.DeleteGroup(group.Id)
+		s.Require().Nil(err)
+
+		err = s.th.App.PermanentDeleteTeamId(team.Id)
+		s.Require().Nil(err)
+	}
+
+	return team, group, cleanUpFn
+}


### PR DESCRIPTION

#### Summary
Add e2e tests for:
- `teamGroupEnableCmdF`
- `teamGroupDisableCmdF`
- `teamGroupStatusCmdF`
- `teamGroupListCmdF`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31414
https://mattermost.atlassian.net/browse/MM-31415
https://mattermost.atlassian.net/browse/MM-31416
https://mattermost.atlassian.net/browse/MM-31417
