### PR TITLE
Makefile: get version from the git tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ VENDOR_MM_SERVER_DIR ?= vendor/github.com/mattermost/mattermost-server/v6
 ENTERPRISE_HASH ?= $(shell cat enterprise_hash)
 TESTFLAGS = -mod=vendor -timeout 30m -race -v
 
+# We specify version for the build; it is the latest semantic version of the tags
+DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
 
 PKG=github.com/mattermost/mmctl/v6/commands
-LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)
+LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)
 BUILD_TAGS =
 
 .PHONY: all

--- a/commands/version.go
+++ b/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	Version = "6.4.2"
+	Version = "unspecified"
 	// SHA1 from git, output of $(git rev-parse HEAD)
 	gitCommit = "dev mode"
 	// State of git tree, either "clean" or "dirty"


### PR DESCRIPTION
#### Summary
We get the version number from the recent git tags. So if we need to build this for release, we need to create the tag before releasing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42701

