### PR TITLE
Support semantic versioning for go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ENTERPRISE_HASH ?= $(shell cat enterprise_hash)
 TESTFLAGS = -mod=vendor -timeout 30m -race -v
 
 
-PKG=github.com/mattermost/mmctl/commands
+PKG=github.com/mattermost/mmctl/v6/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)
 BUILD_TAGS =
 
@@ -33,7 +33,7 @@ include config.mk
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifneq ($(wildcard ${ENTERPRISE_DIR}/.*),)
-	TESTFLAGS += -ldflags '-X "github.com/mattermost/mmctl/commands.EnableEnterpriseTests=true" -X "github.com/mattermost/mattermost-server/v6/model.BuildEnterpriseReady=true"'
+	TESTFLAGS += -ldflags '-X "github.com/mattermost/mmctl/v6/commands.EnableEnterpriseTests=true" -X "github.com/mattermost/mattermost-server/v6/model.BuildEnterpriseReady=true"'
 	BUILD_TAGS +=enterprise
 	IGNORE:=$(shell echo Enterprise build selected, preparing)
 	IGNORE:=$(shell rm -rf $(VENDOR_MM_SERVER_DIR)/enterprise)

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 var AuthCmd = &cobra.Command{

--- a/commands/auth_e2e_test.go
+++ b/commands/auth_e2e_test.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestAuthLoginWithTrailingSlashInInstanceURL() {

--- a/commands/auth_utils.go
+++ b/commands/auth_utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 const (

--- a/commands/bot.go
+++ b/commands/bot.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/bot_e2e_test.go
+++ b/commands/bot_e2e_test.go
@@ -6,8 +6,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/bot_test.go
+++ b/commands/bot_test.go
@@ -9,7 +9,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/channel.go
+++ b/commands/channel.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/web"

--- a/commands/channel_e2e_test.go
+++ b/commands/channel_e2e_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestListChannelsCmdF() {

--- a/commands/channel_test.go
+++ b/commands/channel_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/web"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/channel_users.go
+++ b/commands/channel_users.go
@@ -4,8 +4,8 @@
 package commands
 
 import (
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"

--- a/commands/channel_users_e2e_test.go
+++ b/commands/channel_users_e2e_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestChannelUsersAddCmdF() {

--- a/commands/channel_users_test.go
+++ b/commands/channel_users_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/channelargs.go
+++ b/commands/channelargs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/v6/client"
 )
 
 const channelArgSeparator = ":"

--- a/commands/command.go
+++ b/commands/command.go
@@ -12,8 +12,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 var CommandCmd = &cobra.Command{

--- a/commands/command_e2e_test.go
+++ b/commands/command_e2e_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestListCommandCmd() {

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/commandargs.go
+++ b/commands/commandargs.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"strings"
 
-	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/v6/client"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 )

--- a/commands/config.go
+++ b/commands/config.go
@@ -16,8 +16,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/utils"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/config_e2e_test.go
+++ b/commands/config_e2e_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestConfigResetCmdE2E() {

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 const (

--- a/commands/export.go
+++ b/commands/export.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/export_e2e_test.go
+++ b/commands/export_e2e_test.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/utils"

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/extract.go
+++ b/commands/extract.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/extract_e2e_test.go
+++ b/commands/extract_e2e_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/group.go
+++ b/commands/group.go
@@ -6,8 +6,8 @@ package commands
 import (
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/group_e2e_test.go
+++ b/commands/group_e2e_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestChannelGroupEnableCmd() {

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/import.go
+++ b/commands/import.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/import_e2e_test.go
+++ b/commands/import_e2e_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 )

--- a/commands/init.go
+++ b/commands/init.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 var (

--- a/commands/integrity.go
+++ b/commands/integrity.go
@@ -6,8 +6,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/integrity_test.go
+++ b/commands/integrity_test.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/ldap.go
+++ b/commands/ldap.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 var LdapCmd = &cobra.Command{

--- a/commands/ldap_e2e_test.go
+++ b/commands/ldap_e2e_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/utils/testutils"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func configForLdap(th *api4.TestHelper) {

--- a/commands/ldap_test.go
+++ b/commands/ldap_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/license.go
+++ b/commands/license.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"io/ioutil"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/license_e2e_test.go
+++ b/commands/license_e2e_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestRemoveLicenseCmd() {

--- a/commands/license_test.go
+++ b/commands/license_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 const (

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -13,9 +13,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
-	"github.com/mattermost/mmctl/printer/human"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
+	"github.com/mattermost/mmctl/v6/printer/human"
 )
 
 var LogsCmd = &cobra.Command{

--- a/commands/logs_e2e_test.go
+++ b/commands/logs_e2e_test.go
@@ -4,7 +4,7 @@
 package commands
 
 import (
-	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/v6/client"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/logs_test.go
+++ b/commands/logs_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/v6/client"
 )
 
 const (

--- a/commands/mmctl_test.go
+++ b/commands/mmctl_test.go
@@ -4,9 +4,9 @@
 package commands
 
 import (
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/mocks"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/mocks"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"

--- a/commands/permission_role_test.go
+++ b/commands/permission_role_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 

--- a/commands/permissions.go
+++ b/commands/permissions.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/permissions_e2e_test.go
+++ b/commands/permissions_e2e_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/permissions_reset_e2e_test.go
+++ b/commands/permissions_reset_e2e_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 )

--- a/commands/permissions_role.go
+++ b/commands/permissions_role.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/permissions_role_e2e_test.go
+++ b/commands/permissions_role_e2e_test.go
@@ -4,8 +4,8 @@
 package commands
 
 import (
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"

--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -6,8 +6,8 @@ package commands
 import (
 	"os"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestPluginAddCmd() {

--- a/commands/plugin_marketplace.go
+++ b/commands/plugin_marketplace.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/plugin_marketplace_e2e_test.go
+++ b/commands/plugin_marketplace_e2e_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestPluginMarketplaceInstallCmd() {

--- a/commands/plugin_marketplace_test.go
+++ b/commands/plugin_marketplace_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/plugin_test.go
+++ b/commands/plugin_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/post.go
+++ b/commands/post.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/post_test.go
+++ b/commands/post_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlUnitTestSuite) TestPostCreateCmdF() {

--- a/commands/roles.go
+++ b/commands/roles.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/roles_test.go
+++ b/commands/roles_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/root.go
+++ b/commands/root.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func Run(args []string) error {

--- a/commands/saml.go
+++ b/commands/saml.go
@@ -6,8 +6,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/saml_test.go
+++ b/commands/saml_test.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/sampledata.go
+++ b/commands/sampledata.go
@@ -14,8 +14,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/app"
 	"github.com/mattermost/mattermost-server/v6/model"

--- a/commands/sampledata_test.go
+++ b/commands/sampledata_test.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/system.go
+++ b/commands/system.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 var SystemCmd = &cobra.Command{

--- a/commands/system_e2e_test.go
+++ b/commands/system_e2e_test.go
@@ -6,8 +6,8 @@ package commands
 import (
 	"time"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"

--- a/commands/system_test.go
+++ b/commands/system_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/team.go
+++ b/commands/team.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestRenameTeamCmdF() {

--- a/commands/team_test.go
+++ b/commands/team_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/team_users.go
+++ b/commands/team_users.go
@@ -8,8 +8,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 var TeamUsersCmd = &cobra.Command{

--- a/commands/team_users_e2e_test.go
+++ b/commands/team_users_e2e_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestTeamUserAddCmd() {

--- a/commands/team_users_test.go
+++ b/commands/team_users_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {

--- a/commands/teamargs.go
+++ b/commands/teamargs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/v6/client"
 )
 
 func getTeamsFromTeamArgs(c client.Client, teamArgs []string) []*model.Team {

--- a/commands/token.go
+++ b/commands/token.go
@@ -6,8 +6,8 @@ package commands
 import (
 	"net/http"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/token_e2e_test.go
+++ b/commands/token_e2e_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestTokenGenerateForUserCmd() {

--- a/commands/token_test.go
+++ b/commands/token_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/user.go
+++ b/commands/user.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/user_e2e_test.go
+++ b/commands/user_e2e_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlE2ETestSuite) TestUserActivateCmd() {

--- a/commands/user_test.go
+++ b/commands/user_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/userargs.go
+++ b/commands/userargs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
+	"github.com/mattermost/mmctl/v6/client"
 )
 
 func getUsersFromUserArgs(c client.Client, userArgs []string) []*model.User {

--- a/commands/userargs_test.go
+++ b/commands/userargs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 )
 
 func (s *MmctlUnitTestSuite) TestGetUserFromArgs() {

--- a/commands/version.go
+++ b/commands/version.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/commands/webhook.go
+++ b/commands/webhook.go
@@ -6,8 +6,8 @@ package commands
 import (
 	"github.com/mattermost/mattermost-server/v6/model"
 
-	"github.com/mattermost/mmctl/client"
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/client"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/commands/webhook_test.go
+++ b/commands/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mmctl/printer"
+	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattermost/mmctl
+module github.com/mattermost/mmctl/v6
 
 go 1.16
 

--- a/mmctl.go
+++ b/mmctl.go
@@ -6,7 +6,7 @@ package main
 import (
 	"os"
 
-	"github.com/mattermost/mmctl/commands"
+	"github.com/mattermost/mmctl/v6/commands"
 )
 
 func main() {


### PR DESCRIPTION
Would it make sense to add version to module path at this point?