### PR TITLE
Add insecure-skip-verify flag for skip certificate verification

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -162,6 +162,7 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 
 	allowInsecureSHA1 := viper.GetBool("insecure-sha1-intermediate")
 	allowInsecureTLS := viper.GetBool("insecure-tls-version")
+	allowSkipTLSVerification := viper.GetBool("insecure-skip-verify")
 
 	url := strings.TrimRight(args[0], "/")
 	method := MethodPassword
@@ -203,10 +204,12 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 		var c *model.Client4
 		var err error
 		if mfaToken != "" {
-			c, _, err = InitClientWithMFA(username, password, mfaToken, url, allowInsecureSHA1, allowInsecureTLS)
+			c, _, err = InitClientWithMFA(
+				username, password, mfaToken, url, allowInsecureSHA1, allowInsecureTLS, allowSkipTLSVerification)
 			method = MethodMFA
 		} else {
-			c, _, err = InitClientWithUsernameAndPassword(username, password, url, allowInsecureSHA1, allowInsecureTLS)
+			c, _, err = InitClientWithUsernameAndPassword(
+				username, password, url, allowInsecureSHA1, allowInsecureTLS, allowSkipTLSVerification)
 		}
 		if err != nil {
 			return fmt.Errorf("could not initiate client: %w", err)
@@ -219,7 +222,8 @@ func loginCmdF(cmd *cobra.Command, args []string) error {
 			InstanceURL: url,
 			AuthToken:   accessToken,
 		}
-		if _, _, err := InitClientWithCredentials(&credentials, allowInsecureSHA1, allowInsecureTLS); err != nil {
+		if _, _, err := InitClientWithCredentials(
+			&credentials, allowInsecureSHA1, allowInsecureTLS, allowSkipTLSVerification); err != nil {
 			return fmt.Errorf("could not initiate client: %w", err)
 		}
 	}
@@ -344,6 +348,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 	mfaToken, _ := cmd.Flags().GetString("mfa-token")
 	allowInsecureSHA1 := viper.GetBool("insecure-sha1-intermediate")
 	allowInsecureTLS := viper.GetBool("insecure-tls-version")
+	allowSkipTLSVerification := viper.GetBool("insecure-skip-verify")
 
 	credentials, err := GetCredentials(args[0])
 	if err != nil {
@@ -363,7 +368,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 
 	switch credentials.AuthMethod {
 	case MethodPassword:
-		c, _, err := InitClientWithUsernameAndPassword(credentials.Username, password, credentials.InstanceURL, allowInsecureSHA1, allowInsecureTLS)
+		c, _, err := InitClientWithUsernameAndPassword(credentials.Username, password, credentials.InstanceURL, allowInsecureSHA1, allowInsecureTLS, allowSkipTLSVerification)
 		if err != nil {
 			return err
 		}
@@ -376,7 +381,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 		}
 
 		credentials.AuthToken = accessToken
-		if _, _, err := InitClientWithCredentials(credentials, allowInsecureSHA1, allowInsecureTLS); err != nil {
+		if _, _, err := InitClientWithCredentials(credentials, allowInsecureSHA1, allowInsecureTLS, allowSkipTLSVerification); err != nil {
 			return err
 		}
 
@@ -385,7 +390,7 @@ func renewCmdF(cmd *cobra.Command, args []string) error {
 			return errors.New("requires the --mfa-token parameter to be set")
 		}
 
-		c, _, err := InitClientWithMFA(credentials.Username, password, mfaToken, credentials.InstanceURL, allowInsecureSHA1, allowInsecureTLS)
+		c, _, err := InitClientWithMFA(credentials.Username, password, mfaToken, credentials.InstanceURL, allowInsecureSHA1, allowInsecureTLS, allowSkipTLSVerification)
 		if err != nil {
 			return err
 		}

--- a/commands/root.go
+++ b/commands/root.go
@@ -41,6 +41,8 @@ func Run(args []string) error {
 	_ = viper.BindPFlag("insecure-sha1-intermediate", RootCmd.PersistentFlags().Lookup("insecure-sha1-intermediate"))
 	RootCmd.PersistentFlags().Bool("insecure-tls-version", false, "allows to use TLS versions 1.0 and 1.1")
 	_ = viper.BindPFlag("insecure-tls-version", RootCmd.PersistentFlags().Lookup("insecure-tls-version"))
+	RootCmd.PersistentFlags().Bool("insecure-skip-verify", false, "skip certificate verification")
+	_ = viper.BindPFlag("insecure-skip-verify", RootCmd.PersistentFlags().Lookup("insecure-skip-verify"))
 	RootCmd.PersistentFlags().Bool("local", false, "allows communicating with the server through a unix socket")
 	_ = viper.BindPFlag("local", RootCmd.PersistentFlags().Lookup("local"))
 	RootCmd.PersistentFlags().Bool("short-stat", false, "short stat will provide useful statistical data")

--- a/docs/mmctl.rst
+++ b/docs/mmctl.rst
@@ -20,6 +20,7 @@ Options
       --disable-pager                disables paged output
   -h, --help                         help for mmctl
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth.rst
+++ b/docs/mmctl_auth.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_clean.rst
+++ b/docs/mmctl_auth_clean.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_current.rst
+++ b/docs/mmctl_auth_current.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_delete.rst
+++ b/docs/mmctl_auth_delete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_list.rst
+++ b/docs/mmctl_auth_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_login.rst
+++ b/docs/mmctl_auth_login.rst
@@ -46,6 +46,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_renew.rst
+++ b/docs/mmctl_auth_renew.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_auth_set.rst
+++ b/docs/mmctl_auth_set.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot.rst
+++ b/docs/mmctl_bot.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_assign.rst
+++ b/docs/mmctl_bot_assign.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_create.rst
+++ b/docs/mmctl_bot_create.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_disable.rst
+++ b/docs/mmctl_bot_disable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_enable.rst
+++ b/docs/mmctl_bot_enable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_list.rst
+++ b/docs/mmctl_bot_list.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_bot_update.rst
+++ b/docs/mmctl_bot_update.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel.rst
+++ b/docs/mmctl_channel.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_archive.rst
+++ b/docs/mmctl_channel_archive.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_create.rst
+++ b/docs/mmctl_channel_create.rst
@@ -44,6 +44,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_delete.rst
+++ b/docs/mmctl_channel_delete.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_list.rst
+++ b/docs/mmctl_channel_list.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_make-private.rst
+++ b/docs/mmctl_channel_make-private.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_modify.rst
+++ b/docs/mmctl_channel_modify.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_move.rst
+++ b/docs/mmctl_channel_move.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_rename.rst
+++ b/docs/mmctl_channel_rename.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_search.rst
+++ b/docs/mmctl_channel_search.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_unarchive.rst
+++ b/docs/mmctl_channel_unarchive.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users.rst
+++ b/docs/mmctl_channel_users.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users_add.rst
+++ b/docs/mmctl_channel_users_add.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_channel_users_remove.rst
+++ b/docs/mmctl_channel_users_remove.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command.rst
+++ b/docs/mmctl_command.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_archive.rst
+++ b/docs/mmctl_command_archive.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_create.rst
+++ b/docs/mmctl_command_create.rst
@@ -48,6 +48,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_list.rst
+++ b/docs/mmctl_command_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_modify.rst
+++ b/docs/mmctl_command_modify.rst
@@ -48,6 +48,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_move.rst
+++ b/docs/mmctl_command_move.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_command_show.rst
+++ b/docs/mmctl_command_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion.rst
+++ b/docs/mmctl_completion.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion_bash.rst
+++ b/docs/mmctl_completion_bash.rst
@@ -35,6 +35,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_completion_zsh.rst
+++ b/docs/mmctl_completion_zsh.rst
@@ -35,6 +35,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config.rst
+++ b/docs/mmctl_config.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_edit.rst
+++ b/docs/mmctl_config_edit.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_get.rst
+++ b/docs/mmctl_config_get.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_migrate.rst
+++ b/docs/mmctl_config_migrate.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_patch.rst
+++ b/docs/mmctl_config_patch.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_reload.rst
+++ b/docs/mmctl_config_reload.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_reset.rst
+++ b/docs/mmctl_config_reset.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_set.rst
+++ b/docs/mmctl_config_set.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_show.rst
+++ b/docs/mmctl_config_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_config_subpath.rst
+++ b/docs/mmctl_config_subpath.rst
@@ -46,6 +46,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_docs.rst
+++ b/docs/mmctl_docs.rst
@@ -31,6 +31,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_export.rst
+++ b/docs/mmctl_export.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_export_create.rst
+++ b/docs/mmctl_export_create.rst
@@ -31,6 +31,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_export_delete.rst
+++ b/docs/mmctl_export_delete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_export_download.rst
+++ b/docs/mmctl_export_download.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_export_job.rst
+++ b/docs/mmctl_export_job.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_export_job_list.rst
+++ b/docs/mmctl_export_job_list.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_export_job_show.rst
+++ b/docs/mmctl_export_job_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_export_list.rst
+++ b/docs/mmctl_export_list.rst
@@ -30,6 +30,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_extract.rst
+++ b/docs/mmctl_extract.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_extract_job.rst
+++ b/docs/mmctl_extract_job.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_extract_job_list.rst
+++ b/docs/mmctl_extract_job_list.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_extract_job_show.rst
+++ b/docs/mmctl_extract_job_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_extract_run.rst
+++ b/docs/mmctl_extract_run.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group.rst
+++ b/docs/mmctl_group.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel.rst
+++ b/docs/mmctl_group_channel.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_disable.rst
+++ b/docs/mmctl_group_channel_disable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_enable.rst
+++ b/docs/mmctl_group_channel_enable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_list.rst
+++ b/docs/mmctl_group_channel_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_channel_status.rst
+++ b/docs/mmctl_group_channel_status.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_list-ldap.rst
+++ b/docs/mmctl_group_list-ldap.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team.rst
+++ b/docs/mmctl_group_team.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_disable.rst
+++ b/docs/mmctl_group_team_disable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_enable.rst
+++ b/docs/mmctl_group_team_enable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_list.rst
+++ b/docs/mmctl_group_team_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_group_team_status.rst
+++ b/docs/mmctl_group_team_status.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import.rst
+++ b/docs/mmctl_import.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import_job.rst
+++ b/docs/mmctl_import_job.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import_job_list.rst
+++ b/docs/mmctl_import_job_list.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import_job_show.rst
+++ b/docs/mmctl_import_job_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import_list.rst
+++ b/docs/mmctl_import_list.rst
@@ -33,6 +33,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import_list_available.rst
+++ b/docs/mmctl_import_list_available.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import_list_incomplete.rst
+++ b/docs/mmctl_import_list_incomplete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import_process.rst
+++ b/docs/mmctl_import_process.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_import_upload.rst
+++ b/docs/mmctl_import_upload.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_integrity.rst
+++ b/docs/mmctl_integrity.rst
@@ -32,6 +32,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap.rst
+++ b/docs/mmctl_ldap.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap_idmigrate.rst
+++ b/docs/mmctl_ldap_idmigrate.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_ldap_sync.rst
+++ b/docs/mmctl_ldap_sync.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license.rst
+++ b/docs/mmctl_license.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license_remove.rst
+++ b/docs/mmctl_license_remove.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_license_upload.rst
+++ b/docs/mmctl_license_upload.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_logs.rst
+++ b/docs/mmctl_logs.rst
@@ -32,6 +32,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions.rst
+++ b/docs/mmctl_permissions.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_add.rst
+++ b/docs/mmctl_permissions_add.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_remove.rst
+++ b/docs/mmctl_permissions_remove.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_reset.rst
+++ b/docs/mmctl_permissions_reset.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role.rst
+++ b/docs/mmctl_permissions_role.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_assign.rst
+++ b/docs/mmctl_permissions_role_assign.rst
@@ -43,6 +43,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_show.rst
+++ b/docs/mmctl_permissions_role_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_permissions_role_unassign.rst
+++ b/docs/mmctl_permissions_role_unassign.rst
@@ -43,6 +43,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin.rst
+++ b/docs/mmctl_plugin.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_add.rst
+++ b/docs/mmctl_plugin_add.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_delete.rst
+++ b/docs/mmctl_plugin_delete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_disable.rst
+++ b/docs/mmctl_plugin_disable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_enable.rst
+++ b/docs/mmctl_plugin_enable.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_install-url.rst
+++ b/docs/mmctl_plugin_install-url.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_list.rst
+++ b/docs/mmctl_plugin_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace.rst
+++ b/docs/mmctl_plugin_marketplace.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace_install.rst
+++ b/docs/mmctl_plugin_marketplace_install.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_plugin_marketplace_list.rst
+++ b/docs/mmctl_plugin_marketplace_list.rst
@@ -52,6 +52,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post.rst
+++ b/docs/mmctl_post.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post_create.rst
+++ b/docs/mmctl_post_create.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_post_list.rst
+++ b/docs/mmctl_post_list.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles.rst
+++ b/docs/mmctl_roles.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles_member.rst
+++ b/docs/mmctl_roles_member.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_roles_system-admin.rst
+++ b/docs/mmctl_roles_system-admin.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_saml.rst
+++ b/docs/mmctl_saml.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_saml_auth-data-reset.rst
+++ b/docs/mmctl_saml_auth-data-reset.rst
@@ -51,6 +51,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_sampledata.rst
+++ b/docs/mmctl_sampledata.rst
@@ -65,6 +65,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system.rst
+++ b/docs/mmctl_system.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_clearbusy.rst
+++ b/docs/mmctl_system_clearbusy.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_getbusy.rst
+++ b/docs/mmctl_system_getbusy.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_setbusy.rst
+++ b/docs/mmctl_system_setbusy.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_status.rst
+++ b/docs/mmctl_system_status.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_system_version.rst
+++ b/docs/mmctl_system_version.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team.rst
+++ b/docs/mmctl_team.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_archive.rst
+++ b/docs/mmctl_team_archive.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_create.rst
+++ b/docs/mmctl_team_create.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_delete.rst
+++ b/docs/mmctl_team_delete.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_list.rst
+++ b/docs/mmctl_team_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_modify.rst
+++ b/docs/mmctl_team_modify.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_rename.rst
+++ b/docs/mmctl_team_rename.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_restore.rst
+++ b/docs/mmctl_team_restore.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_search.rst
+++ b/docs/mmctl_team_search.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users.rst
+++ b/docs/mmctl_team_users.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users_add.rst
+++ b/docs/mmctl_team_users_add.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_team_users_remove.rst
+++ b/docs/mmctl_team_users_remove.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token.rst
+++ b/docs/mmctl_token.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_generate.rst
+++ b/docs/mmctl_token_generate.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_list.rst
+++ b/docs/mmctl_token_list.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_token_revoke.rst
+++ b/docs/mmctl_token_revoke.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user.rst
+++ b/docs/mmctl_user.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_activate.rst
+++ b/docs/mmctl_user_activate.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_change-password.rst
+++ b/docs/mmctl_user_change-password.rst
@@ -54,6 +54,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_convert.rst
+++ b/docs/mmctl_user_convert.rst
@@ -54,6 +54,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_create.rst
+++ b/docs/mmctl_user_create.rst
@@ -58,6 +58,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_deactivate.rst
+++ b/docs/mmctl_user_deactivate.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_delete.rst
+++ b/docs/mmctl_user_delete.rst
@@ -39,6 +39,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_deleteall.rst
+++ b/docs/mmctl_user_deleteall.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_demote.rst
+++ b/docs/mmctl_user_demote.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_email.rst
+++ b/docs/mmctl_user_email.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_invite.rst
+++ b/docs/mmctl_user_invite.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_list.rst
+++ b/docs/mmctl_user_list.rst
@@ -41,6 +41,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_migrate-auth.rst
+++ b/docs/mmctl_user_migrate-auth.rst
@@ -40,6 +40,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_promote.rst
+++ b/docs/mmctl_user_promote.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_reset-password.rst
+++ b/docs/mmctl_user_reset-password.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_resetmfa.rst
+++ b/docs/mmctl_user_resetmfa.rst
@@ -38,6 +38,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_search.rst
+++ b/docs/mmctl_user_search.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_username.rst
+++ b/docs/mmctl_user_username.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_user_verify.rst
+++ b/docs/mmctl_user_verify.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_version.rst
+++ b/docs/mmctl_version.rst
@@ -30,6 +30,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_webhook.rst
+++ b/docs/mmctl_webhook.rst
@@ -26,6 +26,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_webhook_create-incoming.rst
+++ b/docs/mmctl_webhook_create-incoming.rst
@@ -43,6 +43,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_webhook_create-outgoing.rst
+++ b/docs/mmctl_webhook_create-outgoing.rst
@@ -48,6 +48,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_webhook_delete.rst
+++ b/docs/mmctl_webhook_delete.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_webhook_list.rst
+++ b/docs/mmctl_webhook_list.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_webhook_modify-incoming.rst
+++ b/docs/mmctl_webhook_modify-incoming.rst
@@ -42,6 +42,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_webhook_modify-outgoing.rst
+++ b/docs/mmctl_webhook_modify-outgoing.rst
@@ -45,6 +45,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_webhook_show.rst
+++ b/docs/mmctl_webhook_show.rst
@@ -37,6 +37,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket

--- a/docs/mmctl_websocket.rst
+++ b/docs/mmctl_websocket.rst
@@ -30,6 +30,7 @@ Options inherited from parent commands
       --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
       --disable-pager                disables paged output
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-skip-verify         skip certificate verification
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
       --local                        allows communicating with the server through a unix socket


### PR DESCRIPTION
#### Summary

I faced with issues with my local mattermost installation - it can't be managed with mmctl because of self signed certificates.  So i decide to contribute this option to skip tls verification.

Please check it.

