### PR TITLE
[MM-41339] commands/webhook: add user id to the request payload

### DIFF
--- a/commands/webhook.go
+++ b/commands/webhook.go
@@ -167,6 +167,7 @@ func createIncomingWebhookCmdF(c client.Client, command *cobra.Command, args []s
 		IconURL:       iconURL,
 		ChannelLocked: channelLocked,
 		Username:      user.Username,
+		UserId:        user.Id,
 	}
 
 	createdIncoming, _, err := c.CreateIncomingWebhook(incomingWebhook)

--- a/commands/webhook_test.go
+++ b/commands/webhook_test.go
@@ -166,6 +166,7 @@ func (s *MmctlUnitTestSuite) TestCreateIncomingWebhookCmd() {
 			ChannelId:   channelID,
 			Username:    userName,
 			DisplayName: displayName,
+			UserId:      userID,
 		}
 		returnedIncomingWebhook := mockIncomingWebhook
 		returnedIncomingWebhook.Id = incomingWebhookID
@@ -210,6 +211,7 @@ func (s *MmctlUnitTestSuite) TestCreateIncomingWebhookCmd() {
 			ChannelId:   channelID,
 			Username:    userName,
 			DisplayName: displayName,
+			UserId:      userID,
 		}
 		mockError := errors.New("mock error")
 


### PR DESCRIPTION
#### Summary
Adds the forgotten user id to the webhook.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41339

