### PR TITLE
Reorganize makefile to overwrite DIST_VER variable at release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,15 @@ TESTFLAGS = -mod=vendor -timeout 30m -race -v
 # We specify version for the build; it is the latest semantic version of the tags
 DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
 
+-include config.override.mk
+include config.mk
+
 PKG=github.com/mattermost/mmctl/v6/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)
 BUILD_TAGS =
 
 .PHONY: all
 all: build
-
--include config.override.mk
-include config.mk
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifneq ($(wildcard ${ENTERPRISE_DIR}/.*),)


### PR DESCRIPTION
#### Summary

We want to automate release cut operation and we need to use different DIST_VER scheme
for release branches. See tickets for details.

Reorder config override include so we can redefine DIST_VER variable at release cut pipeline.
Release cut will create `config.override.mk` file to overwrite that variable.

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/DOPS-894

