### PR TITLE
MM17693 - Updated user create help output to change hyphens to unders…

### DIFF
--- a/commands/user.go
+++ b/commands/user.go
@@ -53,10 +53,10 @@ var UserCreateCmd = &cobra.Command{
   $ mmctl user create --email user@example.com --username userexample --password Password1 --firstname User --lastname Example --nickname userex
 
   # Also you can create the user as system administrator
-  $ mmctl user create --email user@example.com --username userexample --password Password1 --system-admin
+  $ mmctl user create --email user@example.com --username userexample --password Password1 --system_admin
 
   # Finally you can verify user on creation if you have enough permissions
-  $ mmctl user create --email user@example.com --username userexample --password Password1 --system-admin --email-verified`,
+  $ mmctl user create --email user@example.com --username userexample --password Password1 --system_admin --email_verified`,
 	RunE: withClient(userCreateCmdF),
 }
 

--- a/docs/mmctl_user_create.rst
+++ b/docs/mmctl_user_create.rst
@@ -27,10 +27,10 @@ Examples
     $ mmctl user create --email user@example.com --username userexample --password Password1 --firstname User --lastname Example --nickname userex
 
     # Also you can create the user as system administrator
-    $ mmctl user create --email user@example.com --username userexample --password Password1 --system-admin
+    $ mmctl user create --email user@example.com --username userexample --password Password1 --system_admin
 
     # Finally you can verify user on creation if you have enough permissions
-    $ mmctl user create --email user@example.com --username userexample --password Password1 --system-admin --email-verified
+    $ mmctl user create --email user@example.com --username userexample --password Password1 --system_admin --email_verified
 
 Options
 ~~~~~~~


### PR DESCRIPTION
…cores in the examples

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request fixes issue MM-17693 (GitHub) / MM-36108 (Mattermost).  This issue illustrates that the examples output to the command line for creating a user contain the '--system-admin' and '--email-verified' command line arguments.  The actual arguments should use an underscore instead of a hyphen for word separation.  This is a documentation fix and does not change the actual arguments accepted for creating a user.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/17693
Fixes https://mattermost.atlassian.net/browse/MM-36108

Before the fix:
![mm17693-before](https://user-images.githubusercontent.com/85130511/123357464-8e2a8180-d537-11eb-8dd8-8a6d1ff94701.png)

After the fix:
![mm17693-after](https://user-images.githubusercontent.com/85130511/123357474-91be0880-d537-11eb-9f1c-fb9ed7379d58.png)

