### PR TITLE
Enable printing the post list in JSON format

### DIFF
--- a/commands/post.go
+++ b/commands/post.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 
 	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -120,13 +121,15 @@ func printPost(c client.Client, post *model.Post, usernames map[string]string, s
 	}
 
 	if showIds {
-		fmt.Printf("\u001b[31m%s\u001b[0m \u001b[34;1m[%s]\u001b[0m %s\n", post.Id, username, post.Message)
+		printer.PrintT(fmt.Sprintf("\u001b[31m%s\u001b[0m \u001b[34;1m[%s]\u001b[0m {{.Message}}", post.Id, username), post)
 	} else {
-		fmt.Printf("\u001b[34;1m[%s]\u001b[0m %s\n", username, post.Message)
+		printer.PrintT(fmt.Sprintf("\u001b[34;1m[%s]\u001b[0m {{.Message}}", username), post)
 	}
+	printer.Flush()
 }
 
 func postListCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	printer.SetSingle(true)
 	channel := getChannelFromChannelArg(c, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -77,11 +77,12 @@ func Print(v interface{}) {
 func Flush() {
 	if printer.Format == FormatJSON {
 		var b []byte
-		if printer.Single && len(printer.Lines) == 0 {
+		switch {
+		case printer.Single && len(printer.Lines) == 0:
 			return
-		} else if printer.Single && len(printer.Lines) == 1 {
+		case printer.Single && len(printer.Lines) == 1:
 			b, _ = json.MarshalIndent(printer.Lines[0], "", "  ")
-		} else {
+		default:
 			b, _ = json.MarshalIndent(printer.Lines, "", "  ")
 		}
 

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -77,7 +77,9 @@ func Print(v interface{}) {
 func Flush() {
 	if printer.Format == FormatJSON {
 		var b []byte
-		if printer.Single && len(printer.Lines) == 1 {
+		if printer.Single && len(printer.Lines) == 0 {
+			return
+		} else if printer.Single && len(printer.Lines) == 1 {
 			b, _ = json.MarshalIndent(printer.Lines[0], "", "  ")
 		} else {
 			b, _ = json.MarshalIndent(printer.Lines, "", "  ")


### PR DESCRIPTION
#### Summary
Routes the prints of the `post list` command through the `printer` to enable JSON formatting.

Fixes #352 
