### PR TITLE
commands/auth: fix 0-return on unsuccessful login attempts

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -211,7 +211,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			printer.PrintError(err.Error())
 			// We don't want usage to be printed as the command was correctly built
-			return nil
+			return fmt.Errorf("could not initiate client: %w", err)
 		}
 		accessToken = c.AuthToken
 	} else {
@@ -224,7 +224,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 		if _, _, err := InitClientWithCredentials(&credentials, allowInsecureSHA1, allowInsecureTLS); err != nil {
 			printer.PrintError(err.Error())
 			// We don't want usage to be printed as the command was correctly built
-			return nil
+			return fmt.Errorf("could not initiate client: %w", err)
 		}
 	}
 

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -209,8 +209,6 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 			c, _, err = InitClientWithUsernameAndPassword(username, password, url, allowInsecureSHA1, allowInsecureTLS)
 		}
 		if err != nil {
-			printer.PrintError(err.Error())
-			// We don't want usage to be printed as the command was correctly built
 			return fmt.Errorf("could not initiate client: %w", err)
 		}
 		accessToken = c.AuthToken
@@ -222,8 +220,6 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 			AuthToken:   accessToken,
 		}
 		if _, _, err := InitClientWithCredentials(&credentials, allowInsecureSHA1, allowInsecureTLS); err != nil {
-			printer.PrintError(err.Error())
-			// We don't want usage to be printed as the command was correctly built
 			return fmt.Errorf("could not initiate client: %w", err)
 		}
 	}


### PR DESCRIPTION
An unsuccessful command should always return a non zero return value, this PR aims to fix this issue.
 
#### Summary
Fixes #454 

