### PR TITLE
MM-38703: Show error detail while printing jobs

### DIFF
--- a/commands/import.go
+++ b/commands/import.go
@@ -239,10 +239,18 @@ func importProcessCmdF(c client.Client, command *cobra.Command, args []string) e
 
 func printJob(job *model.Job) {
 	if job.StartAt > 0 {
-		printer.PrintT(fmt.Sprintf("  ID: {{.Id}}\n  Status: {{.Status}}\n  Created: %s\n  Started: %s\n",
+		printer.PrintT(fmt.Sprintf(`  ID: {{.Id}}
+  Status: {{.Status}}
+  Created: %s
+  Started: %s
+  Data: {{.Data}}
+`,
 			time.Unix(job.CreateAt/1000, 0), time.Unix(job.StartAt/1000, 0)), job)
 	} else {
-		printer.PrintT(fmt.Sprintf("  ID: {{.Id}}\n  Status: {{.Status}}\n  Created: %s\n\n",
+		printer.PrintT(fmt.Sprintf(`  ID: {{.Id}}
+  Status: {{.Status}}
+  Created: %s
+`,
 			time.Unix(job.CreateAt/1000, 0)), job)
 	}
 }


### PR DESCRIPTION
We show the job metadata which captures detail on why
a job has failed. This can be helpful while debugging.

https://mattermost.atlassian.net/browse/MM-38703

```release-note
NONE
```
