### PR TITLE
bump mmctl to 5.37.6

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	BuildHash = "dev mode"
-	Version   = "5.37.5"
+	Version   = "5.37.6"
 )
 
 var VersionCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/magefile/mage v1.11.0
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mattermost/gorp v2.0.1-0.20200527092429-d62b7b9cadfc+incompatible // indirect
-	github.com/mattermost/mattermost-server/v5 v5.37.5-0.20211123181022-2acaf591c40a
+	github.com/mattermost/mattermost-server/v5 v5.37.6-0.20211202103027-4473fc0e1827
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/poy/onpar v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -679,8 +679,8 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P8=
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
-github.com/mattermost/mattermost-server/v5 v5.37.5-0.20211123181022-2acaf591c40a h1:6tdwQ3kaWWxzq1MMlkDvxSHGjyjZ1l9upKYN3wMUlXo=
-github.com/mattermost/mattermost-server/v5 v5.37.5-0.20211123181022-2acaf591c40a/go.mod h1:S3zT7H4bAxsev1d2ThoSRBhyEXZa6JZOfpxvy2B25y4=
+github.com/mattermost/mattermost-server/v5 v5.37.6-0.20211202103027-4473fc0e1827 h1:VVlxZdL/ZYnj2N3qKKSL+Z8v6EVFgYOVf5Tu5tsxtlo=
+github.com/mattermost/mattermost-server/v5 v5.37.6-0.20211202103027-4473fc0e1827/go.mod h1:S3zT7H4bAxsev1d2ThoSRBhyEXZa6JZOfpxvy2B25y4=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/vendor/github.com/mattermost/mattermost-server/v5/model/version.go
+++ b/vendor/github.com/mattermost/mattermost-server/v5/model/version.go
@@ -13,6 +13,7 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"5.37.6",
 	"5.37.5",
 	"5.37.4",
 	"5.37.3",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -309,7 +309,7 @@ github.com/mattermost/ldap
 github.com/mattermost/logr
 github.com/mattermost/logr/format
 github.com/mattermost/logr/target
-# github.com/mattermost/mattermost-server/v5 v5.37.5-0.20211123181022-2acaf591c40a
+# github.com/mattermost/mattermost-server/v5 v5.37.6-0.20211202103027-4473fc0e1827
 github.com/mattermost/mattermost-server/v5/api4
 github.com/mattermost/mattermost-server/v5/app
 github.com/mattermost/mattermost-server/v5/app/featureflag


### PR DESCRIPTION
#### Summary
bump mmctl to 5.37.6 in the release-5.37 branch to prepare for the next server release

#### Ticket Link
n/a

