### PR TITLE
[MM-32044] Reset SAML auth data

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -141,4 +141,5 @@ type Client interface {
 	ListExports() ([]string, *model.Response)
 	DeleteExport(name string) (bool, *model.Response)
 	DownloadExport(name string, wr io.Writer, offset int64) (int64, *model.Response)
+	ResetSamlAuthDataToEmail(includeDeleted bool, dryRun bool, userIDs []string) (int64, *model.Response)
 }

--- a/commands/saml.go
+++ b/commands/saml.go
@@ -22,13 +22,13 @@ var SamlAuthDataResetCmd = &cobra.Command{
 	Short: "Reset AuthData field to Email",
 	Long:  "Resets the AuthData field for SAML users to their email. Run this utility after setting the 'id' SAML attribute to an empty value.",
 	Example: `  # Reset all SAML users' AuthData field to their email, including deleted users
-$ mmctl saml reset-auth-data --include-deleted
+  $ mmctl saml reset-auth-data --include-deleted
 
-# Show how many users would be affected by the reset
-$ mmctl saml reset-auth-data --dry-run
+  # Show how many users would be affected by the reset
+  $ mmctl saml reset-auth-data --dry-run
 
-# Only reset the AuthData for the following SAML users
-$ mmctl saml reset-auth-data --users userid1,userid2`,
+  # Only reset the AuthData for the following SAML users
+  $ mmctl saml reset-auth-data --users userid1,userid2`,
 	RunE: withClient(samlAuthDataResetCmdF),
 }
 

--- a/commands/saml.go
+++ b/commands/saml.go
@@ -17,20 +17,27 @@ var SamlCmd = &cobra.Command{
 	Short: "SAML related utilities",
 }
 
-var SamlAuthDataReset = &cobra.Command{
-	Use:     "authdatareset",
-	Short:   "Reset AuthData field to Email",
-	Long:    "Resets the AuthData field for SAML users to their email. Run this utility after setting the 'id' SAML attribute to an empty value.",
-	Example: " saml authdatamigrate",
-	RunE:    withClient(samlAuthDataResetCmdF),
+var SamlAuthDataResetCmd = &cobra.Command{
+	Use:   "auth-data-reset",
+	Short: "Reset AuthData field to Email",
+	Long:  "Resets the AuthData field for SAML users to their email. Run this utility after setting the 'id' SAML attribute to an empty value.",
+	Example: `  # Reset all SAML users' AuthData field to their email, including deleted users
+$ mmctl saml reset-auth-data --include-deleted
+
+# Show how many users would be affected by the reset
+$ mmctl saml reset-auth-data --dry-run
+
+# Only reset the AuthData for the following SAML users
+$ mmctl saml reset-auth-data --users userid1,userid2`,
+	RunE: withClient(samlAuthDataResetCmdF),
 }
 
 func init() {
-	SamlAuthDataReset.Flags().Bool("include-deleted", false, "Include deleted users")
-	SamlAuthDataReset.Flags().Bool("dry-run", false, "Dry run only")
-	SamlAuthDataReset.Flags().StringSlice("users", nil, "Comma-separated list of user IDs to which the operation will be applied")
+	SamlAuthDataResetCmd.Flags().Bool("include-deleted", false, "Include deleted users")
+	SamlAuthDataResetCmd.Flags().Bool("dry-run", false, "Dry run only")
+	SamlAuthDataResetCmd.Flags().StringSlice("users", nil, "Comma-separated list of user IDs to which the operation will be applied")
 	SamlCmd.AddCommand(
-		SamlAuthDataReset,
+		SamlAuthDataResetCmd,
 	)
 	RootCmd.AddCommand(SamlCmd)
 }

--- a/commands/saml.go
+++ b/commands/saml.go
@@ -36,6 +36,7 @@ func init() {
 	SamlAuthDataResetCmd.Flags().Bool("include-deleted", false, "Include deleted users")
 	SamlAuthDataResetCmd.Flags().Bool("dry-run", false, "Dry run only")
 	SamlAuthDataResetCmd.Flags().StringSlice("users", nil, "Comma-separated list of user IDs to which the operation will be applied")
+
 	SamlCmd.AddCommand(
 		SamlAuthDataResetCmd,
 	)

--- a/commands/saml.go
+++ b/commands/saml.go
@@ -77,12 +77,12 @@ func samlAuthDataResetCmdF(c client.Client, cmd *cobra.Command, args []string) e
 
 func getSamlAuthDataResetConfirmation() error {
 	var confirm string
-	fmt.Println("This action is irreversible. Are you sure you want to continue? [Y/n] ")
+	fmt.Print("This action is irreversible. Are you sure you want to continue? [Y/n] ")
 	fmt.Scanln(&confirm)
 	confirm = strings.ToLower(confirm)
 
 	if confirm == "y" || confirm == "yes" {
 		return nil
 	}
-	return errors.New("Abort.")
+	return errors.New("aborted")
 }

--- a/commands/saml.go
+++ b/commands/saml.go
@@ -6,10 +6,10 @@ package commands
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	"github.com/mattermost/mmctl/client"
 	"github.com/mattermost/mmctl/printer"
+
+	"github.com/spf13/cobra"
 )
 
 var SamlCmd = &cobra.Command{
@@ -18,11 +18,10 @@ var SamlCmd = &cobra.Command{
 }
 
 var SamlAuthDataReset = &cobra.Command{
-	Use:     "authdatamigrate",
+	Use:     "authdatareset",
 	Short:   "Reset AuthData field to Email",
 	Long:    "Resets the AuthData field for SAML users to their email. Run this utility after setting the 'id' SAML attribute to an empty value.",
 	Example: " saml authdatamigrate",
-	Args:    cobra.ExactArgs(1),
 	RunE:    withClient(samlAuthDataResetCmdF),
 }
 

--- a/commands/saml.go
+++ b/commands/saml.go
@@ -22,13 +22,13 @@ var SamlAuthDataResetCmd = &cobra.Command{
 	Short: "Reset AuthData field to Email",
 	Long:  "Resets the AuthData field for SAML users to their email. Run this utility after setting the 'id' SAML attribute to an empty value.",
 	Example: `  # Reset all SAML users' AuthData field to their email, including deleted users
-  $ mmctl saml reset-auth-data --include-deleted
+  $ mmctl saml auth-data-reset --include-deleted
 
   # Show how many users would be affected by the reset
-  $ mmctl saml reset-auth-data --dry-run
+  $ mmctl saml auth-data-reset --dry-run
 
   # Only reset the AuthData for the following SAML users
-  $ mmctl saml reset-auth-data --users userid1,userid2`,
+  $ mmctl saml auth-data-reset --users userid1,userid2`,
 	RunE: withClient(samlAuthDataResetCmdF),
 }
 

--- a/commands/saml.go
+++ b/commands/saml.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/printer"
+)
+
+var SamlCmd = &cobra.Command{
+	Use:   "saml",
+	Short: "SAML related utilities",
+}
+
+var SamlAuthDataReset = &cobra.Command{
+	Use:     "authdatamigrate",
+	Short:   "Reset AuthData field to Email",
+	Long:    "Resets the AuthData field for SAML users to their email. Run this utility after setting the 'id' SAML attribute to an empty value.",
+	Example: " saml authdatamigrate",
+	Args:    cobra.ExactArgs(1),
+	RunE:    withClient(samlAuthDataResetCmdF),
+}
+
+func init() {
+	SamlAuthDataReset.Flags().Bool("include-deleted", false, "Include deleted users")
+	SamlAuthDataReset.Flags().Bool("dry-run", false, "Dry run only")
+	SamlAuthDataReset.Flags().StringSlice("users", nil, "Comma-separated list of user IDs to which the operation will be applied")
+	SamlCmd.AddCommand(
+		SamlAuthDataReset,
+	)
+	RootCmd.AddCommand(SamlCmd)
+}
+
+func samlAuthDataResetCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	includeDeleted, _ := cmd.Flags().GetBool("include-deleted")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	userIDs, _ := cmd.Flags().GetStringSlice("users")
+
+	numAffected, response := c.ResetSamlAuthDataToEmail(includeDeleted, dryRun, userIDs)
+	if response.Error != nil {
+		return response.Error
+	}
+
+	if dryRun {
+		printer.Print(fmt.Sprintf("%d user records would be affected.\n", numAffected))
+	} else {
+		printer.Print(fmt.Sprintf("%d user records were changed.\n", numAffected))
+	}
+
+	return nil
+}

--- a/commands/saml_test.go
+++ b/commands/saml_test.go
@@ -45,4 +45,19 @@ func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
 		s.Require().Equal(printer.GetLines()[0], outputMessage)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
+	s.Run("Reset auth data with specified users", func() {
+		printer.Clean()
+		users := []string{"user1"}
+		s.client.
+			EXPECT().
+			ResetSamlAuthDataToEmail(false, false, users).
+			Return(int64(1), &model.Response{Error: nil})
+
+		cmd := &cobra.Command{}
+		cmd.Flags().StringSlice("users", users, "")
+
+		err := samlAuthDataResetCmdF(s.client, cmd, nil)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
 }

--- a/commands/saml_test.go
+++ b/commands/saml_test.go
@@ -16,7 +16,7 @@ func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
 		cmd := &cobra.Command{}
 		err := samlAuthDataResetCmdF(s.client, cmd, nil)
 		s.Require().NotNil(err)
-		s.Require().EqualError(err, "Abort.")
+		s.Require().EqualError(err, "aborted")
 	})
 
 	s.Run("Reset auth data without errors", func() {

--- a/commands/saml_test.go
+++ b/commands/saml_test.go
@@ -19,7 +19,8 @@ func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
 		s.client.
 			EXPECT().
 			ResetSamlAuthDataToEmail(false, false, []string{}).
-			Return(int64(1), &model.Response{Error: nil})
+			Return(int64(1), &model.Response{Error: nil}).
+			Times(1)
 
 		err := samlAuthDataResetCmdF(s.client, &cobra.Command{}, nil)
 		s.Require().Nil(err)
@@ -27,6 +28,7 @@ func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
 		s.Require().Equal(printer.GetLines()[0], outputMessage)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
+
 	s.Run("Reset auth data dry run", func() {
 		printer.Clean()
 		outputMessage := "1 user records would be affected.\n"
@@ -37,7 +39,8 @@ func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
 		s.client.
 			EXPECT().
 			ResetSamlAuthDataToEmail(false, true, []string{}).
-			Return(int64(1), &model.Response{Error: nil})
+			Return(int64(1), &model.Response{Error: nil}).
+			Times(1)
 
 		err := samlAuthDataResetCmdF(s.client, cmd, nil)
 		s.Require().Nil(err)
@@ -45,13 +48,15 @@ func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
 		s.Require().Equal(printer.GetLines()[0], outputMessage)
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
+
 	s.Run("Reset auth data with specified users", func() {
 		printer.Clean()
 		users := []string{"user1"}
 		s.client.
 			EXPECT().
 			ResetSamlAuthDataToEmail(false, false, users).
-			Return(int64(1), &model.Response{Error: nil})
+			Return(int64(1), &model.Response{Error: nil}).
+			Times(1)
 
 		cmd := &cobra.Command{}
 		cmd.Flags().StringSlice("users", users, "")

--- a/commands/saml_test.go
+++ b/commands/saml_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mmctl/printer"
+
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
+	s.Run("Reset auth data without errors", func() {
+		printer.Clean()
+		outputMessage := "1 user records were changed.\n"
+
+		s.client.
+			EXPECT().
+			ResetSamlAuthDataToEmail(false, false, []string{}).
+			Return(int64(1), &model.Response{Error: nil})
+
+		err := samlAuthDataResetCmdF(s.client, &cobra.Command{}, nil)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], outputMessage)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+	s.Run("Reset auth data dry run", func() {
+		printer.Clean()
+		outputMessage := "1 user records would be affected.\n"
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("dry-run", true, "")
+
+		s.client.
+			EXPECT().
+			ResetSamlAuthDataToEmail(false, true, []string{}).
+			Return(int64(1), &model.Response{Error: nil})
+
+		err := samlAuthDataResetCmdF(s.client, cmd, nil)
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], outputMessage)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+}

--- a/commands/saml_test.go
+++ b/commands/saml_test.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"github.com/mattermost/mattermost-server/v5/model"
+
 	"github.com/mattermost/mmctl/printer"
 
 	"github.com/spf13/cobra"

--- a/commands/saml_test.go
+++ b/commands/saml_test.go
@@ -12,8 +12,17 @@ import (
 )
 
 func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
+	s.Run("Reset auth data without confirmation returns an error", func() {
+		cmd := &cobra.Command{}
+		err := samlAuthDataResetCmdF(s.client, cmd, nil)
+		s.Require().NotNil(err)
+		s.Require().EqualError(err, "Abort.")
+	})
+
 	s.Run("Reset auth data without errors", func() {
 		printer.Clean()
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("yes", true, "")
 		outputMessage := "1 user records were changed.\n"
 
 		s.client.
@@ -22,7 +31,7 @@ func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
 			Return(int64(1), &model.Response{Error: nil}).
 			Times(1)
 
-		err := samlAuthDataResetCmdF(s.client, &cobra.Command{}, nil)
+		err := samlAuthDataResetCmdF(s.client, cmd, nil)
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Equal(printer.GetLines()[0], outputMessage)
@@ -59,6 +68,7 @@ func (s *MmctlUnitTestSuite) TestSamlAuthDataReset() {
 			Times(1)
 
 		cmd := &cobra.Command{}
+		cmd.Flags().Bool("yes", true, "")
 		cmd.Flags().StringSlice("users", users, "")
 
 		err := samlAuthDataResetCmdF(s.client, cmd, nil)

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -45,6 +45,7 @@ SEE ALSO
 * `mmctl plugin <mmctl_plugin.rst>`_ 	 - Management of plugins
 * `mmctl post <mmctl_post.rst>`_ 	 - Management of posts
 * `mmctl roles <mmctl_roles.rst>`_ 	 - Manage user roles
+* `mmctl saml <mmctl_saml.rst>`_ 	 - SAML related utilities
 * `mmctl system <mmctl_system.rst>`_ 	 - System management
 * `mmctl team <mmctl_team.rst>`_ 	 - Management of teams
 * `mmctl token <mmctl_token.rst>`_ 	 - manage users' access tokens

--- a/docs/mmctl_saml.rst
+++ b/docs/mmctl_saml.rst
@@ -1,0 +1,38 @@
+.. _mmctl_saml:
+
+mmctl saml
+----------
+
+SAML related utilities
+
+Synopsis
+~~~~~~~~
+
+
+SAML related utilities
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for saml
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+      --local                        allows communicating with the server through a unix socket
+      --strict                       will only run commands if the mmctl version matches the server one
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
+* `mmctl saml authdatareset <mmctl_saml_authdatareset.rst>`_ 	 - Reset AuthData field to Email
+

--- a/docs/mmctl_saml.rst
+++ b/docs/mmctl_saml.rst
@@ -34,5 +34,5 @@ SEE ALSO
 ~~~~~~~~
 
 * `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
-* `mmctl saml authdatareset <mmctl_saml_authdatareset.rst>`_ 	 - Reset AuthData field to Email
+* `mmctl saml auth-data-reset <mmctl_saml_auth-data-reset.rst>`_ 	 - Reset AuthData field to Email
 

--- a/docs/mmctl_saml_auth-data-reset.rst
+++ b/docs/mmctl_saml_auth-data-reset.rst
@@ -26,6 +26,9 @@ Examples
     # Show how many users would be affected by the reset
     $ mmctl saml auth-data-reset --dry-run
 
+    # Skip confirmation for resetting the AuthData
+    $ mmctl saml auth-data-reset -y
+
     # Only reset the AuthData for the following SAML users
     $ mmctl saml auth-data-reset --users userid1,userid2
 
@@ -38,6 +41,7 @@ Options
   -h, --help              help for auth-data-reset
       --include-deleted   Include deleted users
       --users strings     Comma-separated list of user IDs to which the operation will be applied
+  -y, --yes               Skip confirmation
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/mmctl_saml_auth-data-reset.rst
+++ b/docs/mmctl_saml_auth-data-reset.rst
@@ -1,7 +1,7 @@
-.. _mmctl_saml_authdatareset:
+.. _mmctl_saml_auth-data-reset:
 
-mmctl saml authdatareset
-------------------------
+mmctl saml auth-data-reset
+--------------------------
 
 Reset AuthData field to Email
 
@@ -13,14 +13,21 @@ Resets the AuthData field for SAML users to their email. Run this utility after 
 
 ::
 
-  mmctl saml authdatareset [flags]
+  mmctl saml auth-data-reset [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-   saml authdatamigrate
+    # Reset all SAML users' AuthData field to their email, including deleted users
+    $ mmctl saml auth-data-reset --include-deleted
+
+    # Show how many users would be affected by the reset
+    $ mmctl saml auth-data-reset --dry-run
+
+    # Only reset the AuthData for the following SAML users
+    $ mmctl saml auth-data-reset --users userid1,userid2
 
 Options
 ~~~~~~~
@@ -28,7 +35,7 @@ Options
 ::
 
       --dry-run           Dry run only
-  -h, --help              help for authdatareset
+  -h, --help              help for auth-data-reset
       --include-deleted   Include deleted users
       --users strings     Comma-separated list of user IDs to which the operation will be applied
 

--- a/docs/mmctl_saml_authdatareset.rst
+++ b/docs/mmctl_saml_authdatareset.rst
@@ -1,0 +1,51 @@
+.. _mmctl_saml_authdatareset:
+
+mmctl saml authdatareset
+------------------------
+
+Reset AuthData field to Email
+
+Synopsis
+~~~~~~~~
+
+
+Resets the AuthData field for SAML users to their email. Run this utility after setting the 'id' SAML attribute to an empty value.
+
+::
+
+  mmctl saml authdatareset [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+   saml authdatamigrate
+
+Options
+~~~~~~~
+
+::
+
+      --dry-run           Dry run only
+  -h, --help              help for authdatareset
+      --include-deleted   Include deleted users
+      --users strings     Comma-separated list of user IDs to which the operation will be applied
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --config-path string           path to the configuration directory. If "$HOME/.mmctl" exists it will take precedence over the default value (default "$XDG_CONFIG_HOME")
+      --format string                the format of the command output [plain, json] (default "plain")
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+      --local                        allows communicating with the server through a unix socket
+      --strict                       will only run commands if the mmctl version matches the server one
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl saml <mmctl_saml.rst>`_ 	 - SAML related utilities
+

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/magefile/mage v1.11.0
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mattermost/gorp v2.0.1-0.20200527092429-d62b7b9cadfc+incompatible // indirect
-	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210312174643-95b080985028
+	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210317142801-5706df9fe0e0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/poy/onpar v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -684,6 +684,8 @@ github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210312174643-95b080985028 h1:kAZEqPqDhFOgGuUu0lDAvLwifaI5zDKnbQ1LIgv+J6U=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210312174643-95b080985028/go.mod h1:eMBbd9H6UN4Ay1wFZrhhsDLrkUCM7hp4RoFfKMnFr8Y=
+github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210317142801-5706df9fe0e0 h1:petF+pjvGqj58hv1OR1uqTFjB1rwyHaFU7hvOILZRAc=
+github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210317142801-5706df9fe0e0/go.mod h1:eMBbd9H6UN4Ay1wFZrhhsDLrkUCM7hp4RoFfKMnFr8Y=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/go.sum
+++ b/go.sum
@@ -682,8 +682,6 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210312174643-95b080985028 h1:kAZEqPqDhFOgGuUu0lDAvLwifaI5zDKnbQ1LIgv+J6U=
-github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210312174643-95b080985028/go.mod h1:eMBbd9H6UN4Ay1wFZrhhsDLrkUCM7hp4RoFfKMnFr8Y=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210317142801-5706df9fe0e0 h1:petF+pjvGqj58hv1OR1uqTFjB1rwyHaFU7hvOILZRAc=
 github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210317142801-5706df9fe0e0/go.mod h1:eMBbd9H6UN4Ay1wFZrhhsDLrkUCM7hp4RoFfKMnFr8Y=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -1614,6 +1614,21 @@ func (mr *MockClientMockRecorder) RemoveUserFromChannel(arg0, arg1 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUserFromChannel", reflect.TypeOf((*MockClient)(nil).RemoveUserFromChannel), arg0, arg1)
 }
 
+// ResetSamlAuthDataToEmail mocks base method
+func (m *MockClient) ResetSamlAuthDataToEmail(arg0, arg1 bool, arg2 []string) (int64, *model.Response) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetSamlAuthDataToEmail", arg0, arg1, arg2)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(*model.Response)
+	return ret0, ret1
+}
+
+// ResetSamlAuthDataToEmail indicates an expected call of ResetSamlAuthDataToEmail
+func (mr *MockClientMockRecorder) ResetSamlAuthDataToEmail(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetSamlAuthDataToEmail", reflect.TypeOf((*MockClient)(nil).ResetSamlAuthDataToEmail), arg0, arg1, arg2)
+}
+
 // RestoreChannel mocks base method
 func (m *MockClient) RestoreChannel(arg0 string) (*model.Channel, *model.Response) {
 	m.ctrl.T.Helper()

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/admin.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/admin.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/services/mailservice"
 	"github.com/mattermost/mattermost-server/v5/shared/i18n"
+	"github.com/mattermost/mattermost-server/v5/shared/mail"
 	"github.com/mattermost/mattermost-server/v5/shared/mlog"
 	"github.com/mattermost/mattermost-server/v5/utils"
 )
@@ -228,7 +228,7 @@ func (a *App) TestEmail(userID string, cfg *model.Config) *model.AppError {
 	T := i18n.GetUserTranslations(user.Locale)
 	license := a.Srv().License()
 	mailConfig := a.Srv().MailServiceConfig()
-	if err := mailservice.SendMailUsingConfig(user.Email, T("api.admin.test_email.subject"), T("api.admin.test_email.body"), mailConfig, license != nil && *license.Features.Compliance, ""); err != nil {
+	if err := mail.SendMailUsingConfig(user.Email, T("api.admin.test_email.subject"), T("api.admin.test_email.body"), mailConfig, license != nil && *license.Features.Compliance, ""); err != nil {
 		return model.NewAppError("testEmail", "app.admin.test_email.failure", map[string]interface{}{"Error": err.Error()}, "", http.StatusInternalServerError)
 	}
 

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/app.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/app.go
@@ -15,10 +15,10 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/services/httpservice"
 	"github.com/mattermost/mattermost-server/v5/services/imageproxy"
-	"github.com/mattermost/mattermost-server/v5/services/mailservice"
 	"github.com/mattermost/mattermost-server/v5/services/searchengine"
 	"github.com/mattermost/mattermost-server/v5/services/timezones"
 	"github.com/mattermost/mattermost-server/v5/shared/i18n"
+	"github.com/mattermost/mattermost-server/v5/shared/mail"
 	"github.com/mattermost/mattermost-server/v5/shared/mlog"
 	"github.com/mattermost/mattermost-server/v5/shared/templates"
 	"github.com/mattermost/mattermost-server/v5/utils"
@@ -498,7 +498,7 @@ func (a *App) NotifyAndSetWarnMetricAck(warnMetricId string, sender *model.User,
 				return model.NewAppError("NotifyAndSetWarnMetricAck", "api.email.send_warn_metric_ack.failure.app_error", map[string]interface{}{"Error": err.Error()}, "", http.StatusInternalServerError)
 			}
 
-			if err := mailservice.SendMailUsingConfig(model.MM_SUPPORT_ADVISOR_ADDRESS, subject, body, mailConfig, false, sender.Email); err != nil {
+			if err := mail.SendMailUsingConfig(model.MM_SUPPORT_ADVISOR_ADDRESS, subject, body, mailConfig, false, sender.Email); err != nil {
 				return model.NewAppError("NotifyAndSetWarnMetricAck", "api.email.send_warn_metric_ack.failure.app_error", map[string]interface{}{"Error": err.Error()}, "", http.StatusInternalServerError)
 			}
 		}

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/app_iface.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/app_iface.go
@@ -866,6 +866,7 @@ type AppIface interface {
 	RequestLicenseAndAckWarnMetric(warnMetricId string, isBot bool) *model.AppError
 	ResetPasswordFromToken(userSuppliedTokenString, newPassword string) *model.AppError
 	ResetPermissionsSystem() *model.AppError
+	ResetSamlAuthDataToEmail(includeDeleted bool, dryRun bool, userIDs []string) (numAffected int64, appErr *model.AppError)
 	RestoreChannel(channel *model.Channel, userID string) (*model.Channel, *model.AppError)
 	RestoreTeam(teamID string) *model.AppError
 	RestrictUsersGetByPermissions(userID string, options *model.UserGetOptions) (*model.UserGetOptions, *model.AppError)

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/config.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/config.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v5/config"
 	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/services/mailservice"
+	"github.com/mattermost/mattermost-server/v5/shared/mail"
 	"github.com/mattermost/mattermost-server/v5/shared/mlog"
 	"github.com/mattermost/mattermost-server/v5/utils"
 )
@@ -453,10 +453,10 @@ func (a *App) HandleMessageExportConfig(cfg *model.Config, appCfg *model.Config)
 	}
 }
 
-func (s *Server) MailServiceConfig() *mailservice.SMTPConfig {
+func (s *Server) MailServiceConfig() *mail.SMTPConfig {
 	emailSettings := s.Config().EmailSettings
 	hostname := utils.GetHostnameFromSiteURL(*s.Config().ServiceSettings.SiteURL)
-	cfg := mailservice.SMTPConfig{
+	cfg := mail.SMTPConfig{
 		Hostname:                          hostname,
 		ConnectionSecurity:                *emailSettings.ConnectionSecurity,
 		SkipServerCertificateVerification: *emailSettings.SkipServerCertificateVerification,

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/email.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/email.go
@@ -20,8 +20,8 @@ import (
 	"github.com/throttled/throttled/store/memstore"
 
 	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/services/mailservice"
 	"github.com/mattermost/mattermost-server/v5/shared/i18n"
+	"github.com/mattermost/mattermost-server/v5/shared/mail"
 	"github.com/mattermost/mattermost-server/v5/shared/mlog"
 	"github.com/mattermost/mattermost-server/v5/shared/templates"
 )
@@ -699,14 +699,14 @@ func (es *EmailService) sendMailWithCC(to, subject, htmlBody string, ccMail stri
 	license := es.srv.License()
 	mailConfig := es.srv.MailServiceConfig()
 
-	return mailservice.SendMailUsingConfig(to, subject, htmlBody, mailConfig, license != nil && *license.Features.Compliance, ccMail)
+	return mail.SendMailUsingConfig(to, subject, htmlBody, mailConfig, license != nil && *license.Features.Compliance, ccMail)
 }
 
 func (es *EmailService) sendMailWithEmbeddedFiles(to, subject, htmlBody string, embeddedFiles map[string]io.Reader) error {
 	license := es.srv.License()
 	mailConfig := es.srv.MailServiceConfig()
 
-	return mailservice.SendMailWithEmbeddedFilesUsingConfig(to, subject, htmlBody, embeddedFiles, mailConfig, license != nil && *license.Features.Compliance, "")
+	return mail.SendMailWithEmbeddedFilesUsingConfig(to, subject, htmlBody, embeddedFiles, mailConfig, license != nil && *license.Features.Compliance, "")
 }
 
 func (es *EmailService) CreateVerifyEmailToken(userID string, newEmail string) (*model.Token, *model.AppError) {

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/opentracing/opentracing_layer.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/opentracing/opentracing_layer.go
@@ -12334,6 +12334,28 @@ func (a *OpenTracingAppLayer) ResetPermissionsSystem() *model.AppError {
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) ResetSamlAuthDataToEmail(includeDeleted bool, dryRun bool, userIDs []string) (numAffected int64, appErr *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.ResetSamlAuthDataToEmail")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.ResetSamlAuthDataToEmail(includeDeleted, dryRun, userIDs)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) RestoreChannel(channel *model.Channel, userID string) (*model.Channel, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.RestoreChannel")

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/saml.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/saml.go
@@ -282,3 +282,16 @@ func (a *App) SetSamlIdpCertificateFromMetadata(data []byte) *model.AppError {
 
 	return nil
 }
+
+func (a *App) ResetSamlAuthDataToEmail(includeDeleted bool, dryRun bool, userIDs []string) (numAffected int64, appErr *model.AppError) {
+	if a.Saml() == nil {
+		appErr = model.NewAppError("ResetAuthDataToEmail", "api.admin.saml.not_available.app_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+	numAffected, err := a.Saml().ResetAuthDataToEmail(includeDeleted, dryRun, userIDs)
+	if err != nil {
+		appErr = model.NewAppError("ResetAuthDataToEmail", "api.admin.saml.failure_reset_authdata_to_email.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	return
+}

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/security_update_check.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/security_update_check.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 
 	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/services/mailservice"
 	"github.com/mattermost/mattermost-server/v5/shared/i18n"
+	"github.com/mattermost/mattermost-server/v5/shared/mail"
 	"github.com/mattermost/mattermost-server/v5/shared/mlog"
 )
 
@@ -116,7 +116,7 @@ func (s *Server) DoSecurityUpdateCheck() {
 						mlog.Info("Sending security bulletin", mlog.String("bulletin_id", bulletin.Id), mlog.String("user_email", user.Email))
 						license := s.License()
 						mailConfig := s.MailServiceConfig()
-						mailservice.SendMailUsingConfig(user.Email, i18n.T("mattermost.bulletin.subject"), string(body), mailConfig, license != nil && *license.Features.Compliance, "")
+						mail.SendMailUsingConfig(user.Email, i18n.T("mattermost.bulletin.subject"), string(body), mailConfig, license != nil && *license.Features.Compliance, "")
 					}
 
 					bulletinSeen := &model.System{Name: "SecurityBulletin_" + bulletin.Id, Value: bulletin.Id}

--- a/vendor/github.com/mattermost/mattermost-server/v5/app/server.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/app/server.go
@@ -48,7 +48,6 @@ import (
 	"github.com/mattermost/mattermost-server/v5/services/cache"
 	"github.com/mattermost/mattermost-server/v5/services/httpservice"
 	"github.com/mattermost/mattermost-server/v5/services/imageproxy"
-	"github.com/mattermost/mattermost-server/v5/services/mailservice"
 	"github.com/mattermost/mattermost-server/v5/services/searchengine"
 	"github.com/mattermost/mattermost-server/v5/services/searchengine/bleveengine"
 	"github.com/mattermost/mattermost-server/v5/services/telemetry"
@@ -57,6 +56,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/services/upgrader"
 	"github.com/mattermost/mattermost-server/v5/shared/filestore"
 	"github.com/mattermost/mattermost-server/v5/shared/i18n"
+	"github.com/mattermost/mattermost-server/v5/shared/mail"
 	"github.com/mattermost/mattermost-server/v5/shared/mlog"
 	"github.com/mattermost/mattermost-server/v5/shared/templates"
 	"github.com/mattermost/mattermost-server/v5/store"
@@ -517,7 +517,7 @@ func NewServer(options ...Option) (*Server, error) {
 
 	mailConfig := s.MailServiceConfig()
 
-	if nErr := mailservice.TestConnection(mailConfig); nErr != nil {
+	if nErr := mail.TestConnection(mailConfig); nErr != nil {
 		mlog.Error("Mail server connection test is failed", mlog.Err(nErr))
 	}
 

--- a/vendor/github.com/mattermost/mattermost-server/v5/einterfaces/saml.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/einterfaces/saml.go
@@ -12,4 +12,5 @@ type SamlInterface interface {
 	BuildRequest(relayState string) (*model.SamlAuthRequest, *model.AppError)
 	DoLogin(encodedXML string, relayState map[string]string) (*model.User, *model.AppError)
 	GetMetadata() (string, *model.AppError)
+	ResetAuthDataToEmail(includeDeleted bool, dryRun bool, specifiedUserIDs []string) (numAffected int64, err error)
 }

--- a/vendor/github.com/mattermost/mattermost-server/v5/model/client4.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/model/client4.go
@@ -3889,6 +3889,28 @@ func (c *Client4) GetSamlMetadataFromIdp(samlMetadataURL string) (*SamlMetadataR
 	return SamlMetadataResponseFromJson(r.Body), BuildResponse(r)
 }
 
+// ResetSamlAuthDataToEmail resets the AuthData field of SAML users to their Email.
+func (c *Client4) ResetSamlAuthDataToEmail(includeDeleted bool, dryRun bool, userIDs []string) (int64, *Response) {
+	params := map[string]interface{}{
+		"include_deleted": includeDeleted,
+		"dry_run":         dryRun,
+		"user_ids":        userIDs,
+	}
+	b, _ := json.Marshal(params)
+	r, err := c.doApiPostBytes(c.GetSamlRoute()+"/resetid", b)
+	if err != nil {
+		return 0, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	respBody := map[string]int64{}
+	jsonErr := json.NewDecoder(r.Body).Decode(&respBody)
+	if jsonErr != nil {
+		appErr := NewAppError("Api4.ResetSamlAuthDataToEmail", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError)
+		return 0, BuildErrorResponse(r, appErr)
+	}
+	return respBody["num_affected"], BuildResponse(r)
+}
+
 // Compliance Section
 
 // CreateComplianceReport creates an incoming webhook for a channel.

--- a/vendor/github.com/mattermost/mattermost-server/v5/shared/mail/inbucket.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/shared/mail/inbucket.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package mailservice
+package mail
 
 import (
 	"bytes"

--- a/vendor/github.com/mattermost/mattermost-server/v5/shared/mail/mail.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/shared/mail/mail.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package mailservice
+package mail
 
 import (
 	"context"

--- a/vendor/github.com/mattermost/mattermost-server/v5/store/sqlstore/user_store.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/store/sqlstore/user_store.go
@@ -1884,6 +1884,7 @@ func (us SqlUserStore) DemoteUserToGuest(userID string) (*model.User, error) {
 
 	query = us.getQueryBuilder().Update("ChannelMembers").
 		Set("SchemeUser", false).
+		Set("SchemeAdmin", false).
 		Set("SchemeGuest", true).
 		Where(sq.Eq{"UserId": userID})
 
@@ -1898,6 +1899,7 @@ func (us SqlUserStore) DemoteUserToGuest(userID string) (*model.User, error) {
 
 	query = us.getQueryBuilder().Update("TeamMembers").
 		Set("SchemeUser", false).
+		Set("SchemeAdmin", false).
 		Set("SchemeGuest", true).
 		Where(sq.Eq{"UserId": userID})
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -322,7 +322,7 @@ github.com/mattermost/ldap
 github.com/mattermost/logr
 github.com/mattermost/logr/format
 github.com/mattermost/logr/target
-# github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210312174643-95b080985028
+# github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210317142801-5706df9fe0e0
 github.com/mattermost/mattermost-server/v5/api4
 github.com/mattermost/mattermost-server/v5/app
 github.com/mattermost/mattermost-server/v5/app/opentracing
@@ -342,7 +342,6 @@ github.com/mattermost/mattermost-server/v5/services/configservice
 github.com/mattermost/mattermost-server/v5/services/docextractor
 github.com/mattermost/mattermost-server/v5/services/httpservice
 github.com/mattermost/mattermost-server/v5/services/imageproxy
-github.com/mattermost/mattermost-server/v5/services/mailservice
 github.com/mattermost/mattermost-server/v5/services/marketplace
 github.com/mattermost/mattermost-server/v5/services/searchengine
 github.com/mattermost/mattermost-server/v5/services/searchengine/bleveengine
@@ -353,6 +352,7 @@ github.com/mattermost/mattermost-server/v5/services/tracing
 github.com/mattermost/mattermost-server/v5/services/upgrader
 github.com/mattermost/mattermost-server/v5/shared/filestore
 github.com/mattermost/mattermost-server/v5/shared/i18n
+github.com/mattermost/mattermost-server/v5/shared/mail
 github.com/mattermost/mattermost-server/v5/shared/mfa
 github.com/mattermost/mattermost-server/v5/shared/mlog
 github.com/mattermost/mattermost-server/v5/shared/mlog/human


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds an mmctl command that reset SAML users' AuthData field to their email.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32044

#### Server PR
https://github.com/mattermost/mattermost-server/pull/17161

