### PR TITLE
[MM-40604] Enable parsing of floating point values from config

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -208,6 +208,14 @@ func setValueWithConversion(val reflect.Value, newValue interface{}) error {
 		}
 		val.SetInt(v)
 		return nil
+	case reflect.Float32, reflect.Float64:
+		bits := val.Type().Bits()
+		v, err := strconv.ParseFloat(newValue.(string), bits)
+		if err != nil {
+			return fmt.Errorf("target value is of type %v and provided value is not", val.Kind())
+		}
+		val.SetFloat(v)
+		return nil
 	case reflect.String:
 		val.SetString(newValue.(string))
 		return nil


### PR DESCRIPTION
#### Summary

Numeric values coming from plugins' config are mapped to floating point numbers. This made it impossible to update them from `mmctl`.

E.g.

`mmctl --local config set PluginSettings.Plugins.com.mattermost.calls.udpserverport 8443`

would fail with:

```
Error: target value type is not supported
exit status 1
```

PR adds support for such conversion.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-40604