### PR TITLE
[MM-42100] Fixes: team users add and remove command example

### DIFF
--- a/commands/team_users.go
+++ b/commands/team_users.go
@@ -21,7 +21,7 @@ var TeamUsersRemoveCmd = &cobra.Command{
 	Use:     "remove [team] [users]",
 	Short:   "Remove users from team",
 	Long:    "Remove some users from team",
-	Example: "  team remove myteam user@example.com username",
+	Example: "  team users remove myteam user@example.com username",
 	Args:    cobra.MinimumNArgs(2),
 	RunE:    withClient(teamUsersRemoveCmdF),
 }
@@ -30,7 +30,7 @@ var TeamUsersAddCmd = &cobra.Command{
 	Use:     "add [team] [users]",
 	Short:   "Add users to team",
 	Long:    "Add some users to team",
-	Example: "  team add myteam user@example.com username",
+	Example: "  team users add myteam user@example.com username",
 	Args:    cobra.MinimumNArgs(2),
 	RunE:    withClient(teamUsersAddCmdF),
 }

--- a/docs/mmctl_team_users_add.rst
+++ b/docs/mmctl_team_users_add.rst
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-    team add myteam user@example.com username
+    team users add myteam user@example.com username
 
 Options
 ~~~~~~~

--- a/docs/mmctl_team_users_remove.rst
+++ b/docs/mmctl_team_users_remove.rst
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-    team remove myteam user@example.com username
+    team users remove myteam user@example.com username
 
 Options
 ~~~~~~~


### PR DESCRIPTION
#### Summary
Fixes: team users add and remove command example

from : 
 ``team add myteam user@example.com username``
 to 
  ``team users add myteam user@example.com username``
  
  same for remove

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-42100
  Fixes https://github.com/mattermost/mattermost-server/issues/19637
