### PR TITLE
update mmctl to 6.1.2

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	BuildHash = "dev mode"
-	Version   = "6.1.1"
+	Version   = "6.1.2"
 )
 
 var VersionCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/magefile/mage v1.11.0
 	github.com/mattermost/gosaml2 v0.3.3
 	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d
-	github.com/mattermost/mattermost-server/v6 v6.1.1-0.20211123083306-e464e4fb6222
+	github.com/mattermost/mattermost-server/v6 v6.1.1
 	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -781,8 +781,8 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr/v2 v2.0.15 h1:+WNbGcsc3dBao65eXlceB6dTILNJRIrvubnsTl3zBew=
 github.com/mattermost/logr/v2 v2.0.15/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
-github.com/mattermost/mattermost-server/v6 v6.1.1-0.20211123083306-e464e4fb6222 h1:KYAXPYrGCEGA9+bYa1sMWtzgEiGl7Wt/3UVv+qlm3qk=
-github.com/mattermost/mattermost-server/v6 v6.1.1-0.20211123083306-e464e4fb6222/go.mod h1:VH26NcOr3xgkSBAvh4q+9+RoBD/M9gYO2F1PISq9KMw=
+github.com/mattermost/mattermost-server/v6 v6.1.1 h1:ZU4rCMCE3ic5sVa1OSIlebzI9iKkT2LpFJ6kWW1xrx8=
+github.com/mattermost/mattermost-server/v6 v6.1.1/go.mod h1:VH26NcOr3xgkSBAvh4q+9+RoBD/M9gYO2F1PISq9KMw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/vendor/github.com/mattermost/mattermost-server/v6/app/file.go
+++ b/vendor/github.com/mattermost/mattermost-server/v6/app/file.go
@@ -11,7 +11,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"image"
-	"image/gif"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -830,13 +829,11 @@ func (t *UploadFileTask) preprocessImage() *model.AppError {
 	// For animated GIFs disable the preview; since we have to Decode gifs
 	// anyway, cache the decoded image for later.
 	if t.fileinfo.MimeType == "image/gif" {
-		gifConfig, err := gif.DecodeAll(io.MultiReader(bytes.NewReader(t.buf.Bytes()), t.teeInput))
-		if err == nil {
-			if len(gifConfig.Image) > 0 {
-				t.fileinfo.HasPreviewImage = false
-				t.decoded = gifConfig.Image[0]
-				t.imageType = "gif"
-			}
+		image, format, err := t.imgDecoder.Decode(io.MultiReader(bytes.NewReader(t.buf.Bytes()), t.teeInput))
+		if err == nil && image != nil {
+			t.fileinfo.HasPreviewImage = false
+			t.decoded = image
+			t.imageType = format
 		}
 	}
 

--- a/vendor/github.com/mattermost/mattermost-server/v6/app/post_metadata.go
+++ b/vendor/github.com/mattermost/mattermost-server/v6/app/post_metadata.go
@@ -132,7 +132,7 @@ func (a *App) PreparePostForClient(originalPost *model.Post, isNewPost, isEditPo
 
 func (a *App) PreparePostForClientWithEmbedsAndImages(originalPost *model.Post, isNewPost, isEditPost bool) *model.Post {
 	post := a.PreparePostForClient(originalPost, isNewPost, isEditPost)
-	post = a.getEmbedsAndImages(post, true)
+	post = a.getEmbedsAndImages(post, isNewPost)
 	return post
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -370,7 +370,7 @@ github.com/mattermost/logr/v2
 github.com/mattermost/logr/v2/config
 github.com/mattermost/logr/v2/formatters
 github.com/mattermost/logr/v2/targets
-# github.com/mattermost/mattermost-server/v6 v6.1.1-0.20211123083306-e464e4fb6222
+# github.com/mattermost/mattermost-server/v6 v6.1.1
 ## explicit
 github.com/mattermost/mattermost-server/v6/api4
 github.com/mattermost/mattermost-server/v6/app


### PR DESCRIPTION

#### Summary
update mmctl to 6.1.2 on release 6.1 branch

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

