### PR TITLE
Makefile sets DIST_VER value empty when there is no tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ TESTFLAGS = -mod=vendor -timeout 30m -race -v
 include config.mk
 
 # In case DIST_VER is not assigned, fallback to using the latest semver tag available
-ifndef DIST_VER
-   DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
+ifeq ($(DIST_VER), )
+    DIST_VER=$(shell git tag | sort -r --version-sort | head -n1)
 endif
 
 PKG=github.com/mattermost/mmctl/v6/commands


### PR DESCRIPTION
#### Summary
PR contains changes to check DIST_VER variable with undefined/empty values. When it is empty it will set to latest tag available.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-3718