### PR TITLE
update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A remote CLI tool for [Mattermost](https://github.com/mattermost/mattermost-serv
 To install the project in your `$GOPATH`, simply run:
 
 ```
-go get -u github.com/mattermost/mmctl
+go get github.com/mattermost/mmctl
 ```
 
 ### Install shell completions

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A remote CLI tool for [Mattermost](https://github.com/mattermost/mattermost-serv
 To install the project in your `$GOPATH`, simply run:
 
 ```
-go get github.com/mattermost/mmctl
+go install github.com/mattermost/mmctl@latest
 ```
 
 ### Install shell completions


### PR DESCRIPTION


#### Summary
We should not use `-u` flag when installing mmctl. From the documentation:
```
The -u flag instructs get to update modules providing dependencies
of packages named on the command line to use newer minor or patch
releases when available.
```
This can cause some pain when trying to install if there are new versions of the dependencies.

Example: https://community-daily.mattermost.com/core/pl/dcfrp6nzptyuz89q5uziwcu9ic


