### PR TITLE
mmctl plugin add: introduce optional 'force' flag to allow existing plugins to be replaced

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -52,6 +52,7 @@ type Client interface {
 	GetRoleByName(name string) (*model.Role, *model.Response, error)
 	PatchRole(roleId string, patch *model.RolePatch) (*model.Role, *model.Response, error)
 	UploadPlugin(file io.Reader) (*model.Manifest, *model.Response, error)
+	UploadPluginForced(file io.Reader) (*model.Manifest, *model.Response, error)
 	RemovePlugin(id string) (*model.Response, error)
 	EnablePlugin(id string) (*model.Response, error)
 	DisablePlugin(id string) (*model.Response, error)

--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -76,6 +76,7 @@ var PluginListCmd = &cobra.Command{
 }
 
 func init() {
+	PluginAddCmd.Flags().BoolP("force", "f", false, "overwrite a previously installed plugin with the same ID, if any")
 	PluginInstallURLCmd.Flags().BoolP("force", "f", false, "overwrite a previously installed plugin with the same ID, if any")
 
 	PluginCmd.AddCommand(
@@ -90,13 +91,21 @@ func init() {
 }
 
 func pluginAddCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	force, _ := cmd.Flags().GetBool("force")
+
 	for i, plugin := range args {
 		fileReader, err := os.Open(plugin)
 		if err != nil {
 			return err
 		}
 
-		if _, _, err := c.UploadPlugin(fileReader); err != nil {
+		if force {
+			_, _, err = c.UploadPluginForced(fileReader)
+		} else {
+			_, _, err = c.UploadPlugin(fileReader)
+		}
+
+		if err != nil {
 			printer.PrintError("Unable to add plugin: " + args[i] + ". Error: " + err.Error())
 		} else {
 			printer.Print("Added plugin: " + plugin)

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -89,6 +89,7 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 
 		s.Require().Equal(1, len(printer.GetLines()))
 		s.Require().Equal(0, len(printer.GetErrorLines()))
+		s.Require().Contains(printer.GetLines()[0], "Added plugin: ")
 
 		plugins, appErr := s.th.App.GetPlugins()
 		s.Require().Nil(appErr)

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -46,7 +46,7 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 
 		s.Require().Equal(1, len(printer.GetLines()))
 		s.Require().Equal(1, len(printer.GetErrorLines()))
-		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to add plugin"))
+		s.Require().Contains(printer.GetErrorLines()[0], "Unable to add plugin")
 		s.Require().Contains(printer.GetErrorLines()[0], "Unable to install plugin. A plugin with the same ID is already installed.")
 
 		plugins, appErr := s.th.App.GetPlugins()

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -41,10 +41,12 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 		s.Require().Equal(1, len(printer.GetLines()))
 		s.Require().Contains(printer.GetLines()[0], "Added plugin: ")
 
+		printer.Clean()
+
 		err = pluginAddCmdF(c, &cobra.Command{}, []string{pluginPath})
 		s.Require().Nil(err)
 
-		s.Require().Equal(1, len(printer.GetLines()))
+		s.Require().Equal(0, len(printer.GetLines()))
 		s.Require().Equal(1, len(printer.GetErrorLines()))
 		s.Require().Contains(printer.GetErrorLines()[0], "Unable to install plugin. A plugin with the same ID is already installed.")
 
@@ -78,12 +80,14 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 		s.Require().Equal(1, len(printer.GetLines()))
 		s.Require().Contains(printer.GetLines()[0], "Added plugin: ")
 
+		printer.Clean()
+
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool("force", true, "")
 		err = pluginAddCmdF(c, cmd, []string{pluginPath})
 		s.Require().Nil(err)
 
-		s.Require().Equal(2, len(printer.GetLines()))
+		s.Require().Equal(1, len(printer.GetLines()))
 		s.Require().Equal(0, len(printer.GetErrorLines()))
 
 		plugins, appErr := s.th.App.GetPlugins()

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -22,6 +22,82 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 
 	pluginPath := filepath.Join(os.Getenv("MM_SERVER_PATH"), "tests", "testplugin.tar.gz")
 
+	s.RunForSystemAdminAndLocal("add an already installed plugin without force", func(c client.Client) {
+		printer.Clean()
+
+		s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = true
+			*cfg.PluginSettings.EnableUploads = true
+		})
+
+		defer s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = false
+			*cfg.PluginSettings.EnableUploads = false
+		})
+
+		err := pluginAddCmdF(c, &cobra.Command{}, []string{pluginPath})
+		s.Require().Nil(err)
+
+		s.Require().Equal(1, len(printer.GetLines()))
+		s.Require().Contains(printer.GetLines()[0], "Added plugin: ")
+
+		err = pluginAddCmdF(c, &cobra.Command{}, []string{pluginPath})
+		s.Require().Nil(err)
+
+		s.Require().Equal(1, len(printer.GetLines()))
+		s.Require().Equal(1, len(printer.GetErrorLines()))
+		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to add plugin"))
+		s.Require().Contains(printer.GetErrorLines()[0], "Unable to install plugin. A plugin with the same ID is already installed.")
+
+		plugins, appErr := s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 0)
+		s.Require().Len(plugins.Inactive, 1)
+
+		// teardown
+		pInfo := plugins.Inactive[0]
+		appErr = s.th.App.RemovePlugin(pInfo.Id)
+		s.Require().Nil(appErr)
+	})
+
+	s.RunForSystemAdminAndLocal("add an already installed plugin with force", func(c client.Client) {
+		printer.Clean()
+
+		s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = true
+			*cfg.PluginSettings.EnableUploads = true
+		})
+
+		defer s.th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = false
+			*cfg.PluginSettings.EnableUploads = false
+		})
+
+		err := pluginAddCmdF(c, &cobra.Command{}, []string{pluginPath})
+		s.Require().Nil(err)
+
+		s.Require().Equal(1, len(printer.GetLines()))
+		s.Require().Contains(printer.GetLines()[0], "Added plugin: ")
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("force", true, "")
+		err = pluginAddCmdF(c, cmd, []string{pluginPath})
+		s.Require().Nil(err)
+
+		s.Require().Equal(2, len(printer.GetLines()))
+		s.Require().Equal(0, len(printer.GetErrorLines()))
+
+		plugins, appErr := s.th.App.GetPlugins()
+		s.Require().Nil(appErr)
+		s.Require().Len(plugins.Active, 0)
+		s.Require().Len(plugins.Inactive, 1)
+
+		// teardown
+		pInfo := plugins.Inactive[0]
+		appErr = s.th.App.RemovePlugin(pInfo.Id)
+		s.Require().Nil(appErr)
+	})
+
 	s.RunForSystemAdminAndLocal("admin and local can't add plugins if the config doesn't allow it", func(c client.Client) {
 		printer.Clean()
 

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -46,7 +46,6 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 
 		s.Require().Equal(1, len(printer.GetLines()))
 		s.Require().Equal(1, len(printer.GetErrorLines()))
-		s.Require().Contains(printer.GetErrorLines()[0], "Unable to add plugin")
 		s.Require().Contains(printer.GetErrorLines()[0], "Unable to install plugin. A plugin with the same ID is already installed.")
 
 		plugins, appErr := s.th.App.GetPlugins()

--- a/commands/plugin_test.go
+++ b/commands/plugin_test.go
@@ -39,6 +39,29 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 		s.Require().Equal(printer.GetLines()[0], "Added plugin: "+pluginName)
 	})
 
+	s.Run("Add 1 plugin, with force active", func() {
+		printer.Clean()
+		tmpFile, err := ioutil.TempFile("", "tmpPlugin")
+		s.Require().Nil(err)
+		defer os.Remove(tmpFile.Name())
+
+		pluginName := tmpFile.Name()
+
+		s.client.
+			EXPECT().
+			UploadPluginForced(gomock.AssignableToTypeOf(tmpFile)).
+			Return(&model.Manifest{}, &model.Response{}, nil).
+			Times(1)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("force", true, "")
+
+		err = pluginAddCmdF(s.client, cmd, []string{pluginName})
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Added plugin: "+pluginName)
+	})
+
 	s.Run("Add 1 plugin no file", func() {
 		printer.Clean()
 		err := pluginAddCmdF(s.client, &cobra.Command{}, []string{"non_existent_plugin"})

--- a/docs/mmctl_plugin_add.rst
+++ b/docs/mmctl_plugin_add.rst
@@ -27,7 +27,8 @@ Options
 
 ::
 
-  -h, --help   help for add
+  -f, --force   overwrite a previously installed plugin with the same ID, if any
+  -h, --help    help for add
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mocks/client_mock.go
+++ b/mocks/client_mock.go
@@ -2098,6 +2098,22 @@ func (mr *MockClientMockRecorder) UploadPlugin(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadPlugin", reflect.TypeOf((*MockClient)(nil).UploadPlugin), arg0)
 }
 
+// UploadPluginForced mocks base method
+func (m *MockClient) UploadPluginForced(arg0 io.Reader) (*model.Manifest, *model.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadPluginForced", arg0)
+	ret0, _ := ret[0].(*model.Manifest)
+	ret1, _ := ret[1].(*model.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UploadPluginForced indicates an expected call of UploadPluginForced
+func (mr *MockClientMockRecorder) UploadPluginForced(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadPluginForced", reflect.TypeOf((*MockClient)(nil).UploadPluginForced), arg0)
+}
+
 // VerifyUserEmailWithoutToken mocks base method
 func (m *MockClient) VerifyUserEmailWithoutToken(arg0 string) (*model.User, *model.Response, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
#### Summary
This allows users to add a plugin with add-and-replace-if-exists semantics when using the `mmctl plugin add`, by specifying the `--force` flag.

This is implemented by calling the `client.UploadPluginForced` function.

Supercedes mattermost/mattermost-server#18081 and resolves #382.