### PR TITLE
commands/init: version check revamped to indicate errors

### DIFF
--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -16,6 +16,7 @@ func TestCheckVersionMatch(t *testing.T) {
 		Version       string
 		ServerVersion string
 		Expected      bool
+		ErrExpected   bool
 	}{
 		{
 			Name:          "Both versions are equal",
@@ -45,7 +46,7 @@ func TestCheckVersionMatch(t *testing.T) {
 			Name:          "Minor version is greater",
 			Version:       "1.2.3",
 			ServerVersion: "1.3.3",
-			Expected:      false,
+			Expected:      true,
 		},
 		{
 			Name:          "Minor version is less",
@@ -53,12 +54,25 @@ func TestCheckVersionMatch(t *testing.T) {
 			ServerVersion: "1.1.3",
 			Expected:      false,
 		},
+		{
+			Name:          "Both versions are equal but one has v in front of it",
+			Version:       "v1.2.3",
+			ServerVersion: "1.2.3",
+			Expected:      true,
+		},
+		{
+			Name:          "unspecified version",
+			Version:       "",
+			ServerVersion: "1.2.3",
+			Expected:      false,
+			ErrExpected:   true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			res := CheckVersionMatch(tc.Version, tc.ServerVersion)
-
+			res, err := CheckVersionMatch(tc.Version, tc.ServerVersion)
+			require.True(t, (err != nil) == tc.ErrExpected)
 			require.Equal(t, tc.Expected, res)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mattermost/mmctl/v6
 go 1.16
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/corpix/uarand v0.1.1 // indirect
 	github.com/fatih/color v1.13.0
 	github.com/golang/mock v1.6.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -5,6 +5,7 @@ code.sajari.com/docconv/snappy
 # github.com/JalfResi/justext v0.0.0-20170829062021-c0282dea7198
 github.com/JalfResi/justext
 # github.com/Masterminds/semver/v3 v3.1.1
+## explicit
 github.com/Masterminds/semver/v3
 # github.com/Masterminds/squirrel v1.5.1
 github.com/Masterminds/squirrel


### PR DESCRIPTION

#### Summary
Fix an issue where we were silently overlooking the error. If we have major version differences or client is ahead of the server we raise a warning. We don't need to raise a warning if the server is ahead of client on the minor version. We need to be backwards compatible. 
