### PR TITLE
Update go version to 1.18 for v7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
 
     - name: Run build
       run: make package

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.46.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,8 @@ include:
   file: private.yml
 
 variables:
-  IMAGE_BUILD_MMCTL: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20210824_golang-1.17.0
-  IMAGE_BUILD_SERVER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20210810_golang-1.16.7
+  IMAGE_BUILD_MMCTL: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20220415_golang-1.18.1
+  IMAGE_BUILD_SERVER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20220415_golang-1.18.1
 
 docs:
   stage: test
@@ -24,7 +24,7 @@ docs:
 
 lint:
   stage: test
-  image: docker.io/golangci/golangci-lint:v1.42.1
+  image: docker.io/golangci/golangci-lint:v1.46.2
   script:
     - echo "Installing mattermost-govet"
     - GO111MODULE=off go get -u github.com/mattermost/mattermost-govet


### PR DESCRIPTION
#### Summary
Mmctl go version is not compatible with Mattermost Server version. PR contains changes to upgrade go version of mmctl.

#### Ticket Link
Related to https://github.com/mattermost/mmctl/issues/547
