### PR TITLE
MM-38701: Automatically retry on a failed export download

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -168,7 +168,7 @@ func exportDownloadCmdF(c client.Client, command *cobra.Command, args []string) 
 		path = name
 	}
 
-	retries, _ := command.Flags().GetInt("num_retries")
+	retries, _ := command.Flags().GetInt("num-retries")
 
 	var outFile *os.File
 	info, err := os.Stat(path)

--- a/commands/export.go
+++ b/commands/export.go
@@ -82,7 +82,11 @@ func init() {
 	ExportCreateCmd.Flags().Bool("attachments", false, "Set to true to include file attachments in the export file.")
 
 	ExportDownloadCmd.Flags().Bool("resume", false, "Set to true to resume an export download.")
-	ExportDownloadCmd.Flags().Int("num_retries", 5, "Number of retries to do to resume a download.")
+	_ = ExportDownloadCmd.Flags().MarkHidden("resume")
+	// Intentionally the message does not start with a capital letter because
+	// cobra prepends "Flag --resume has been deprecated,"
+	_ = ExportDownloadCmd.Flags().MarkDeprecated("resume", "the tool now resumes a download automatically. The flag will be removed in a future version.")
+	ExportDownloadCmd.Flags().Int("num-retries", 5, "Number of retries to do to resume a download.")
 
 	ExportJobListCmd.Flags().Int("page", 0, "Page number to fetch for the list of export jobs")
 	ExportJobListCmd.Flags().Int("per-page", 200, "Number of export jobs to be fetched")
@@ -162,11 +166,6 @@ func exportDownloadCmdF(c client.Client, command *cobra.Command, args []string) 
 	}
 	if path == "" {
 		path = name
-	}
-
-	resume, _ := command.Flags().GetBool("resume")
-	if resume {
-		printer.PrintWarning("The --resume flag has been deprecated and now the tool resumes a download automatically. The flag will be removed in a future version.")
 	}
 
 	retries, _ := command.Flags().GetInt("num_retries")

--- a/commands/export.go
+++ b/commands/export.go
@@ -194,7 +194,7 @@ func exportDownloadCmdF(c client.Client, command *cobra.Command, args []string) 
 	defer outFile.Close()
 
 	i := 0
-	for i < retries {
+	for i < retries+1 {
 		off, err := outFile.Seek(0, io.SeekEnd)
 		if err != nil {
 			return fmt.Errorf("failed to seek export file: %w", err)
@@ -208,7 +208,7 @@ func exportDownloadCmdF(c client.Client, command *cobra.Command, args []string) 
 		break
 	}
 
-	if i == retries {
+	if retries != 0 && i == retries+1 {
 		return fmt.Errorf("failed to download export after %d retries", retries)
 	}
 

--- a/commands/export.go
+++ b/commands/export.go
@@ -4,13 +4,13 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
-	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
@@ -207,7 +207,7 @@ func exportDownloadCmdF(c client.Client, command *cobra.Command, args []string) 
 	}
 
 	if i == 5 {
-		return errors.New("failed to download export after 5 retries.")
+		return errors.New("failed to download export after 5 retries")
 	}
 
 	return nil

--- a/commands/export.go
+++ b/commands/export.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -210,7 +209,7 @@ func exportDownloadCmdF(c client.Client, command *cobra.Command, args []string) 
 	}
 
 	if i == retries {
-		return errors.New("failed to download export after 5 retries")
+		return fmt.Errorf("failed to download export after %d retries", retries)
 	}
 
 	return nil

--- a/commands/export_e2e_test.go
+++ b/commands/export_e2e_test.go
@@ -177,7 +177,10 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 	s.Run("MM-T3879 - no permissions", func() {
 		printer.Clean()
 
-		err := exportDownloadCmdF(s.th.Client, &cobra.Command{}, []string{exportName})
+		cmd := &cobra.Command{}
+		cmd.Flags().Int("num_retries", 5, "")
+
+		err := exportDownloadCmdF(s.th.Client, cmd, []string{exportName})
 		s.Require().EqualError(err, "failed to download export after 5 retries")
 		s.Require().Empty(printer.GetLines())
 		s.Require().Empty(printer.GetErrorLines())
@@ -187,6 +190,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
+		cmd.Flags().Int("num_retries", 5, "")
 
 		downloadPath, err := filepath.Abs(exportName)
 		s.Require().Nil(err)
@@ -204,6 +208,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
+		cmd.Flags().Int("num_retries", 5, "")
 
 		downloadPath, err := filepath.Abs(exportName)
 		s.Require().Nil(err)
@@ -219,6 +224,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
+		cmd.Flags().Int("num_retries", 5, "")
 
 		exportFilePath := filepath.Join(exportPath, exportName)
 		err := utils.CopyFile(importFilePath, exportFilePath)
@@ -242,6 +248,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
+		cmd.Flags().Int("num_retries", 5, "")
 
 		exportFilePath := filepath.Join(exportPath, exportName)
 		err := utils.CopyFile(importFilePath, exportFilePath)

--- a/commands/export_e2e_test.go
+++ b/commands/export_e2e_test.go
@@ -178,7 +178,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
-		cmd.Flags().Int("num_retries", 5, "")
+		cmd.Flags().Int("num-retries", 5, "")
 
 		err := exportDownloadCmdF(s.th.Client, cmd, []string{exportName})
 		s.Require().EqualError(err, "failed to download export after 5 retries")
@@ -190,7 +190,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
-		cmd.Flags().Int("num_retries", 5, "")
+		cmd.Flags().Int("num-retries", 5, "")
 
 		downloadPath, err := filepath.Abs(exportName)
 		s.Require().Nil(err)
@@ -208,7 +208,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
-		cmd.Flags().Int("num_retries", 5, "")
+		cmd.Flags().Int("num-retries", 5, "")
 
 		downloadPath, err := filepath.Abs(exportName)
 		s.Require().Nil(err)
@@ -224,7 +224,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
-		cmd.Flags().Int("num_retries", 5, "")
+		cmd.Flags().Int("num-retries", 5, "")
 
 		exportFilePath := filepath.Join(exportPath, exportName)
 		err := utils.CopyFile(importFilePath, exportFilePath)
@@ -248,7 +248,7 @@ func (s *MmctlE2ETestSuite) TestExportDownloadCmdF() {
 		printer.Clean()
 
 		cmd := &cobra.Command{}
-		cmd.Flags().Int("num_retries", 5, "")
+		cmd.Flags().Int("num-retries", 5, "")
 
 		exportFilePath := filepath.Join(exportPath, exportName)
 		err := utils.CopyFile(importFilePath, exportFilePath)

--- a/docs/mmctl_export_download.rst
+++ b/docs/mmctl_export_download.rst
@@ -31,8 +31,9 @@ Options
 
 ::
 
-  -h, --help     help for download
-      --resume   Set to true to resume an export download.
+  -h, --help              help for download
+      --num_retries int   Number of retries to do to resume a download. (default 5)
+      --resume            Set to true to resume an export download.
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/mmctl_export_download.rst
+++ b/docs/mmctl_export_download.rst
@@ -32,8 +32,7 @@ Options
 ::
 
   -h, --help              help for download
-      --num_retries int   Number of retries to do to resume a download. (default 5)
-      --resume            Set to true to resume an export download.
+      --num-retries int   Number of retries to do to resume a download. (default 5)
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We had a resume functionality which would download the file
again from a given offset. But clients would create wrapper
scripts which would auto-retry.

Therefore, we add that functionality in-built and deprecate
the resume flag. The reasoning behind removing the flag is that
if it doesn't succeed within 5 tries, then probably it's better
to attempt to download the file from scratch again sometime later.

https://mattermost.atlassian.net/browse/MM-38701
