### PR TITLE
encourage users to not copy their secrets on shell history

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -6,7 +6,6 @@ package commands
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -138,30 +137,24 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 	}
 	passwordFile, _ := cmd.Flags().GetString("password-file")
 	if password != "" && passwordFile != "" {
-		return errors.New("can not use two passwords at the same time")
+		return errors.New("cannot use two passwords at the same time")
 	}
-	if passwordFile != "" {
-		b, err2 := ioutil.ReadFile(passwordFile)
-		if err2 != nil {
-			return err2
-		}
-		password = strings.TrimSpace(string(b))
+	if fErr := readSecretFromFile(passwordFile, &password); fErr != nil {
+		return fmt.Errorf("could not read the password: %w", fErr)
 	}
+
 	accessToken, err := cmd.Flags().GetString("access-token")
 	if err != nil {
 		return err
 	}
 	accessTokenFile, _ := cmd.Flags().GetString("access-token-file")
 	if accessToken != "" && accessTokenFile != "" {
-		return errors.New("can not use two access tokens at the same time")
+		return errors.New("cannot use two access tokens at the same time")
 	}
-	if accessTokenFile != "" {
-		b, err2 := ioutil.ReadFile(accessTokenFile)
-		if err2 != nil {
-			return err2
-		}
-		accessToken = strings.TrimSpace(string(b))
+	if fErr := readSecretFromFile(accessTokenFile, &accessToken); fErr != nil {
+		return fmt.Errorf("could not read the access-token: %w", fErr)
 	}
+
 	mfaToken, err := cmd.Flags().GetString("mfa-token")
 	if err != nil {
 		return err
@@ -337,27 +330,21 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 	password, _ := cmd.Flags().GetString("password")
 	passwordFile, _ := cmd.Flags().GetString("password-file")
 	if password != "" && passwordFile != "" {
-		return errors.New("can not use two passwords at the same time")
+		return errors.New("cannot use two passwords at the same time")
 	}
-	if passwordFile != "" {
-		b, err2 := ioutil.ReadFile(passwordFile)
-		if err2 != nil {
-			return err2
-		}
-		password = strings.TrimSpace(string(b))
+	if fErr := readSecretFromFile(passwordFile, &password); fErr != nil {
+		return fmt.Errorf("could not read the password: %w", fErr)
 	}
+
 	accessToken, _ := cmd.Flags().GetString("access-token")
 	accessTokenFile, _ := cmd.Flags().GetString("access-token-file")
 	if accessToken != "" && accessTokenFile != "" {
-		return errors.New("can not use two access tokens at the same time")
+		return errors.New("cannot use two access tokens at the same time")
 	}
-	if accessTokenFile != "" {
-		b, err2 := ioutil.ReadFile(accessTokenFile)
-		if err2 != nil {
-			return err2
-		}
-		accessToken = strings.TrimSpace(string(b))
+	if fErr := readSecretFromFile(accessTokenFile, &accessToken); fErr != nil {
+		return fmt.Errorf("could not read the access-token: %w", fErr)
 	}
+
 	mfaToken, _ := cmd.Flags().GetString("mfa-token")
 	allowInsecureSHA1 := viper.GetBool("insecure-sha1-intermediate")
 	allowInsecureTLS := viper.GetBool("insecure-tls-version")

--- a/commands/auth_utils.go
+++ b/commands/auth_utils.go
@@ -192,3 +192,16 @@ func CleanCredentials() error {
 func SetUser(newUser *user.User) {
 	currentUser = newUser
 }
+
+// will read the scret from file, if there is one
+func readSecretFromFile(file string, secret *string) error {
+	if file != "" {
+		b, err := ioutil.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		*secret = strings.TrimSpace(string(b))
+	}
+
+	return nil
+}

--- a/commands/auth_utils_test.go
+++ b/commands/auth_utils_test.go
@@ -105,3 +105,32 @@ func createFile(path string) error {
 	}
 	return nil
 }
+
+func TestReadSecretFromFile(t *testing.T) {
+	f, err := ioutil.TempFile(t.TempDir(), "mmctl")
+	require.NoError(t, err)
+
+	_, err = f.WriteString("test-pass")
+	require.NoError(t, err)
+
+	t.Run("password from file", func(t *testing.T) {
+		var pass string
+		err := readSecretFromFile(f.Name(), &pass)
+		require.NoError(t, err)
+		require.Equal(t, "test-pass", pass)
+	})
+
+	t.Run("no file path is provided", func(t *testing.T) {
+		pass := "test-pass-2"
+		err := readSecretFromFile("", &pass)
+		require.NoError(t, err)
+		require.Equal(t, "test-pass-2", pass)
+	})
+
+	t.Run("nonexistent file provided", func(t *testing.T) {
+		var pass string
+		err := readSecretFromFile(filepath.Join(t.TempDir(), "bla"), &pass)
+		require.Error(t, err)
+		require.Empty(t, pass)
+	})
+}

--- a/docs/mmctl_auth_login.rst
+++ b/docs/mmctl_auth_login.rst
@@ -13,7 +13,7 @@ Login into an instance and store credentials
 
 ::
 
-  mmctl auth login [instance url] --name [server name] --username [username] --password [password] [flags]
+  mmctl auth login [instance url] --name [server name] --username [username] --password-file [password-file] [flags]
 
 Examples
 ~~~~~~~~
@@ -21,8 +21,8 @@ Examples
 ::
 
     auth login https://mattermost.example.com
-    auth login https://mattermost.example.com --name local-server --username sysadmin --password mysupersecret
-    auth login https://mattermost.example.com --name local-server --username sysadmin --password mysupersecret --mfa-token 123456
+    auth login https://mattermost.example.com --name local-server --username sysadmin --password-file mysupersecret.txt
+    auth login https://mattermost.example.com --name local-server --username sysadmin --password-file mysupersecret.txt --mfa-token 123456
     auth login https://mattermost.example.com --name local-server --access-token myaccesstoken
 
 Options
@@ -30,13 +30,13 @@ Options
 
 ::
 
-  -a, --access-token string   Access token to use instead of username/password
-  -h, --help                  help for login
-  -m, --mfa-token string      MFA token for the credentials
-  -n, --name string           Name for the credentials
-      --no-activate           If present, it won't activate the credentials after login
-  -p, --password string       Password for the credentials
-  -u, --username string       Username for the credentials
+  -t, --access-token-file string   Access token file to be read to use instead of username/password
+  -h, --help                       help for login
+  -m, --mfa-token string           MFA token for the credentials
+  -n, --name string                Name for the credentials
+      --no-activate                If present, it won't activate the credentials after login
+  -f, --password-file string       Password file to be read for the credentials
+  -u, --username string            Username for the credentials
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/mmctl_auth_renew.rst
+++ b/docs/mmctl_auth_renew.rst
@@ -27,10 +27,10 @@ Options
 
 ::
 
-  -a, --access-token string   Access token to use instead of username/password
-  -h, --help                  help for renew
-  -m, --mfa-token string      MFA token for the credentials
-  -p, --password string       Password for the credentials
+  -t, --access-token-file string   Access token file to be read to use instead of username/password
+  -h, --help                       help for renew
+  -m, --mfa-token string           MFA token for the credentials
+  -f, --password-file string       Password file to be read for the credentials
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION

#### Summary
The `--password` arg may leak a secret into `ps`/`top` output or to shell history. We can encourage users to use a more secure way to supply their secrets. Although existing flags remain, we will mark them as hidden.

#### Release note

```release-note
mmctl will accept --password-file or --access-token-file for login secrets. Please consider updating your scripts accordingly
```


