### PR TITLE
[MM-41665] Set the AllowOpenInvite field to define public/invite only teams

### DIFF
--- a/commands/team.go
+++ b/commands/team.go
@@ -148,15 +148,18 @@ func createTeamCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	useprivate, _ := cmd.Flags().GetBool("private")
 
 	teamType := model.TeamOpen
+	allowOpenInvite := true
 	if useprivate {
 		teamType = model.TeamInvite
+		allowOpenInvite = false
 	}
 
 	team := &model.Team{
-		Name:        name,
-		DisplayName: displayname,
-		Email:       email,
-		Type:        teamType,
+		Name:            name,
+		DisplayName:     displayname,
+		Email:           email,
+		Type:            teamType,
+		AllowOpenInvite: allowOpenInvite,
 	}
 
 	newTeam, _, err := c.CreateTeam(team)

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -294,6 +294,7 @@ func (s *MmctlE2ETestSuite) TestTeamCreateCmdF() {
 		newTeam, err := s.th.App.GetTeamByName(teamName)
 		s.Require().Nil(err)
 		s.Equal(newTeam.Type, model.TeamOpen)
+		s.Equal(newTeam.AllowOpenInvite, true)
 	})
 
 	s.RunForAllClients("Should create a new private team", func(c client.Client) {
@@ -310,6 +311,7 @@ func (s *MmctlE2ETestSuite) TestTeamCreateCmdF() {
 		newTeam, err := s.th.App.GetTeamByName(teamName)
 		s.Require().Nil(err)
 		s.Equal(newTeam.Type, model.TeamInvite)
+		s.Equal(newTeam.AllowOpenInvite, false)
 	})
 }
 

--- a/commands/team_test.go
+++ b/commands/team_test.go
@@ -46,9 +46,10 @@ func (s *MmctlUnitTestSuite) TestCreateTeamCmd() {
 		cmd.Flags().String("display-name", mockTeamDisplayname, "")
 
 		mockTeam := &model.Team{
-			Name:        mockTeamName,
-			DisplayName: mockTeamDisplayname,
-			Type:        model.TeamOpen,
+			Name:            mockTeamName,
+			DisplayName:     mockTeamDisplayname,
+			Type:            model.TeamOpen,
+			AllowOpenInvite: true,
 		}
 
 		s.client.
@@ -72,10 +73,11 @@ func (s *MmctlUnitTestSuite) TestCreateTeamCmd() {
 		cmd.Flags().Bool("private", true, "")
 
 		mockTeam := &model.Team{
-			Name:        mockTeamName,
-			DisplayName: mockTeamDisplayname,
-			Email:       mockTeamEmail,
-			Type:        model.TeamInvite,
+			Name:            mockTeamName,
+			DisplayName:     mockTeamDisplayname,
+			Email:           mockTeamEmail,
+			Type:            model.TeamInvite,
+			AllowOpenInvite: false,
 		}
 
 		s.client.
@@ -97,9 +99,10 @@ func (s *MmctlUnitTestSuite) TestCreateTeamCmd() {
 		cmd.Flags().String("display-name", mockTeamDisplayname, "")
 
 		mockTeam := &model.Team{
-			Name:        mockTeamName,
-			DisplayName: mockTeamDisplayname,
-			Type:        model.TeamOpen,
+			Name:            mockTeamName,
+			DisplayName:     mockTeamDisplayname,
+			Type:            model.TeamOpen,
+			AllowOpenInvite: true,
 		}
 		mockError := errors.New("remote error")
 


### PR DESCRIPTION
#### Summary
We now use the `AllowOpenInvite` field on `Team` to determine if a team is public/invite. This PR ensures this field is set when creating a team.
More context @ https://community-daily.mattermost.com/private-core/pl/kft3wugsnfbqzjuayzrurwnimc
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41665