### PR TITLE
[MM-37687] Add pagination to channel list command

### DIFF
--- a/commands/channel.go
+++ b/commands/channel.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mattermost/mmctl/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/web"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -263,6 +265,48 @@ func archiveChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) err
 	return nil
 }
 
+func getAllPublicChannelsForTeam(c client.Client, teamID string) ([]*model.Channel, error) {
+	channels := []*model.Channel{}
+	page := 0
+
+	for {
+		channelsPage, response := c.GetPublicChannelsForTeam(teamID, page, web.PerPageMaximum, "")
+		if response.Error != nil {
+			return nil, response.Error
+		}
+
+		if len(channelsPage) == 0 {
+			break
+		}
+
+		channels = append(channels, channelsPage...)
+		page++
+	}
+
+	return channels, nil
+}
+
+func getAllDeletedChannelsForTeam(c client.Client, teamID string) ([]*model.Channel, error) {
+	channels := []*model.Channel{}
+	page := 0
+
+	for {
+		channelsPage, response := c.GetDeletedChannelsForTeam(teamID, page, web.PerPageMaximum, "")
+		if response.Error != nil {
+			return nil, response.Error
+		}
+
+		if len(channelsPage) == 0 {
+			break
+		}
+
+		channels = append(channels, channelsPage...)
+		page++
+	}
+
+	return channels, nil
+}
+
 func listChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	teams := getTeamsFromTeamArgs(c, args)
 	for i, team := range teams {
@@ -271,25 +315,25 @@ func listChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) error 
 			continue
 		}
 
-		publicChannels, response := c.GetPublicChannelsForTeam(team.Id, 0, 10000, "")
-		if response.Error != nil {
-			printer.PrintError("Unable to list public channels for '" + args[i] + "'. Error: " + response.Error.Error())
+		publicChannels, err := getAllPublicChannelsForTeam(c, team.Id)
+		if err != nil {
+			printer.PrintError(fmt.Sprintf("unable to list public channels for %q: %s", args[i], err))
 		}
 		for _, channel := range publicChannels {
 			printer.PrintT("{{.Name}}", channel)
 		}
 
-		deletedChannels, response := c.GetDeletedChannelsForTeam(team.Id, 0, 10000, "")
-		if response.Error != nil {
-			printer.PrintError("Unable to list archived channels for '" + args[i] + "'. Error: " + response.Error.Error())
+		deletedChannels, err := getAllDeletedChannelsForTeam(c, team.Id)
+		if err != nil {
+			printer.PrintError(fmt.Sprintf("unable to list archived channels for %q: %s", args[i], err))
 		}
 		for _, channel := range deletedChannels {
 			printer.PrintT("{{.Name}} (archived)", channel)
 		}
 
-		privateChannels, err := getPrivateChannels(c, team.Id)
-		if err != nil {
-			printer.PrintError("Unable to list private channels for '" + args[i] + "'. Error: " + err.Error())
+		privateChannels, appErr := getPrivateChannels(c, team.Id)
+		if appErr != nil {
+			printer.PrintError(fmt.Sprintf("unable to list private channels for %q: %s", args[i], appErr.Error()))
 		}
 		for _, channel := range privateChannels {
 			printer.PrintT("{{.Name}} (private)", channel)
@@ -484,11 +528,35 @@ func moveChannelCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 }
 
 func getPrivateChannels(c client.Client, teamID string) ([]*model.Channel, *model.AppError) {
-	allPrivateChannels, response := c.GetPrivateChannelsForTeam(teamID, 0, 10000, "")
-	// local mode admin result is a superset of user result
-	// if see an error and we're in local mode we can return early
-	if response.Error == nil || viper.GetBool("local") {
-		return allPrivateChannels, response.Error
+	allPrivateChannels := []*model.Channel{}
+	page := 0
+	var appErr *model.AppError
+
+	for {
+		channelsPage, response := c.GetPrivateChannelsForTeam(teamID, page, web.PerPageMaximum, "")
+		if response.Error != nil && viper.GetBool("local") {
+			return nil, response.Error
+		} else if response.Error != nil {
+			// This means that the user is not in local mode neither
+			// an admin, so we need to continue fetching the private
+			// channels specific to their credentials
+			appErr = response.Error
+			break
+		}
+
+		if len(channelsPage) == 0 {
+			break
+		}
+
+		allPrivateChannels = append(allPrivateChannels, channelsPage...)
+		page++
+	}
+
+	// if the break happened without an error, this means we're either
+	// in local mode or an admin, and we'll have all private channels
+	// by now, so we can safely return
+	if appErr == nil {
+		return allPrivateChannels, nil
 	}
 
 	// We are definitely not in local mode here so we can safely use "GetChannelsForTeamForUser"

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -530,7 +530,7 @@ func moveChannelCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 func getPrivateChannels(c client.Client, teamID string) ([]*model.Channel, *model.AppError) {
 	allPrivateChannels := []*model.Channel{}
 	page := 0
-	var appErr *model.AppError
+	withoutError := true
 
 	for {
 		channelsPage, response := c.GetPrivateChannelsForTeam(teamID, page, web.PerPageMaximum, "")
@@ -540,7 +540,7 @@ func getPrivateChannels(c client.Client, teamID string) ([]*model.Channel, *mode
 			// This means that the user is not in local mode neither
 			// an admin, so we need to continue fetching the private
 			// channels specific to their credentials
-			appErr = response.Error
+			withoutError = false
 			break
 		}
 
@@ -555,12 +555,12 @@ func getPrivateChannels(c client.Client, teamID string) ([]*model.Channel, *mode
 	// if the break happened without an error, this means we're either
 	// in local mode or an admin, and we'll have all private channels
 	// by now, so we can safely return
-	if appErr == nil {
+	if withoutError {
 		return allPrivateChannels, nil
 	}
 
-	// We are definitely not in local mode here so we can safely use "GetChannelsForTeamForUser"
-	// and "me" for userId
+	// We are definitely not in local mode here so we can safely use
+	// "GetChannelsForTeamForUser" and "me" for userId
 	allChannels, response := c.GetChannelsForTeamForUser(teamID, "me", false, "")
 	if response.Error != nil {
 		if response.StatusCode == http.StatusNotFound { // user doesn't belong to any channels

--- a/commands/channel_test.go
+++ b/commands/channel_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/web"
 
 	"github.com/mattermost/mmctl/printer"
 
@@ -645,6 +646,8 @@ func (s *MmctlUnitTestSuite) TestArchiveChannelCmdF() {
 }
 
 func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
+	emptyChannels := []*model.Channel{}
+
 	s.Run("Team is not found", func() {
 		printer.Clean()
 		args := []string{""}
@@ -695,19 +698,19 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(publicChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(archivedChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: nil}).
 			Times(1)
 		s.client.
@@ -752,21 +755,28 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(publicChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(archivedChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID, "me", false, "").
@@ -811,21 +821,28 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(publicChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(archivedChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID, "me", false, "").
@@ -872,21 +889,40 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(publicChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(archivedChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: nil}).
 			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID, "me", false, "").
@@ -925,7 +961,6 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		userChannels := []*model.Channel{archivedChannel1, publicChannel1, privateChannel1, privateChannel2}
 
 		mockError := &model.AppError{Message: "User does not have permissions to list all private channels in team"}
-		emptyChannels := []*model.Channel{}
 
 		s.client.
 			EXPECT().
@@ -935,19 +970,19 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: mockError}).
 			Times(1)
 		s.client.
@@ -976,7 +1011,6 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		}
 
 		mockError := &model.AppError{Message: "Mock error"}
-		emptyChannels := []*model.Channel{}
 
 		s.client.
 			EXPECT().
@@ -986,21 +1020,22 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: mockError}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID, "me", false, "").
@@ -1012,7 +1047,7 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		s.Require().Nil(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
-		s.Require().Equal(printer.GetErrorLines()[0], "Unable to list public channels for '"+args[0]+"'. Error: "+mockError.Error())
+		s.Require().Equal(printer.GetErrorLines()[0], fmt.Sprintf("unable to list public channels for %q: %s", args[0], mockError.Error()))
 	})
 
 	s.Run("API fails to get team's archived channels list", func() {
@@ -1025,7 +1060,6 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		}
 
 		mockError := &model.AppError{Message: "Mock error"}
-		emptyChannels := []*model.Channel{}
 
 		s.client.
 			EXPECT().
@@ -1035,19 +1069,19 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: mockError}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: nil}).
 			Times(1)
 		s.client.
@@ -1061,7 +1095,7 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		s.Require().Nil(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
-		s.Require().Equal(printer.GetErrorLines()[0], "Unable to list archived channels for '"+args[0]+"'. Error: "+mockError.Error())
+		s.Require().Equal(printer.GetErrorLines()[0], fmt.Sprintf("unable to list archived channels for %q: %s", args[0], mockError.Error()))
 	})
 
 	s.Run("API fails to get team's private channels list", func() {
@@ -1074,7 +1108,6 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		}
 
 		mockError := &model.AppError{Message: "Mock error"}
-		emptyChannels := []*model.Channel{}
 
 		s.client.
 			EXPECT().
@@ -1084,21 +1117,22 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: mockError}).
 			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID, "me", false, "").
@@ -1110,7 +1144,7 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		s.Require().Nil(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
-		s.Require().Equal(printer.GetErrorLines()[0], "Unable to list private channels for '"+args[0]+"'. Error: "+mockError.Error())
+		s.Require().Equal(printer.GetErrorLines()[0], fmt.Sprintf("unable to list private channels for %q: %s", args[0], mockError.Error()))
 	})
 
 	s.Run("API fails to get team's private channels list in local mode", func() {
@@ -1125,7 +1159,6 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		}
 
 		mockError := &model.AppError{Message: "Mock error"}
-		emptyChannels := []*model.Channel{}
 
 		s.client.
 			EXPECT().
@@ -1135,21 +1168,22 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(emptyChannels, &model.Response{Error: mockError}).
 			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID, "me", false, "").
@@ -1161,7 +1195,7 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		s.Require().Nil(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
-		s.Require().Equal(printer.GetErrorLines()[0], "Unable to list private channels for '"+args[0]+"'. Error: "+mockError.Error())
+		s.Require().Equal(printer.GetErrorLines()[0], fmt.Sprintf("unable to list private channels for %q: %s", args[0], mockError.Error()))
 	})
 
 	s.Run("API fails to get team's public, archived and private channels", func() {
@@ -1186,21 +1220,22 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: mockError}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: mockError}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: mockError}).
 			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID, "me", false, "").
@@ -1212,9 +1247,9 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 		s.Require().Nil(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 3)
-		s.Require().Equal(printer.GetErrorLines()[0], "Unable to list public channels for '"+args[0]+"'. Error: "+mockError.Error())
-		s.Require().Equal(printer.GetErrorLines()[1], "Unable to list archived channels for '"+args[0]+"'. Error: "+mockError.Error())
-		s.Require().Equal(printer.GetErrorLines()[2], "Unable to list private channels for '"+args[0]+"'. Error: "+mockError.Error())
+		s.Require().Equal(printer.GetErrorLines()[0], fmt.Sprintf("unable to list public channels for %q: %s", args[0], mockError.Error()))
+		s.Require().Equal(printer.GetErrorLines()[1], fmt.Sprintf("unable to list archived channels for %q: %s", args[0], mockError.Error()))
+		s.Require().Equal(printer.GetErrorLines()[2], fmt.Sprintf("unable to list private channels for %q: %s", args[0], mockError.Error()))
 	})
 
 	s.Run("Two teams, one is found and other is not found", func() {
@@ -1256,21 +1291,40 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID1, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(publicChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID1, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetDeletedChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(archivedChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID1, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: nil}).
 			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID1, "me", false, "").
@@ -1315,21 +1369,43 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 			GetTeam(teamID1, "").
 			Return(team1, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID1, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(publicChannels, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID1, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetDeletedChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(archivedChannels, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID1, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: nil}).
 			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID1, "me", false, "").
@@ -1346,19 +1422,19 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID2, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID2, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: mockError}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID2, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID2, 0, web.PerPageMaximum, "").
 			Return(nil, &model.Response{Error: mockError}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID2, 0, 10000, "").
+			GetPrivateChannelsForTeam(teamID2, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: mockError}).
 			Times(1)
 		s.client.
@@ -1444,21 +1520,43 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 			GetTeam(teamID1, "").
 			Return(team1, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID1, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(publicChannels, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID1, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetDeletedChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(archivedChannels, &model.Response{Error: nil}).
 			Times(1)
+
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID1, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID1, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: nil}).
 			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID1, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID1, "me", false, "").
@@ -1473,21 +1571,40 @@ func (s *MmctlUnitTestSuite) TestListChannelsCmd() {
 
 		s.client.
 			EXPECT().
-			GetPublicChannelsForTeam(teamID2, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID2, 0, web.PerPageMaximum, "").
 			Return(publicChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetDeletedChannelsForTeam(teamID2, 0, 10000, "").
+			GetPublicChannelsForTeam(teamID2, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetDeletedChannelsForTeam(teamID2, 0, web.PerPageMaximum, "").
 			Return(archivedChannels, &model.Response{Error: nil}).
 			Times(1)
 
 		s.client.
 			EXPECT().
-			GetPrivateChannelsForTeam(teamID2, 0, 10000, "").
+			GetDeletedChannelsForTeam(teamID2, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID2, 0, web.PerPageMaximum, "").
 			Return(privateChannels, &model.Response{Error: nil}).
 			Times(1)
+
+		s.client.
+			EXPECT().
+			GetPrivateChannelsForTeam(teamID2, 1, web.PerPageMaximum, "").
+			Return(emptyChannels, &model.Response{Error: nil}).
+			Times(1)
+
 		s.client.
 			EXPECT().
 			GetChannelsForTeamForUser(teamID2, "me", false, "").


### PR DESCRIPTION
#### Summary
This PR adds a loop for each of the channel fetch functions, so the `channel list` command doesn't hit the max per page limit in the server and effectively fetches all the channels available.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37687

