### PR TITLE
Drop support for installing a plugin with a specific version

### DIFF
--- a/commands/plugin_marketplace.go
+++ b/commands/plugin_marketplace.go
@@ -19,13 +19,12 @@ var PluginMarketplaceCmd = &cobra.Command{
 }
 
 var PluginMarketplaceInstallCmd = &cobra.Command{
-	Use:   "install <id>",
-	Short: "Install a plugin from the marketplace",
-	Long:  "Installs a plugin listed in the marketplace server",
-	Example: `  # you can specify with both the plugin id
-  $ mmctl plugin marketplace install jitsi`,
-	Args: cobra.ExactArgs(1),
-	RunE: withClient(pluginMarketplaceInstallCmdF),
+	Use:     "install <id>",
+	Short:   "Install a plugin from the marketplace",
+	Long:    "Installs a plugin listed in the marketplace server",
+	Example: `  plugin marketplace install jitsi`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    withClient(pluginMarketplaceInstallCmdF),
 }
 
 var PluginMarketplaceListCmd = &cobra.Command{

--- a/commands/plugin_marketplace.go
+++ b/commands/plugin_marketplace.go
@@ -4,8 +4,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/mattermost/mattermost-server/v6/model"
 
 	"github.com/mattermost/mmctl/v6/client"
@@ -21,15 +19,12 @@ var PluginMarketplaceCmd = &cobra.Command{
 }
 
 var PluginMarketplaceInstallCmd = &cobra.Command{
-	Use:   "install <id> [version]",
+	Use:   "install <id>",
 	Short: "Install a plugin from the marketplace",
 	Long:  "Installs a plugin listed in the marketplace server",
-	Example: `  # you can specify with both the plugin id and its version
-  $ mmctl plugin marketplace install jitsi 2.0.0
-
-  # if you don't specify the version, the latest one will be installed
+	Example: `  # you can specify with both the plugin id
   $ mmctl plugin marketplace install jitsi`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.ExactArgs(1),
 	RunE: withClient(pluginMarketplaceInstallCmdF),
 }
 
@@ -71,28 +66,8 @@ func init() {
 
 func pluginMarketplaceInstallCmdF(c client.Client, _ *cobra.Command, args []string) error {
 	id := args[0]
-	var version string
 
-	if len(args) < 2 {
-		plugins, _, err := c.GetMarketplacePlugins(&model.MarketplacePluginFilter{Filter: id, PerPage: 200})
-		if err != nil {
-			return errors.Wrap(err, "Failed to fetch plugins")
-		}
-
-		for _, plugin := range plugins {
-			if plugin.Manifest.Id == id {
-				version = plugin.Manifest.Version
-			}
-		}
-
-		if version == "" {
-			return fmt.Errorf("couldn't find a plugin with id %q", id)
-		}
-	} else {
-		version = args[1]
-	}
-
-	pluginRequest := &model.InstallMarketplacePluginRequest{Id: id, Version: version}
+	pluginRequest := &model.InstallMarketplacePluginRequest{Id: id}
 	manifest, _, err := c.InstallMarketplacePlugin(pluginRequest)
 	if err != nil {
 		return errors.Wrap(err, "couldn't install plugin from marketplace")

--- a/commands/plugin_marketplace_e2e_test.go
+++ b/commands/plugin_marketplace_e2e_test.go
@@ -33,7 +33,7 @@ func (s *MmctlE2ETestSuite) TestPluginMarketplaceInstallCmd() {
 
 		defer removePluginIfInstalled(c, s, pluginID)
 
-		err := pluginMarketplaceInstallCmdF(c, &cobra.Command{}, []string{pluginID, pluginVersion})
+		err := pluginMarketplaceInstallCmdF(c, &cobra.Command{}, []string{pluginID})
 		s.Require().Nil(err)
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 1)
@@ -54,63 +54,14 @@ func (s *MmctlE2ETestSuite) TestPluginMarketplaceInstallCmd() {
 		printer.Clean()
 
 		const (
-			pluginID      = "jira"
-			pluginVersion = "3.0.0"
+			pluginID = "jira"
 		)
 
 		defer removePluginIfInstalled(s.th.Client, s, pluginID)
 
-		err := pluginMarketplaceInstallCmdF(s.th.Client, &cobra.Command{}, []string{pluginID, pluginVersion})
+		err := pluginMarketplaceInstallCmdF(s.th.Client, &cobra.Command{}, []string{pluginID})
 		s.Require().NotNil(err)
 		s.Require().Contains(err.Error(), "You do not have the appropriate permissions.")
-		s.Require().Len(printer.GetErrorLines(), 0)
-		s.Require().Len(printer.GetLines(), 0)
-
-		plugins, appErr := s.th.App.GetPlugins()
-		s.Require().Nil(appErr)
-		s.Require().Len(plugins.Active, 0)
-		s.Require().Len(plugins.Inactive, 0)
-	})
-
-	s.RunForSystemAdminAndLocal("install a plugin without version", func(c client.Client) {
-		printer.Clean()
-
-		const (
-			pluginID = "jira"
-		)
-
-		defer removePluginIfInstalled(c, s, pluginID)
-
-		err := pluginMarketplaceInstallCmdF(c, &cobra.Command{}, []string{pluginID})
-		s.Require().Nil(err)
-		s.Require().Len(printer.GetErrorLines(), 0)
-		s.Require().Len(printer.GetLines(), 1)
-
-		manifest := printer.GetLines()[0].(*model.Manifest)
-		s.Require().Equal(pluginID, manifest.Id)
-		s.Require().NotEmpty(manifest.Version)
-
-		plugins, appErr := s.th.App.GetPlugins()
-		s.Require().Nil(appErr)
-		s.Require().Len(plugins.Active, 0)
-		s.Require().Len(plugins.Inactive, 1)
-		s.Require().Equal(pluginID, plugins.Inactive[0].Id)
-		s.Require().NotEmpty(plugins.Inactive[0].Version)
-	})
-
-	s.RunForSystemAdminAndLocal("install a plugin with invalid version", func(c client.Client) {
-		printer.Clean()
-
-		const (
-			pluginID      = "jira"
-			pluginVersion = "invalid-version"
-		)
-
-		defer removePluginIfInstalled(c, s, pluginID)
-
-		err := pluginMarketplaceInstallCmdF(c, &cobra.Command{}, []string{pluginID, pluginVersion})
-		s.Require().NotNil(err)
-		s.Require().Contains(err.Error(), "Could not find the requested marketplace plugin.")
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 0)
 

--- a/commands/plugin_marketplace_test.go
+++ b/commands/plugin_marketplace_test.go
@@ -25,9 +25,8 @@ func (s *MmctlUnitTestSuite) TestPluginMarketplaceInstallCmd() {
 		printer.Clean()
 
 		id := "myplugin"
-		version := "2.0.0"
-		args := []string{id, version}
-		pluginRequest := &model.InstallMarketplacePluginRequest{Id: id, Version: version}
+		args := []string{id}
+		pluginRequest := &model.InstallMarketplacePluginRequest{Id: id}
 		manifest := &model.Manifest{Name: "My Plugin", Id: id}
 
 		s.client.
@@ -37,39 +36,6 @@ func (s *MmctlUnitTestSuite) TestPluginMarketplaceInstallCmd() {
 			Times(1)
 
 		err := pluginMarketplaceInstallCmdF(s.client, &cobra.Command{}, args)
-		s.Require().NoError(err)
-		s.Require().Len(printer.GetErrorLines(), 0)
-		s.Require().Len(printer.GetLines(), 1)
-		s.Require().Equal(manifest, printer.GetLines()[0])
-	})
-
-	s.Run("Install a valid plugin omitting the version", func() {
-		printer.Clean()
-
-		id := "myplugin"
-		version := "2.0.0"
-
-		plugin := createMarketplacePlugin(id)
-		plugin.BaseMarketplacePlugin.Manifest.Id = id
-		plugin.BaseMarketplacePlugin.Manifest.Version = version
-		plugins := []*model.MarketplacePlugin{plugin}
-
-		pluginRequest := &model.InstallMarketplacePluginRequest{Id: id, Version: version}
-		manifest := &model.Manifest{Name: "My Plugin", Id: id}
-
-		s.client.
-			EXPECT().
-			GetMarketplacePlugins(&model.MarketplacePluginFilter{Filter: id, PerPage: 200}).
-			Return(plugins, &model.Response{}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			InstallMarketplacePlugin(pluginRequest).
-			Return(manifest, &model.Response{}, nil).
-			Times(1)
-
-		err := pluginMarketplaceInstallCmdF(s.client, &cobra.Command{}, []string{id})
 		s.Require().NoError(err)
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 1)
@@ -80,9 +46,8 @@ func (s *MmctlUnitTestSuite) TestPluginMarketplaceInstallCmd() {
 		printer.Clean()
 
 		id := "myplugin"
-		version := "2.0.0"
-		args := []string{id, version}
-		pluginRequest := &model.InstallMarketplacePluginRequest{Id: id, Version: version}
+		args := []string{id}
+		pluginRequest := &model.InstallMarketplacePluginRequest{Id: id}
 
 		s.client.
 			EXPECT().
@@ -91,40 +56,6 @@ func (s *MmctlUnitTestSuite) TestPluginMarketplaceInstallCmd() {
 			Times(1)
 
 		err := pluginMarketplaceInstallCmdF(s.client, &cobra.Command{}, args)
-		s.Require().Error(err)
-		s.Require().Len(printer.GetErrorLines(), 0)
-		s.Require().Len(printer.GetLines(), 0)
-	})
-
-	s.Run("Install an invalid plugin omitting the version", func() {
-		printer.Clean()
-
-		id := "myplugin"
-
-		s.client.
-			EXPECT().
-			GetMarketplacePlugins(&model.MarketplacePluginFilter{Filter: id, PerPage: 200}).
-			Return(nil, &model.Response{}, errors.New("mock error")).
-			Times(1)
-
-		err := pluginMarketplaceInstallCmdF(s.client, &cobra.Command{}, []string{id})
-		s.Require().Error(err)
-		s.Require().Len(printer.GetErrorLines(), 0)
-		s.Require().Len(printer.GetLines(), 0)
-	})
-
-	s.Run("Install a nonexisting plugin omitting the version", func() {
-		printer.Clean()
-
-		id := "myplugin"
-
-		s.client.
-			EXPECT().
-			GetMarketplacePlugins(&model.MarketplacePluginFilter{Filter: id, PerPage: 200}).
-			Return([]*model.MarketplacePlugin{}, &model.Response{}, nil).
-			Times(1)
-
-		err := pluginMarketplaceInstallCmdF(s.client, &cobra.Command{}, []string{id})
 		s.Require().Error(err)
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Len(printer.GetLines(), 0)

--- a/docs/mmctl_plugin_marketplace_install.rst
+++ b/docs/mmctl_plugin_marketplace_install.rst
@@ -20,8 +20,7 @@ Examples
 
 ::
 
-    # you can specify with both the plugin id
-    $ mmctl plugin marketplace install jitsi
+    plugin marketplace install jitsi
 
 Options
 ~~~~~~~

--- a/docs/mmctl_plugin_marketplace_install.rst
+++ b/docs/mmctl_plugin_marketplace_install.rst
@@ -13,17 +13,14 @@ Installs a plugin listed in the marketplace server
 
 ::
 
-  mmctl plugin marketplace install <id> [version] [flags]
+  mmctl plugin marketplace install <id> [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    # you can specify with both the plugin id and its version
-    $ mmctl plugin marketplace install jitsi 2.0.0
-
-    # if you don't specify the version, the latest one will be installed
+    # you can specify with both the plugin id
     $ mmctl plugin marketplace install jitsi
 
 Options


### PR DESCRIPTION
#### Summary
Since https://github.com/mattermost/mattermost-server/pull/19613, the Marketplace install endpoint always installs the latest version of a given plugin.

This PR updated `mmctl` to take that into account and drops the support for passing a version as part of the command. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42721

