### PR TITLE
Chore/update dependencies release 6.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ENTERPRISE_HASH ?= $(shell cat enterprise_hash)
 TESTFLAGS = -mod=vendor -timeout 30m -race -v
 
 # We specify version for the build; it is the latest semantic version of the tags
-DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
+DIST_VER=$(shell git tag -l --sort=-version:refname "v6.6.*" | head -n 1)
 
 PKG=github.com/mattermost/mmctl/v6/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)


### PR DESCRIPTION
We cut release-6.6 branch and need to configure `DIST_VER` variable to consider only tags from `v6.6` 