### PR TITLE
[Build] Support go 1.17

### DIFF
--- a/commands/main_test.go
+++ b/commands/main_test.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+//go:build e2e
 // +build e2e
 
 package commands

--- a/commands/mmctl_e2e_test.go
+++ b/commands/mmctl_e2e_test.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+//go:build e2e
 // +build e2e
 
 package commands

--- a/commands/mmctl_unit_test.go
+++ b/commands/mmctl_unit_test.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+//go:build unit
 // +build unit
 
 package commands

--- a/commands/utils_unix.go
+++ b/commands/utils_unix.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+//go:build linux || darwin
 // +build linux darwin
 
 package commands

--- a/magefile.go
+++ b/magefile.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+//go:build mage
 // +build mage
 
 package main


### PR DESCRIPTION
#### Summary
Updates mmctl to support go1.17 as described here: https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md

This is currently blocking homebrew here: https://github.com/Homebrew/homebrew-core/pull/83413/

#### Ticket Link
https://github.com/mattermost/mmctl/issues/363
