### PR TITLE
[fix] Makefile fallback to using latest semver tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,13 @@ VENDOR_MM_SERVER_DIR ?= vendor/github.com/mattermost/mattermost-server/v6
 ENTERPRISE_HASH ?= $(shell cat enterprise_hash)
 TESTFLAGS = -mod=vendor -timeout 30m -race -v
 
-# We specify version for the build; it is the latest semantic version of the tags
-DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
-
 -include config.override.mk
 include config.mk
+
+# In case DIST_VER is not assigned, fallback to using the latest semver tag available
+ifndef DIST_VER
+   DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
+endif
 
 PKG=github.com/mattermost/mmctl/v6/commands
 LDFLAGS= -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE) -X $(PKG).Version=$(DIST_VER)


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
## Rationale 

In case there is no Tag available, `DIST_VER` remains unitilized therefore building with an empty `DIST_VER` variable.
For example:
```
Build Linux amd64
env GOOS=linux GOARCH=amd64 go build -trimpath -ldflags '-X github.com/mattermost/mmctl/v6/commands.gitCommit=e58015f66734b77f223592a63d158652e94d5b82 -X github.com/mattermost/mmctl/v6/commands.gitTreeState="clean" -X github.com/mattermost/mmctl/v6/commands.buildDate='2022-05-31T08:20:04Z' -X github.com/mattermost/mmctl/v6/commands.Version=' -mod=vendor
tar cf build/linux_amd64.tar mmctl
md5sum < build/linux_amd64.tar | cut -d ' ' -f 1 > build/linux_amd64.tar.md5.txt
Build Linux arm64
env GOOS=linux GOARCH=arm64 go build -trimpath -ldflags '-X github.com/mattermost/mmctl/v6/commands.gitCommit=e58015f66734b77f223592a63d158652e94d5b82 -X github.com/mattermost/mmctl/v6/commands.gitTreeState="clean" -X github.com/mattermost/mmctl/v6/commands.buildDate='2022-05-31T08:20:04Z' -X github.com/mattermost/mmctl/v6/commands.Version=' -mod=vendor
tar cf build/linux_arm64.tar mmctl
```
In the above example, `github.com/mattermost/mmctl/v6/commands.Version` is empty. 
And builds the following binary:
```
$ mmctl version
mmctl:
Version:
GitCommit:	e58015f66734b77f223592a63d158652e94d5b82
GitTreeState:	"clean"
BuildDate:	2022-05-31T08:20:04Z
GoVersion:	go1.17
Compiler:	gc
Platform:	linux/amd64
```

## Proposal 
In case `DIST_VER` is not defined, fallback to using latest semver tag available, instead of building with `NULL` `DIST_VER`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/DOPS-1049

