### PR TITLE
bugfix: Do not check local mode socket owner if current user is root

### DIFF
--- a/commands/utils_unix.go
+++ b/commands/utils_unix.go
@@ -33,7 +33,8 @@ func checkValidSocket(socketPath string) error {
 	if !ok {
 		return fmt.Errorf("cannot get owner of the file %q", socketPath)
 	}
-	if fmt.Sprint(s.Uid) != cUser.Uid {
+	// if user id is "0", they are root and we should avoid this check
+	if fmt.Sprint(s.Uid) != cUser.Uid && cUser.Uid != "0" {
 		return fmt.Errorf("owner of the file %q must be the same user running mmctl", socketPath)
 	}
 


### PR DESCRIPTION
#### Summary
We should avoid erroring for the local mode file ownage if the current user is root.


