### PR TITLE
Prepare release 6.3.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ENTERPRISE_HASH ?= $(shell cat enterprise_hash)
 TESTFLAGS = -mod=vendor -timeout 30m -race -v
 
 # We specify version for the build; it is the latest semantic version of the tags
-DIST_VER=v6.3.7
+DIST_VER=$(shell git tag -l --sort=-version:refname "v6.3.*" | head -n 1)
 
 PKG=github.com/mattermost/mmctl/v6/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ TESTFLAGS = -mod=vendor -timeout 30m -race -v
 # We specify version for the build; it is the latest semantic version of the tags
 DIST_VER=$(shell git tag -l --sort=-version:refname "v6.3.*" | head -n 1)
 
-PKG=github.com/mattermost/mmctl/v6/commands
+PKG=github.com/mattermost/mmctl/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)
 BUILD_TAGS =
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ENTERPRISE_HASH ?= $(shell cat enterprise_hash)
 TESTFLAGS = -mod=vendor -timeout 30m -race -v
 
 # We specify version for the build; it is the latest semantic version of the tags
-DIST_VER=v6.3.6
+DIST_VER=v6.3.7
 
 PKG=github.com/mattermost/mmctl/v6/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,16 @@ VENDOR_MM_SERVER_DIR ?= vendor/github.com/mattermost/mattermost-server/v6
 ENTERPRISE_HASH ?= $(shell cat enterprise_hash)
 TESTFLAGS = -mod=vendor -timeout 30m -race -v
 
+# We specify version for the build; it is the latest semantic version of the tags
+DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
 
+<<<<<<< HEAD
 PKG=github.com/mattermost/mmctl/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)
+=======
+PKG=github.com/mattermost/mmctl/v6/commands
+LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)
+>>>>>>> d5ed8eb4... Makefile: get version from the git tags (#488)
 BUILD_TAGS =
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,8 @@ TESTFLAGS = -mod=vendor -timeout 30m -race -v
 # We specify version for the build; it is the latest semantic version of the tags
 DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
 
-<<<<<<< HEAD
-PKG=github.com/mattermost/mmctl/commands
-LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)
-=======
 PKG=github.com/mattermost/mmctl/v6/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)
->>>>>>> d5ed8eb4... Makefile: get version from the git tags (#488)
 BUILD_TAGS =
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ENTERPRISE_HASH ?= $(shell cat enterprise_hash)
 TESTFLAGS = -mod=vendor -timeout 30m -race -v
 
 # We specify version for the build; it is the latest semantic version of the tags
-DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
+DIST_VER=v6.3.6
 
 PKG=github.com/mattermost/mmctl/v6/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)

--- a/commands/version.go
+++ b/commands/version.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	Version = "6.3.6"
+	Version = "unspecified"
 	// SHA1 from git, output of $(git rev-parse HEAD)
 	gitCommit = "dev mode"
 	// State of git tree, either "clean" or "dirty"


### PR DESCRIPTION
This PR prepares release-6.3 branch for v6.3.7. 

6.3.6 is released by creating tag. 

Ticket Link
https://mattermost.atlassian.net/browse/DOPS-881