### PR TITLE
update mmctl to 6.0.5

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	BuildHash = "dev mode"
-	Version   = "6.0.4"
+	Version   = "6.0.5"
 )
 
 var VersionCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mattermost/gosaml2 v0.3.3
 	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d
-	github.com/mattermost/mattermost-server/v6 v6.0.4-0.20211123083334-bb4d1c41ba16
+	github.com/mattermost/mattermost-server/v6 v6.0.5-0.20211217224031-76e1b689fb02
 	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/mattermost/logr v1.0.13 h1:6F/fM3csvH6Oy5sUpJuW7YyZSzZZAhJm5VcgKMxA2P
 github.com/mattermost/logr v1.0.13/go.mod h1:Mt4DPu1NXMe6JxPdwCC0XBoxXmN9eXOIRPoZarU2PXs=
 github.com/mattermost/logr/v2 v2.0.10 h1:i6rJbuX/EkBM9maM8M0eJ3rxB+fsBKNslPvzSlA2w/M=
 github.com/mattermost/logr/v2 v2.0.10/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
-github.com/mattermost/mattermost-server/v6 v6.0.4-0.20211123083334-bb4d1c41ba16 h1:itxPLZEJXO5hk8JCYBMFth+1XGaWTPUKkXCg9pCHmJs=
-github.com/mattermost/mattermost-server/v6 v6.0.4-0.20211123083334-bb4d1c41ba16/go.mod h1:I7hgNyInWiVaIcGjYMDoJufO1E4SbK3Zj+3OEIk417g=
+github.com/mattermost/mattermost-server/v6 v6.0.5-0.20211217224031-76e1b689fb02 h1:3iyf4lsQSLu9cxuIKzUfkUviJtt+nGGSt/jrycpRiDU=
+github.com/mattermost/mattermost-server/v6 v6.0.5-0.20211217224031-76e1b689fb02/go.mod h1:I7hgNyInWiVaIcGjYMDoJufO1E4SbK3Zj+3OEIk417g=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/vendor/github.com/mattermost/mattermost-server/v6/app/file.go
+++ b/vendor/github.com/mattermost/mattermost-server/v6/app/file.go
@@ -11,7 +11,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"image"
-	"image/gif"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -830,13 +829,11 @@ func (t *UploadFileTask) preprocessImage() *model.AppError {
 	// For animated GIFs disable the preview; since we have to Decode gifs
 	// anyway, cache the decoded image for later.
 	if t.fileinfo.MimeType == "image/gif" {
-		gifConfig, err := gif.DecodeAll(io.MultiReader(bytes.NewReader(t.buf.Bytes()), t.teeInput))
-		if err == nil {
-			if len(gifConfig.Image) > 0 {
-				t.fileinfo.HasPreviewImage = false
-				t.decoded = gifConfig.Image[0]
-				t.imageType = "gif"
-			}
+		image, format, err := t.imgDecoder.Decode(io.MultiReader(bytes.NewReader(t.buf.Bytes()), t.teeInput))
+		if err == nil && image != nil {
+			t.fileinfo.HasPreviewImage = false
+			t.decoded = image
+			t.imageType = format
 		}
 	}
 

--- a/vendor/github.com/mattermost/mattermost-server/v6/app/post_metadata.go
+++ b/vendor/github.com/mattermost/mattermost-server/v6/app/post_metadata.go
@@ -132,7 +132,7 @@ func (a *App) PreparePostForClient(originalPost *model.Post, isNewPost, isEditPo
 
 func (a *App) PreparePostForClientWithEmbedsAndImages(originalPost *model.Post, isNewPost, isEditPost bool) *model.Post {
 	post := a.PreparePostForClient(originalPost, isNewPost, isEditPost)
-	post = a.getEmbedsAndImages(post, true)
+	post = a.getEmbedsAndImages(post, isNewPost)
 	return post
 }
 

--- a/vendor/github.com/mattermost/mattermost-server/v6/model/version.go
+++ b/vendor/github.com/mattermost/mattermost-server/v6/model/version.go
@@ -13,6 +13,7 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"6.0.5",
 	"6.0.4",
 	"6.0.3",
 	"6.0.2",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -364,7 +364,7 @@ github.com/mattermost/logr/v2
 github.com/mattermost/logr/v2/config
 github.com/mattermost/logr/v2/formatters
 github.com/mattermost/logr/v2/targets
-# github.com/mattermost/mattermost-server/v6 v6.0.4-0.20211123083334-bb4d1c41ba16
+# github.com/mattermost/mattermost-server/v6 v6.0.5-0.20211217224031-76e1b689fb02
 ## explicit
 github.com/mattermost/mattermost-server/v6/api4
 github.com/mattermost/mattermost-server/v6/app


### PR DESCRIPTION
#### Summary
update mmctl to 6.0.5

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

