### PR TITLE
commands/channel_e2_test: skip channel creation with invalid name case

### DIFF
--- a/commands/channel_e2e_test.go
+++ b/commands/channel_e2e_test.go
@@ -210,6 +210,7 @@ func (s *MmctlE2ETestSuite) TestCreateChannelCmd() {
 	})
 
 	s.RunForAllClients("create channel with invalid name", func(c client.Client) {
+		s.T().Skip("MM-43873")
 		printer.Clean()
 
 		cmd := &cobra.Command{}


### PR DESCRIPTION

#### Summary
Skip a test case needs to be updated. 
