### PR TITLE
[MM-38708] Add import validator

### DIFF
--- a/commands/import.go
+++ b/commands/import.go
@@ -393,7 +393,7 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 
 	printStatistics(stat)
 
-	if createMissingTeams {
+	if createMissingTeams && len(teams) != 0 {
 		printer.PrintT("Automatically created teams: {{ join .CreatedTeams \", \" }}\n", struct {
 			CreatedTeams []string `json:"created_teams"`
 		}{teams})

--- a/commands/import.go
+++ b/commands/import.go
@@ -102,7 +102,8 @@ func init() {
 	ImportJobListCmd.Flags().Int("per-page", 200, "Number of import jobs to be fetched")
 	ImportJobListCmd.Flags().Bool("all", false, "Fetch all import jobs. --page flag will be ignore if provided")
 
-	ImportValidateCmd.Flags().StringArray("team", nil, "The names of the team[s]. The flag can be repeated. Omit this flag to disable the check")
+	ImportValidateCmd.Flags().StringArray("team", nil, "Predefined team[s] to assume as already present on the destination server. Implies --check-missing-teams. The flag can be repeated")
+	ImportValidateCmd.Flags().Bool("check-missing-teams", false, "Check for teams that are not defined but referenced in the archive")
 	ImportValidateCmd.Flags().Bool("ignore-attachments", false, "Don't check if the attached files are present in the archive")
 
 	ImportListCmd.AddCommand(
@@ -351,13 +352,17 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	checkMissingTeams, err := command.Flags().GetBool("check-missing-teams")
+	if err != nil {
+		return err
+	}
 
 	ignoreAttachments, err := command.Flags().GetBool("ignore-attachments")
 	if err != nil {
 		return err
 	}
 
-	createMissingTeams := len(injectedTeams) == 0
+	createMissingTeams := !checkMissingTeams && len(injectedTeams) == 0
 	validator := importer.NewValidator(args[0], ignoreAttachments, createMissingTeams)
 
 	for _, team := range injectedTeams {

--- a/commands/import.go
+++ b/commands/import.go
@@ -102,7 +102,7 @@ func init() {
 	ImportJobListCmd.Flags().Int("per-page", 200, "Number of import jobs to be fetched")
 	ImportJobListCmd.Flags().Bool("all", false, "Fetch all import jobs. --page flag will be ignore if provided")
 
-	ImportValidateCmd.Flags().StringArray("team", nil, "The names of the team[s] (flag can be repeated)")
+	ImportValidateCmd.Flags().StringArray("team", nil, "The names of the team[s]. The flag can be repeated. Omit this flag to disable the check")
 	ImportValidateCmd.Flags().Bool("ignore-attachments", false, "Don't check if the attached files are present in the archive")
 
 	ImportListCmd.AddCommand(

--- a/commands/import.go
+++ b/commands/import.go
@@ -12,12 +12,12 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/spf13/cobra"
+
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/commands/importer"
 	"github.com/mattermost/mmctl/v6/printer"
-
-	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/spf13/cobra"
 )
 
 var ImportCmd = &cobra.Command{

--- a/commands/import.go
+++ b/commands/import.go
@@ -20,6 +20,18 @@ import (
 	"github.com/mattermost/mmctl/v6/printer"
 )
 
+type Statistics struct {
+	Schemes        int `json:"schemes"`
+	Teams          int `json:"teams"`
+	Channels       int `json:"channels"`
+	Users          int `json:"users"`
+	Emojis         int `json:"emojis"`
+	Posts          int `json:"posts"`
+	DirectChannels int `json:"direct_channels"`
+	DirectPosts    int `json:"direct_posts"`
+	Attachments    int `json:"attachments"`
+}
+
 var ImportCmd = &cobra.Command{
 	Use:   "import",
 	Short: "Management of imports",
@@ -401,18 +413,6 @@ func configurePrinter() {
 
 	// define a join function
 	printer.SetTemplateFunc("join", strings.Join)
-}
-
-type Statistics struct {
-	Schemes        int `json:"schemes"`
-	Teams          int `json:"teams"`
-	Channels       int `json:"channels"`
-	Users          int `json:"users"`
-	Emojis         int `json:"emojis"`
-	Posts          int `json:"posts"`
-	DirectChannels int `json:"direct_channels"`
-	DirectPosts    int `json:"direct_posts"`
-	Attachments    int `json:"attachments"`
 }
 
 func printStatistics(stat Statistics) {

--- a/commands/import.go
+++ b/commands/import.go
@@ -357,6 +357,7 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 	printer.PrintT("Predefined teams: {{ join .Teams \", \" }}\n", struct {
 		Teams []string `json:"injected_teams"`
 	}{injectedTeams})
+	printer.Flush() // flush the output, the next line could take a long time
 
 	templateError := template.Must(template.New("").Parse("{{ .Error }}\n"))
 	validator.OnError(func(ive *importer.ImportValidationError) error {
@@ -394,7 +395,7 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 	printer.PrintT("It took {{ .Elapsed }} to validate {{ .TotalLines }} lines in {{ .FileName }}\n", struct {
 		FileName   string        `json:"file_name"`
 		TotalLines uint64        `json:"total_lines"`
-		Elapsed    time.Duration `json:"elapsed_time"`
+		Elapsed    time.Duration `json:"elapsed_time_ns"`
 	}{args[0], validator.Lines(), validator.Duration()})
 
 	return nil

--- a/commands/import.go
+++ b/commands/import.go
@@ -377,9 +377,11 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 		return err
 	}
 
+	teams := validator.Teams()
+
 	stat := Statistics{
 		Schemes:        len(validator.Schemes()),
-		Teams:          len(validator.Teams()),
+		Teams:          len(teams),
 		Channels:       len(validator.Channels()),
 		Users:          len(validator.Users()),
 		Posts:          int(validator.PostCount()),
@@ -390,6 +392,12 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 	}
 
 	printStatistics(stat)
+
+	if createMissingTeams {
+		printer.PrintT("Automatically created teams: {{ join .CreatedTeams \", \" }}\n", struct {
+			CreatedTeams []string `json:"created_teams"`
+		}{teams})
+	}
 
 	unusedAttachments := validator.UnusedAttachments()
 	if len(unusedAttachments) > 0 {

--- a/commands/import.go
+++ b/commands/import.go
@@ -345,13 +345,13 @@ type Statistics struct {
 
 func importValidateCmdF(command *cobra.Command, args []string) error {
 	configurePrinter()
-
 	defer printer.Print("Validation complete\n")
 
 	injectedTeams, err := command.Flags().GetStringArray("team")
 	if err != nil {
 		return err
 	}
+
 	checkMissingTeams, err := command.Flags().GetBool("check-missing-teams")
 	if err != nil {
 		return err

--- a/commands/import.go
+++ b/commands/import.go
@@ -374,15 +374,15 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 		unusedAttachments  = validator.UnusedAttachments()
 	)
 
-	fmt.Printf("Schemes (%d):  [%s]\n", len(schemes), printMax(schemes, 2))
-	fmt.Printf("Teams (%d):    [%s]\n", len(teams), printMax(teams, 2))
-	fmt.Printf("Channels (%d): [%s]\n", len(channels), printMax(channels, 2))
-	fmt.Printf("Users (%d):    [%s]\n", len(users), printMax(users, 2))
-	fmt.Printf("Emojis (%d):   [%s]\n", len(emojis), printMax(emojis, 2))
+	fmt.Printf("Schemes (%d):  [%s]\n", len(schemes), print2(schemes))
+	fmt.Printf("Teams (%d):    [%s]\n", len(teams), print2(teams))
+	fmt.Printf("Channels (%d): [%s]\n", len(channels), print2(channels))
+	fmt.Printf("Users (%d):    [%s]\n", len(users), print2(users))
+	fmt.Printf("Emojis (%d):   [%s]\n", len(emojis), print2(emojis))
 	fmt.Printf("Posts           (%d)\n", postCount)
 	fmt.Printf("Direct Channels (%d)\n", directChannelCount)
 	fmt.Printf("Direct Posts    (%d)\n", directPostCount)
-	fmt.Printf("Attachments (%d): [%s]\n", len(attachments), printMax(attachments, 2))
+	fmt.Printf("Attachments (%d): [%s]\n", len(attachments), print2(attachments))
 
 	if len(unusedAttachments) > 0 {
 		fmt.Printf("Unused Attachments (%d):\n", len(unusedAttachments))
@@ -396,9 +396,9 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func printMax(sl []string, max int) string {
-	if len(sl) > max {
-		return strings.Join(sl[:max], ", ") + ", …"
+func print2(sl []string) string {
+	if len(sl) > 2 {
+		return strings.Join(sl[:2], ", ") + ", …"
 	}
 	return strings.Join(sl, ", ")
 }

--- a/commands/import.go
+++ b/commands/import.go
@@ -20,18 +20,6 @@ import (
 	"github.com/mattermost/mmctl/v6/printer"
 )
 
-type Statistics struct {
-	Schemes        int `json:"schemes"`
-	Teams          int `json:"teams"`
-	Channels       int `json:"channels"`
-	Users          int `json:"users"`
-	Emojis         int `json:"emojis"`
-	Posts          int `json:"posts"`
-	DirectChannels int `json:"direct_channels"`
-	DirectPosts    int `json:"direct_posts"`
-	Attachments    int `json:"attachments"`
-}
-
 var ImportCmd = &cobra.Command{
 	Use:   "import",
 	Short: "Management of imports",
@@ -114,7 +102,7 @@ func init() {
 	ImportJobListCmd.Flags().Int("per-page", 200, "Number of import jobs to be fetched")
 	ImportJobListCmd.Flags().Bool("all", false, "Fetch all import jobs. --page flag will be ignore if provided")
 
-	ImportValidateCmd.Flags().StringArray("team", nil, "Predefined teams")
+	ImportValidateCmd.Flags().StringArray("team", nil, "The names of the team[s] (flag can be repeated)")
 	ImportValidateCmd.Flags().Bool("ignore-attachments", false, "Don't check if the attached files are present in the archive")
 
 	ImportListCmd.AddCommand(
@@ -340,6 +328,18 @@ func jobListCmdF(c client.Client, command *cobra.Command, jobType string) error 
 
 func importJobListCmdF(c client.Client, command *cobra.Command, args []string) error {
 	return jobListCmdF(c, command, model.JobTypeImportProcess)
+}
+
+type Statistics struct {
+	Schemes        int `json:"schemes"`
+	Teams          int `json:"teams"`
+	Channels       int `json:"channels"`
+	Users          int `json:"users"`
+	Emojis         int `json:"emojis"`
+	Posts          int `json:"posts"`
+	DirectChannels int `json:"direct_channels"`
+	DirectPosts    int `json:"direct_posts"`
+	Attachments    int `json:"attachments"`
 }
 
 func importValidateCmdF(command *cobra.Command, args []string) error {

--- a/commands/import.go
+++ b/commands/import.go
@@ -345,9 +345,7 @@ type Statistics struct {
 func importValidateCmdF(command *cobra.Command, args []string) error {
 	configurePrinter()
 
-	defer printer.PrintT("Validation complete\n", struct {
-		Completed bool `json:"completed"`
-	}{true})
+	defer printer.Print("Validation complete\n")
 
 	injectedTeams, err := command.Flags().GetStringArray("team")
 	if err != nil {

--- a/commands/import.go
+++ b/commands/import.go
@@ -347,17 +347,11 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	validator := importer.NewValidator(args[0])
-
-	validator.IgnoreAttachments(ignoreAttachments)
+	validator := importer.NewValidator(args[0], ignoreAttachments)
 
 	for _, team := range injectedTeams {
 		validator.InjectTeam(team)
 	}
-	printer.PrintT("Predefined teams: {{ join .Teams \", \" }}\n", struct {
-		Teams []string `json:"injected_teams"`
-	}{injectedTeams})
-	printer.Flush() // flush the output, the next line could take a long time
 
 	templateError := template.Must(template.New("").Parse("{{ .Error }}\n"))
 	validator.OnError(func(ive *importer.ImportValidationError) error {

--- a/commands/import.go
+++ b/commands/import.go
@@ -421,13 +421,14 @@ type Statistics struct {
 }
 
 func printStatistics(stat Statistics) {
-	tmpl := "Schemes         {{ .Schemes }}\n" +
+	tmpl := "\n" +
+		"Schemes         {{ .Schemes }}\n" +
 		"Teams           {{ .Teams }}\n" +
 		"Channels        {{ .Channels }}\n" +
 		"Users           {{ .Users }}\n" +
 		"Emojis          {{ .Emojis }}\n" +
 		"Posts           {{ .Posts }}\n" +
-		"Direct Channels { .DirectChannels }}\n" +
+		"Direct Channels {{ .DirectChannels }}\n" +
 		"Direct Posts    {{ .DirectPosts }}\n" +
 		"Attachments     {{ .Attachments }}\n"
 

--- a/commands/import.go
+++ b/commands/import.go
@@ -87,7 +87,7 @@ var ImportProcessCmd = &cobra.Command{
 
 var ImportValidateCmd = &cobra.Command{
 	Use:     "validate [filepath]",
-	Example: "  import validate import_file.zip",
+	Example: "  import validate import_file.zip --team myteam --team myotherteam",
 	Short:   "Validate an import file",
 	Args:    cobra.ExactArgs(1),
 	RunE:    importValidateCmdF,

--- a/commands/import.go
+++ b/commands/import.go
@@ -359,7 +359,8 @@ func importValidateCmdF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	validator := importer.NewValidator(args[0], ignoreAttachments)
+	createMissingTeams := len(injectedTeams) == 0
+	validator := importer.NewValidator(args[0], ignoreAttachments, createMissingTeams)
 
 	for _, team := range injectedTeams {
 		validator.InjectTeam(team)

--- a/commands/importer/types.go
+++ b/commands/importer/types.go
@@ -11,7 +11,7 @@ import (
 
 // Import Data Models
 
-type LineImportData struct {
+type LineImportData struct { //nolint:govet
 	Type          string                   `json:"type"`
 	Scheme        *SchemeImportData        `json:"scheme,omitempty"`
 	Team          *TeamImportData          `json:"team,omitempty"`

--- a/commands/importer/types.go
+++ b/commands/importer/types.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package importer
 
 import (

--- a/commands/importer/types.go
+++ b/commands/importer/types.go
@@ -1,0 +1,216 @@
+package importer
+
+import (
+	"archive/zip"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+)
+
+// Import Data Models
+
+type LineImportData struct {
+	Type          string                   `json:"type"`
+	Scheme        *SchemeImportData        `json:"scheme,omitempty"`
+	Team          *TeamImportData          `json:"team,omitempty"`
+	Channel       *ChannelImportData       `json:"channel,omitempty"`
+	User          *UserImportData          `json:"user,omitempty"`
+	Post          *PostImportData          `json:"post,omitempty"`
+	DirectChannel *DirectChannelImportData `json:"direct_channel,omitempty"`
+	DirectPost    *DirectPostImportData    `json:"direct_post,omitempty"`
+	Emoji         *EmojiImportData         `json:"emoji,omitempty"`
+	Version       *int                     `json:"version,omitempty"`
+}
+
+type TeamImportData struct {
+	Name            *string `json:"name"`
+	DisplayName     *string `json:"display_name"`
+	Type            *string `json:"type"`
+	Description     *string `json:"description,omitempty"`
+	AllowOpenInvite *bool   `json:"allow_open_invite,omitempty"`
+	Scheme          *string `json:"scheme,omitempty"`
+}
+
+type ChannelImportData struct {
+	Team        *string            `json:"team"`
+	Name        *string            `json:"name"`
+	DisplayName *string            `json:"display_name"`
+	Type        *model.ChannelType `json:"type"`
+	Header      *string            `json:"header,omitempty"`
+	Purpose     *string            `json:"purpose,omitempty"`
+	Scheme      *string            `json:"scheme,omitempty"`
+}
+
+type UserImportData struct {
+	ProfileImage       *string   `json:"profile_image,omitempty"`
+	ProfileImageData   *zip.File `json:"-"`
+	Username           *string   `json:"username"`
+	Email              *string   `json:"email"`
+	AuthService        *string   `json:"auth_service"`
+	AuthData           *string   `json:"auth_data,omitempty"`
+	Password           *string   `json:"password,omitempty"`
+	Nickname           *string   `json:"nickname"`
+	FirstName          *string   `json:"first_name"`
+	LastName           *string   `json:"last_name"`
+	Position           *string   `json:"position"`
+	Roles              *string   `json:"roles"`
+	Locale             *string   `json:"locale"`
+	UseMarkdownPreview *string   `json:"feature_enabled_markdown_preview,omitempty"`
+	UseFormatting      *string   `json:"formatting,omitempty"`
+	ShowUnreadSection  *string   `json:"show_unread_section,omitempty"`
+	DeleteAt           *int64    `json:"delete_at,omitempty"`
+
+	Teams *[]UserTeamImportData `json:"teams,omitempty"`
+
+	Theme               *string `json:"theme,omitempty"`
+	UseMilitaryTime     *string `json:"military_time,omitempty"`
+	CollapsePreviews    *string `json:"link_previews,omitempty"`
+	MessageDisplay      *string `json:"message_display,omitempty"`
+	CollapseConsecutive *string `json:"collapse_consecutive_messages,omitempty"`
+	ColorizeUsernames   *string `json:"colorize_usernames,omitempty"`
+	ChannelDisplayMode  *string `json:"channel_display_mode,omitempty"`
+	TutorialStep        *string `json:"tutorial_step,omitempty"`
+	EmailInterval       *string `json:"email_interval,omitempty"`
+
+	NotifyProps *UserNotifyPropsImportData `json:"notify_props,omitempty"`
+}
+
+type UserNotifyPropsImportData struct {
+	Desktop      *string `json:"desktop"`
+	DesktopSound *string `json:"desktop_sound"`
+
+	Email *string `json:"email"`
+
+	Mobile           *string `json:"mobile"`
+	MobilePushStatus *string `json:"mobile_push_status"`
+
+	ChannelTrigger  *string `json:"channel"`
+	CommentsTrigger *string `json:"comments"`
+	MentionKeys     *string `json:"mention_keys"`
+}
+
+type UserTeamImportData struct {
+	Name     *string                  `json:"name"`
+	Roles    *string                  `json:"roles"`
+	Theme    *string                  `json:"theme,omitempty"`
+	Channels *[]UserChannelImportData `json:"channels,omitempty"`
+}
+
+type UserChannelImportData struct {
+	Name        *string                           `json:"name"`
+	Roles       *string                           `json:"roles"`
+	NotifyProps *UserChannelNotifyPropsImportData `json:"notify_props,omitempty"`
+	Favorite    *bool                             `json:"favorite,omitempty"`
+}
+
+type UserChannelNotifyPropsImportData struct {
+	Desktop    *string `json:"desktop"`
+	Mobile     *string `json:"mobile"`
+	MarkUnread *string `json:"mark_unread"`
+}
+
+type EmojiImportData struct {
+	Name  *string   `json:"name"`
+	Image *string   `json:"image"`
+	Data  *zip.File `json:"-"`
+}
+
+type ReactionImportData struct {
+	User      *string `json:"user"`
+	CreateAt  *int64  `json:"create_at"`
+	EmojiName *string `json:"emoji_name"`
+}
+
+type ReplyImportData struct {
+	User *string `json:"user"`
+
+	Type     *string `json:"type"`
+	Message  *string `json:"message"`
+	CreateAt *int64  `json:"create_at"`
+	EditAt   *int64  `json:"edit_at"`
+
+	FlaggedBy   *[]string               `json:"flagged_by,omitempty"`
+	Reactions   *[]ReactionImportData   `json:"reactions,omitempty"`
+	Attachments *[]AttachmentImportData `json:"attachments,omitempty"`
+}
+
+type PostImportData struct {
+	Team    *string `json:"team"`
+	Channel *string `json:"channel"`
+	User    *string `json:"user"`
+
+	Type     *string                `json:"type"`
+	Message  *string                `json:"message"`
+	Props    *model.StringInterface `json:"props"`
+	CreateAt *int64                 `json:"create_at"`
+	EditAt   *int64                 `json:"edit_at"`
+
+	FlaggedBy   *[]string               `json:"flagged_by,omitempty"`
+	Reactions   *[]ReactionImportData   `json:"reactions,omitempty"`
+	Replies     *[]ReplyImportData      `json:"replies,omitempty"`
+	Attachments *[]AttachmentImportData `json:"attachments,omitempty"`
+	IsPinned    *bool                   `json:"is_pinned,omitempty"`
+}
+
+type DirectChannelImportData struct {
+	Members     *[]string `json:"members"`
+	FavoritedBy *[]string `json:"favorited_by"`
+
+	Header *string `json:"header"`
+}
+
+type DirectPostImportData struct {
+	ChannelMembers *[]string `json:"channel_members"`
+	User           *string   `json:"user"`
+
+	Type     *string                `json:"type"`
+	Message  *string                `json:"message"`
+	Props    *model.StringInterface `json:"props"`
+	CreateAt *int64                 `json:"create_at"`
+	EditAt   *int64                 `json:"edit_at"`
+
+	FlaggedBy   *[]string               `json:"flagged_by"`
+	Reactions   *[]ReactionImportData   `json:"reactions"`
+	Replies     *[]ReplyImportData      `json:"replies"`
+	Attachments *[]AttachmentImportData `json:"attachments"`
+	IsPinned    *bool                   `json:"is_pinned,omitempty"`
+}
+
+type SchemeImportData struct {
+	Name                    *string         `json:"name"`
+	DisplayName             *string         `json:"display_name"`
+	Description             *string         `json:"description"`
+	Scope                   *string         `json:"scope"`
+	DefaultTeamAdminRole    *RoleImportData `json:"default_team_admin_role"`
+	DefaultTeamUserRole     *RoleImportData `json:"default_team_user_role"`
+	DefaultChannelAdminRole *RoleImportData `json:"default_channel_admin_role"`
+	DefaultChannelUserRole  *RoleImportData `json:"default_channel_user_role"`
+	DefaultTeamGuestRole    *RoleImportData `json:"default_team_guest_role"`
+	DefaultChannelGuestRole *RoleImportData `json:"default_channel_guest_role"`
+}
+
+type RoleImportData struct {
+	Name        *string   `json:"name"`
+	DisplayName *string   `json:"display_name"`
+	Description *string   `json:"description"`
+	Permissions *[]string `json:"permissions"`
+}
+
+type LineImportWorkerData struct {
+	LineImportData
+	LineNumber int
+}
+
+type LineImportWorkerError struct {
+	Error      *model.AppError
+	LineNumber int
+}
+
+type AttachmentImportData struct {
+	Path *string   `json:"path"`
+	Data *zip.File `json:"-"`
+}
+
+type ComparablePreference struct {
+	Category string
+	Name     string
+}

--- a/commands/importer/utils.go
+++ b/commands/importer/utils.go
@@ -1,0 +1,41 @@
+package importer
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ImportFileInfo struct {
+	ArchiveName string
+	FileName    string
+	LineNumber  uint64
+	TotalLines  uint64
+}
+
+type ImportValidationError struct {
+	ImportFileInfo
+	FieldName       string
+	Err             error
+	Suggestion      string
+	SuggestedValue  []any
+	ApplySuggestion func(any) error
+}
+
+func (e *ImportValidationError) Error() string {
+	msg := &strings.Builder{}
+	msg.WriteString("import validation error")
+
+	if e.FileName != "" || e.ArchiveName != "" {
+		fmt.Fprintf(msg, " in %q->%q:%d", e.ArchiveName, e.FileName, e.LineNumber)
+	}
+
+	if e.FieldName != "" {
+		fmt.Fprintf(msg, " field %q", e.FieldName)
+	}
+
+	if e.Err != nil {
+		fmt.Fprintf(msg, ": %s", e.Err)
+	}
+
+	return msg.String()
+}

--- a/commands/importer/utils.go
+++ b/commands/importer/utils.go
@@ -9,19 +9,19 @@ import (
 )
 
 type ImportFileInfo struct {
-	ArchiveName string
-	FileName    string
-	LineNumber  uint64
-	TotalLines  uint64
+	ArchiveName string `json:"archive_name"`
+	FileName    string `json:"file_name,omitempty"`
+	CurrentLine uint64 `json:"current_line,omitempty"`
+	TotalLines  uint64 `json:"total_lines,omitempty"`
 }
 
 type ImportValidationError struct { //nolint:govet
 	ImportFileInfo
-	FieldName       string
-	Err             error
-	Suggestion      string
-	SuggestedValues []any
-	ApplySuggestion func(any) error
+	FieldName       string          `json:"field_name,omitempty"`
+	Err             error           `json:"error"`
+	Suggestion      string          `json:"suggestion,omitempty"`
+	SuggestedValues []any           `json:"suggested_values,omitempty"`
+	ApplySuggestion func(any) error `json:"-"`
 }
 
 func (e *ImportValidationError) Error() string {
@@ -29,7 +29,7 @@ func (e *ImportValidationError) Error() string {
 	msg.WriteString("import validation error")
 
 	if e.FileName != "" || e.ArchiveName != "" {
-		fmt.Fprintf(msg, " in %q->%q:%d", e.ArchiveName, e.FileName, e.LineNumber)
+		fmt.Fprintf(msg, " in %q->%q:%d", e.ArchiveName, e.FileName, e.CurrentLine)
 	}
 
 	if e.FieldName != "" {

--- a/commands/importer/utils.go
+++ b/commands/importer/utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package importer
 
 import (

--- a/commands/importer/utils.go
+++ b/commands/importer/utils.go
@@ -17,7 +17,7 @@ type ImportValidationError struct {
 	FieldName       string
 	Err             error
 	Suggestion      string
-	SuggestedValue  []any
+	SuggestedValues []any
 	ApplySuggestion func(any) error
 }
 

--- a/commands/importer/utils.go
+++ b/commands/importer/utils.go
@@ -51,7 +51,7 @@ func (e *ImportValidationError) Error() string {
 	msg.WriteString("import validation error")
 
 	if e.FileName != "" || e.ArchiveName != "" {
-		fmt.Fprintf(msg, " in %q->%q:%d", e.ArchiveName, e.FileName, e.CurrentLine)
+		fmt.Fprintf(msg, " in %s->%s:%d", e.ArchiveName, e.FileName, e.CurrentLine)
 	}
 
 	if e.FieldName != "" {

--- a/commands/importer/utils.go
+++ b/commands/importer/utils.go
@@ -15,7 +15,7 @@ type ImportFileInfo struct {
 	TotalLines  uint64
 }
 
-type ImportValidationError struct {
+type ImportValidationError struct { //nolint:govet
 	ImportFileInfo
 	FieldName       string
 	Err             error

--- a/commands/importer/utils.go
+++ b/commands/importer/utils.go
@@ -4,6 +4,7 @@
 package importer
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -17,11 +18,32 @@ type ImportFileInfo struct {
 
 type ImportValidationError struct { //nolint:govet
 	ImportFileInfo
-	FieldName       string          `json:"field_name,omitempty"`
-	Err             error           `json:"error"`
-	Suggestion      string          `json:"suggestion,omitempty"`
-	SuggestedValues []any           `json:"suggested_values,omitempty"`
-	ApplySuggestion func(any) error `json:"-"`
+	FieldName       string
+	Err             error
+	Suggestion      string
+	SuggestedValues []any
+	ApplySuggestion func(any) error
+}
+
+func (e *ImportValidationError) MarshalJSON() ([]byte, error) {
+	t := struct { //nolint:govet
+		ImportFileInfo
+		FieldName       string `json:"field_name,omitempty"`
+		Err             string `json:"error,omitempty"`
+		Suggestion      string `json:"suggestion,omitempty"`
+		SuggestedValues []any  `json:"suggested_values,omitempty"`
+	}{
+		ImportFileInfo:  e.ImportFileInfo,
+		FieldName:       e.FieldName,
+		Suggestion:      e.Suggestion,
+		SuggestedValues: e.SuggestedValues,
+	}
+
+	if e.Err != nil {
+		t.Err = e.Err.Error()
+	}
+
+	return json.Marshal(t)
 }
 
 func (e *ImportValidationError) Error() string {

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -492,12 +492,12 @@ func (v *Validator) validateChannel(info ImportFileInfo, line LineImportData) (e
 			if _, ok := v.teams[*data.Team]; !ok {
 				if v.createMissingTeams {
 					v.createTeam(*data.Team)
-				}
-
-				return &ImportValidationError{
-					ImportFileInfo: info,
-					FieldName:      "channel.team",
-					Err:            fmt.Errorf("reference to unknown team %q", *data.Team),
+				} else {
+					return &ImportValidationError{
+						ImportFileInfo: info,
+						FieldName:      "channel.team",
+						Err:            fmt.Errorf("reference to unknown team %q", *data.Team),
+					}
 				}
 			}
 		}
@@ -556,12 +556,12 @@ func (v *Validator) validateUser(info ImportFileInfo, line LineImportData) (err 
 				if _, ok := v.teams[*team.Name]; !ok {
 					if v.createMissingTeams {
 						v.createTeam(*team.Name)
-					}
-
-					return &ImportValidationError{
-						ImportFileInfo: info,
-						FieldName:      fmt.Sprintf("user.teams[%d]", i),
-						Err:            fmt.Errorf("reference to unknown team %q", *team.Name),
+					} else {
+						return &ImportValidationError{
+							ImportFileInfo: info,
+							FieldName:      fmt.Sprintf("user.teams[%d]", i),
+							Err:            fmt.Errorf("reference to unknown team %q", *team.Name),
+						}
 					}
 				}
 			}
@@ -591,12 +591,12 @@ func (v *Validator) validatePost(info ImportFileInfo, line LineImportData) (err 
 			if _, ok := v.teams[*data.Team]; !ok {
 				if v.createMissingTeams {
 					v.createTeam(*data.Team)
-				}
-
-				return &ImportValidationError{
-					ImportFileInfo: info,
-					FieldName:      "post.team",
-					Err:            fmt.Errorf("reference to unknown team %q", *data.Team),
+				} else {
+					return &ImportValidationError{
+						ImportFileInfo: info,
+						FieldName:      "post.team",
+						Err:            fmt.Errorf("reference to unknown team %q", *data.Team),
+					}
 				}
 			}
 		}

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -261,6 +261,8 @@ func (v *Validator) countLines(zf *zip.File) (uint64, error) {
 			}
 		}
 
+		printCount(count)
+
 		if err != nil {
 			if err == io.EOF {
 				err = nil
@@ -929,5 +931,16 @@ func printProgress(current, total uint64) {
 	}{current, total, percent}
 
 	printer.PrintPreparedT(progressTemplate, data)
+	printer.Flush()
+}
+
+var countTemplate = template.Must(template.New("").Parse("Counting lines: {{ .Current }}\r"))
+
+func printCount(total uint64) {
+	data := struct {
+		Total uint64 `json:"total_lines"`
+	}{total}
+
+	printer.PrintPreparedT(countTemplate, data)
 	printer.Flush()
 }

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -815,7 +815,7 @@ func (v *Validator) validateEmoji(info ImportFileInfo, line LineImportData) (err
 }
 
 func (v *Validator) Attachments() []string {
-	var used []string
+	used := make([]string, 0, len(v.attachmentsUsed))
 	for attachment := range v.attachmentsUsed {
 		used = append(used, attachment)
 	}

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -934,7 +934,7 @@ func printProgress(current, total uint64) {
 	printer.Flush()
 }
 
-var countTemplate = template.Must(template.New("").Parse("Counting lines: {{ .Current }}\r"))
+var countTemplate = template.Must(template.New("").Parse("Counting lines: {{ .Total }}\r"))
 
 func printCount(total uint64) {
 	data := struct {

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -60,6 +60,18 @@ type Validator struct { //nolint:govet
 	lines uint64
 }
 
+const (
+	LineTypeVersion       = "version"
+	LineTypeScheme        = "scheme"
+	LineTypeTeam          = "team"
+	LineTypeChannel       = "channel"
+	LineTypeUser          = "user"
+	LineTypePost          = "post"
+	LineTypeDirectChannel = "direct_channel"
+	LineTypeDirectPost    = "direct_post"
+	LineTypeEmoji         = "emoji"
+)
+
 func NewValidator(name string, ignoreAttachments bool) *Validator {
 	return &Validator{
 		archiveName:       name,
@@ -326,23 +338,23 @@ func (v *Validator) validateLine(info ImportFileInfo, line LineImportData) error
 	}
 
 	switch line.Type {
-	case "version":
+	case LineTypeVersion:
 		err = v.validateVersion(info, line)
-	case "scheme":
+	case LineTypeScheme:
 		err = v.validateScheme(info, line)
-	case "team":
+	case LineTypeTeam:
 		err = v.validateTeam(info, line)
-	case "channel":
+	case LineTypeChannel:
 		err = v.validateChannel(info, line)
-	case "user":
+	case LineTypeUser:
 		err = v.validateUser(info, line)
-	case "post":
+	case LineTypePost:
 		err = v.validatePost(info, line)
-	case "direct_channel":
+	case LineTypeDirectChannel:
 		err = v.validateDirectChannel(info, line)
-	case "direct_post":
+	case LineTypeDirectPost:
 		err = v.validateDirectPost(info, line)
-	case "emoji":
+	case LineTypeEmoji:
 		err = v.validateEmoji(info, line)
 	default:
 		err = v.onError(&ImportValidationError{

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -1,0 +1,711 @@
+package importer
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"  // image decoder
+	_ "image/jpeg" // image decoder
+	_ "image/png"  // image decoder
+	"mime"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	_ "golang.org/x/image/webp" // image decoder
+
+	"github.com/mattermost/mattermost-server/v6/model"
+)
+
+type Validator struct {
+	archiveName string
+	onError     func(*ImportValidationError) error
+
+	attachments     map[string]*zip.File
+	attachmentsUsed map[string]uint64
+
+	schemes        map[string]ImportFileInfo
+	teams          map[string]ImportFileInfo
+	channels       map[string]ImportFileInfo
+	users          map[string]ImportFileInfo
+	posts          uint64
+	directChannels uint64
+	emojis         map[string]ImportFileInfo
+}
+
+func NewValidator(name string) *Validator {
+	return &Validator{
+		archiveName: name,
+		onError:     func(ive *ImportValidationError) error { return ive },
+
+		attachments:     make(map[string]*zip.File),
+		attachmentsUsed: make(map[string]uint64),
+
+		schemes:        map[string]ImportFileInfo{},
+		teams:          map[string]ImportFileInfo{},
+		channels:       map[string]ImportFileInfo{},
+		users:          map[string]ImportFileInfo{},
+		posts:          0,
+		directChannels: 0,
+		emojis:         map[string]ImportFileInfo{},
+	}
+}
+
+func (v *Validator) Schemes() []string {
+	return v.listMap(v.schemes)
+}
+
+func (v *Validator) Teams() []string {
+	return v.listMap(v.teams)
+}
+
+func (v *Validator) Channels() []string {
+	return v.listMap(v.channels)
+}
+
+func (v *Validator) Users() []string {
+	return v.listMap(v.users)
+}
+
+func (v *Validator) PostCount() uint64 {
+	return v.posts
+}
+
+func (v *Validator) DirectChannelCount() uint64 {
+	return v.directChannels
+}
+
+func (v *Validator) Emojis() []string {
+	return v.listMap(v.emojis)
+}
+
+func (v *Validator) listMap(m map[string]ImportFileInfo) []string {
+	entries := make([]string, 0, len(m))
+	for entry := range m {
+		entries = append(entries, entry)
+	}
+	sort.Strings(entries)
+	return entries
+}
+
+func (v *Validator) OnError(f func(ive *ImportValidationError) error) {
+	if f == nil {
+		f = func(ive *ImportValidationError) error { return ive }
+	}
+
+	v.onError = f
+}
+
+func (v *Validator) InjectTeam(name string) {
+	v.teams[name] = ImportFileInfo{
+		ArchiveName: "injected",
+	}
+}
+
+func (v *Validator) Validate() error {
+	f, err := os.Open(v.archiveName)
+	if err != nil {
+		return fmt.Errorf("error opening the import file %q: %w", v.archiveName, err)
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("error reading the metadata the input file: %w", err)
+	}
+
+	z, err := zip.NewReader(f, stat.Size())
+	if err != nil {
+		return fmt.Errorf("error reading the ZIP file: %w", err)
+	}
+
+	var jsonlZip *zip.File
+	for _, zfile := range z.File {
+		if filepath.Ext(zfile.Name) != ".jsonl" {
+			continue
+		}
+
+		jsonlZip = zfile
+		break
+	}
+	if jsonlZip == nil {
+		return fmt.Errorf("could not find a .jsonl file in the import archive")
+	}
+
+	for _, zfile := range z.File {
+		if zfile.FileInfo().IsDir() {
+			continue
+		}
+		if strings.HasPrefix(zfile.Name, "data/") {
+			v.attachments[zfile.Name] = zfile
+		}
+	}
+
+	lines, err := v.countLines(jsonlZip)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("The .jsonl file has %d lines\n", lines)
+
+	info := ImportFileInfo{
+		ArchiveName: filepath.Base(v.archiveName),
+		FileName:    jsonlZip.Name,
+		TotalLines:  lines,
+	}
+
+	err = v.validateLines(info, jsonlZip)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func (v *Validator) countLines(zf *zip.File) (uint64, error) {
+	f, err := zf.Open()
+	if err != nil {
+		return 0, fmt.Errorf("error counting the lines: %w", err)
+	}
+	defer f.Close()
+
+	count := uint64(0)
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		count++
+	}
+
+	return count, nil
+}
+
+func (v *Validator) validateLines(info ImportFileInfo, zf *zip.File) error {
+	f, err := zf.Open()
+	if err != nil {
+		return fmt.Errorf("error validating the lines: %w", err)
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	s.Buffer(buf, 16*1024*1024)
+
+	for s.Scan() {
+		info.LineNumber++
+
+		rawLine := s.Bytes()
+
+		// filter empty lines
+		rawLine = bytes.TrimSpace(rawLine)
+		if len(rawLine) == 0 {
+			if err = v.onError(&ImportValidationError{
+				ImportFileInfo: info,
+				Err:            errors.New("unexpected empty line"),
+			}); err != nil {
+				return err
+			}
+		}
+
+		// decode the line
+		var line LineImportData
+		err = json.Unmarshal(rawLine, &line)
+		if err != nil {
+			if err = v.onError(&ImportValidationError{
+				ImportFileInfo: info,
+				Err:            err,
+			}); err != nil {
+				return err
+			}
+		}
+
+		err = v.validateLine(info, line)
+		if err != nil {
+			return err
+		}
+
+		if info.LineNumber%10000 == 0 {
+			fmt.Printf("Progress: %d/%d (%.2f%%)\n", info.LineNumber, info.TotalLines, float64(info.LineNumber)*100/float64(info.TotalLines))
+		}
+	}
+
+	return nil
+}
+
+func (v *Validator) validateLine(info ImportFileInfo, line LineImportData) error {
+	var err error
+
+	// make sure the file starts with a version
+	if info.LineNumber == 1 && line.Type != "version" {
+		if err = v.onError(&ImportValidationError{
+			ImportFileInfo: info,
+			Err:            fmt.Errorf("first line has the wrong type: expected \"version\", got %q", line.Type),
+		}); err != nil {
+			return err
+		}
+	}
+
+	switch line.Type {
+	case "version":
+		err = v.validateVersion(info, line)
+	case "scheme":
+		err = v.validateScheme(info, line)
+	case "team":
+		err = v.validateTeam(info, line)
+	case "channel":
+		err = v.validateChannel(info, line)
+	case "user":
+		err = v.validateUser(info, line)
+	case "post":
+		err = v.validatePost(info, line)
+	case "direct_channel":
+		err = v.validateDirectChannel(info, line)
+	case "emoji":
+		err = v.validateEmoji(info, line)
+	default:
+		err = v.onError(&ImportValidationError{
+			ImportFileInfo: info,
+			FieldName:      "type",
+			Err:            fmt.Errorf("unknown import type %q", line.Type),
+		})
+	}
+
+	return err
+}
+
+func (v *Validator) validateVersion(info ImportFileInfo, line LineImportData) (err error) {
+	if info.LineNumber != 1 {
+		if err = v.onError(&ImportValidationError{
+			ImportFileInfo: info,
+			Err:            fmt.Errorf("version info must be the first line of the file"),
+		}); err != nil {
+			return err
+		}
+	}
+
+	if line.Version == nil {
+		if err = v.onError(&ImportValidationError{
+			ImportFileInfo: info,
+			Err:            fmt.Errorf("version must not be null or missing"),
+		}); err != nil {
+			return err
+		}
+	} else if *line.Version != 1 {
+		if err = v.onError(&ImportValidationError{
+			ImportFileInfo: info,
+			Err:            fmt.Errorf("version must not be 1"),
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (v *Validator) validateScheme(info ImportFileInfo, line LineImportData) (err error) {
+	ive := validateNotNil(info, "scheme", line.Scheme, func(data SchemeImportData) *ImportValidationError {
+		appErr := validateSchemeImportData(&data)
+		if appErr != nil {
+			return &ImportValidationError{
+				ImportFileInfo: info,
+				FieldName:      "scheme",
+				Err:            appErr,
+			}
+		}
+
+		if data.Name != nil {
+			if existing, ok := v.schemes[*data.Name]; ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "scheme",
+					Err:            fmt.Errorf("duplicate entry, previous was in line: %d", existing.LineNumber),
+				}
+			}
+			v.schemes[*data.Name] = info
+		}
+
+		return nil
+	})
+	if ive != nil {
+		return v.onError(ive)
+	}
+
+	return nil
+}
+
+func (v *Validator) validateTeam(info ImportFileInfo, line LineImportData) (err error) {
+	ive := validateNotNil(info, "team", line.Team, func(data TeamImportData) *ImportValidationError {
+		appErr := validateTeamImportData(&data)
+		if appErr != nil {
+			return &ImportValidationError{
+				ImportFileInfo: info,
+				FieldName:      "team",
+				Err:            appErr,
+			}
+		}
+
+		if data.Name != nil {
+			if existing, ok := v.teams[*data.Name]; ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "team",
+					Err:            fmt.Errorf("duplicate entry, previous was in line: %d", existing.LineNumber),
+				}
+			}
+			v.teams[*data.Name] = info
+		}
+		if data.Scheme != nil {
+			if _, ok := v.schemes[*data.Scheme]; !ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "team.scheme",
+					Err:            fmt.Errorf("reference to unknown scheme %q", *data.Scheme),
+				}
+			}
+		}
+
+		return nil
+	})
+	if ive != nil {
+		return v.onError(ive)
+	}
+
+	return nil
+}
+
+func (v *Validator) validateChannel(info ImportFileInfo, line LineImportData) (err error) {
+	ive := validateNotNil(info, "channel", line.Channel, func(data ChannelImportData) *ImportValidationError {
+		appErr := validateChannelImportData(&data)
+		if appErr != nil {
+			return &ImportValidationError{
+				ImportFileInfo: info,
+				FieldName:      "channel",
+				Err:            appErr,
+			}
+		}
+
+		if data.Name != nil {
+			if existing, ok := v.channels[*data.Name]; ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "channel",
+					Err:            fmt.Errorf("duplicate entry, previous was in line: %d", existing.LineNumber),
+				}
+			}
+			v.channels[*data.Name] = info
+		}
+		if data.Scheme != nil {
+			if _, ok := v.schemes[*data.Scheme]; !ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "channel.scheme",
+					Err:            fmt.Errorf("reference to unknown scheme %q", *data.Scheme),
+				}
+			}
+		}
+		if data.Team != nil {
+			if _, ok := v.teams[*data.Team]; !ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "channel.team",
+					Err:            fmt.Errorf("reference to unknown team %q", *data.Team),
+				}
+			}
+		}
+
+		return nil
+	})
+	if ive != nil {
+		return v.onError(ive)
+	}
+
+	return nil
+}
+
+func (v *Validator) validateUser(info ImportFileInfo, line LineImportData) (err error) {
+	ive := validateNotNil(info, "user", line.User, func(data UserImportData) *ImportValidationError {
+		appErr := validateUserImportData(&data)
+		if appErr != nil {
+			return &ImportValidationError{
+				ImportFileInfo: info,
+				FieldName:      "user",
+				Err:            appErr,
+			}
+		}
+
+		if data.Username != nil {
+			if existing, ok := v.users[*data.Username]; ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "user",
+					Err:            fmt.Errorf("duplicate entry, previous was in line: %d", existing.LineNumber),
+				}
+			}
+			v.users[*data.Username] = info
+		}
+		if data.Teams != nil {
+			for i, team := range *data.Teams {
+				if _, ok := v.teams[*team.Name]; !ok {
+					return &ImportValidationError{
+						ImportFileInfo: info,
+						FieldName:      fmt.Sprintf("user.teams[%d]", i),
+						Err:            fmt.Errorf("reference to unknown team %q", *team.Name),
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+	if ive != nil {
+		return v.onError(ive)
+	}
+
+	return nil
+}
+
+func (v *Validator) validatePost(info ImportFileInfo, line LineImportData) (err error) {
+	ive := validateNotNil(info, "post", line.Post, func(data PostImportData) *ImportValidationError {
+		appErr := validatePostImportData(&data, model.PostMessageMaxRunesV1)
+		if appErr != nil {
+			return &ImportValidationError{
+				ImportFileInfo: info,
+				FieldName:      "post",
+				Err:            appErr,
+			}
+		}
+
+		if data.Team != nil {
+			if _, ok := v.teams[*data.Team]; !ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "post.team",
+					Err:            fmt.Errorf("reference to unknown team %q", *data.Team),
+				}
+			}
+		}
+		if data.Channel != nil {
+			if _, ok := v.channels[*data.Channel]; !ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "post.channel",
+					Err:            fmt.Errorf("reference to unknown channel %q", *data.Channel),
+				}
+			}
+		}
+		if data.User != nil {
+			if _, ok := v.users[*data.User]; !ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "post.user",
+					Err:            fmt.Errorf("reference to unknown user %q", *data.User),
+				}
+			}
+		}
+
+		return nil
+	})
+	if ive != nil {
+		if err = v.onError(ive); err != nil {
+			return err
+		}
+	}
+
+	if line.Post != nil && line.Post.Attachments != nil {
+		for i, attachment := range *line.Post.Attachments {
+			if attachment.Path == nil {
+				continue
+			}
+
+			attachmentPath := path.Join("data", *attachment.Path)
+
+			if _, ok := v.attachments[attachmentPath]; !ok {
+				if err = v.onError(&ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      fmt.Sprintf("post.attachments[%d]", i),
+					Err:            fmt.Errorf("missing attachment file %q", attachmentPath),
+				}); err != nil {
+					return err
+				}
+			} else {
+				v.attachmentsUsed[attachmentPath]++
+			}
+		}
+	}
+
+	v.posts++
+
+	return nil
+}
+
+func (v *Validator) validateDirectChannel(info ImportFileInfo, line LineImportData) (err error) {
+	ive := validateNotNil(info, "direct_channel", line.DirectChannel, func(data DirectChannelImportData) *ImportValidationError {
+		appErr := validateDirectChannelImportData(&data)
+		if appErr != nil {
+			return &ImportValidationError{
+				ImportFileInfo: info,
+				FieldName:      "direct_channel",
+				Err:            appErr,
+			}
+		}
+
+		if data.FavoritedBy != nil {
+			for i, favoritedBy := range *data.FavoritedBy {
+				if _, ok := v.users[favoritedBy]; !ok {
+					return &ImportValidationError{
+						ImportFileInfo: info,
+						FieldName:      fmt.Sprintf("direct_channel.favorited_by[%d]", i),
+						Err:            fmt.Errorf("reference to unknown user %q", favoritedBy),
+					}
+				}
+			}
+		}
+
+		if data.Members != nil {
+			for i, member := range *data.Members {
+				if _, ok := v.users[member]; !ok {
+					return &ImportValidationError{
+						ImportFileInfo: info,
+						FieldName:      fmt.Sprintf("direct_channel.members[%d]", i),
+						Err:            fmt.Errorf("reference to unknown user %q", member),
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+	if ive != nil {
+		if err = v.onError(ive); err != nil {
+			return err
+		}
+	}
+
+	v.directChannels++
+
+	return nil
+}
+
+func (v *Validator) validateEmoji(info ImportFileInfo, line LineImportData) (err error) {
+	ive := validateNotNil(info, "emoji", line.Emoji, func(data EmojiImportData) *ImportValidationError {
+		appErr := validateEmojiImportData(&data)
+		if appErr != nil {
+			return &ImportValidationError{
+				ImportFileInfo: info,
+				FieldName:      "emoji",
+				Err:            appErr,
+			}
+		}
+
+		if data.Name != nil {
+			if existing, ok := v.emojis[*data.Name]; ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "emoji",
+					Err:            fmt.Errorf("duplicate entry, previous was in line: %d", existing.LineNumber),
+				}
+			}
+			v.emojis[*data.Name] = info
+		}
+
+		if data.Image != nil {
+			attachmentPath := path.Join("data", *data.Image)
+
+			zfile, ok := v.attachments[attachmentPath]
+			if !ok {
+				return &ImportValidationError{
+					ImportFileInfo: info,
+					FieldName:      "emoji.image",
+					Err:            fmt.Errorf("missing image file for emoji %s: %s", *data.Name, attachmentPath),
+				}
+			}
+
+			return v.validateSupportedImage(info, zfile)
+		}
+
+		return nil
+	})
+	if ive != nil {
+		return v.onError(ive)
+	}
+
+	return nil
+}
+
+func (v *Validator) Attachments() []string {
+	var used []string
+	for attachment := range v.attachmentsUsed {
+		used = append(used, attachment)
+	}
+	sort.Strings(used)
+	return used
+}
+
+func (v *Validator) UnusedAttachments() []string {
+	var unused []string
+	for attachment := range v.attachments {
+		if _, ok := v.attachmentsUsed[attachment]; !ok {
+			unused = append(unused, attachment)
+		}
+	}
+	sort.Strings(unused)
+	return unused
+}
+
+func (v *Validator) validateSupportedImage(info ImportFileInfo, zfile *zip.File) *ImportValidationError {
+	f, err := zfile.Open()
+	if err != nil {
+		return &ImportValidationError{
+			ImportFileInfo: info,
+			FieldName:      "emoji.image",
+			Err:            fmt.Errorf("error opening emoji image: %w", err),
+		}
+	}
+	defer f.Close()
+
+	if mime.TypeByExtension(strings.ToLower(path.Ext(zfile.Name))) == "image/svg+xml" {
+		var svg struct{}
+		err = xml.NewDecoder(f).Decode(&svg)
+		if err != nil {
+			return &ImportValidationError{
+				ImportFileInfo: info,
+				FieldName:      "emoji.image",
+				Err:            fmt.Errorf("error decoding emoji SVG file: %w", err),
+			}
+		}
+
+		return nil
+	}
+
+	_, _, err = image.Decode(f)
+	if err != nil {
+		return &ImportValidationError{
+			ImportFileInfo: info,
+			FieldName:      "emoji.image",
+			Err:            fmt.Errorf("error decoding emoji image: %w", err),
+		}
+	}
+
+	return nil
+}
+
+func validateNotNil[T any](info ImportFileInfo, name string, value *T, then func(T) *ImportValidationError) *ImportValidationError {
+	if value == nil {
+		return &ImportValidationError{
+			ImportFileInfo: info,
+			FieldName:      name,
+			Err:            errors.New("field must not be null or missing"),
+		}
+	}
+
+	if then != nil {
+		return then(*value)
+	}
+
+	return nil
+}

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -75,7 +75,7 @@ const (
 func NewValidator(name string, ignoreAttachments bool) *Validator {
 	return &Validator{
 		archiveName:       name,
-		onError:           func(ive *ImportValidationError) error { return ive },
+		onError:           func(ivErr *ImportValidationError) error { return ivErr },
 		ignoreAttachments: ignoreAttachments,
 
 		attachments:     make(map[string]*zip.File),
@@ -151,9 +151,9 @@ func (v *Validator) listMap(m map[string]ImportFileInfo) []string {
 	return entries
 }
 
-func (v *Validator) OnError(f func(ive *ImportValidationError) error) {
+func (v *Validator) OnError(f func(*ImportValidationError) error) {
 	if f == nil {
-		f = func(ive *ImportValidationError) error { return ive }
+		f = func(ivErr *ImportValidationError) error { return ivErr }
 	}
 
 	v.onError = f
@@ -397,7 +397,7 @@ func (v *Validator) validateVersion(info ImportFileInfo, line LineImportData) (e
 }
 
 func (v *Validator) validateScheme(info ImportFileInfo, line LineImportData) (err error) {
-	ive := validateNotNil(info, "scheme", line.Scheme, func(data SchemeImportData) *ImportValidationError {
+	ivErr := validateNotNil(info, "scheme", line.Scheme, func(data SchemeImportData) *ImportValidationError {
 		appErr := validateSchemeImportData(&data)
 		if appErr != nil {
 			return &ImportValidationError{
@@ -420,15 +420,15 @@ func (v *Validator) validateScheme(info ImportFileInfo, line LineImportData) (er
 
 		return nil
 	})
-	if ive != nil {
-		return v.onError(ive)
+	if ivErr != nil {
+		return v.onError(ivErr)
 	}
 
 	return nil
 }
 
 func (v *Validator) validateTeam(info ImportFileInfo, line LineImportData) (err error) {
-	ive := validateNotNil(info, "team", line.Team, func(data TeamImportData) *ImportValidationError {
+	ivErr := validateNotNil(info, "team", line.Team, func(data TeamImportData) *ImportValidationError {
 		appErr := validateTeamImportData(&data)
 		if appErr != nil {
 			return &ImportValidationError{
@@ -460,15 +460,15 @@ func (v *Validator) validateTeam(info ImportFileInfo, line LineImportData) (err 
 
 		return nil
 	})
-	if ive != nil {
-		return v.onError(ive)
+	if ivErr != nil {
+		return v.onError(ivErr)
 	}
 
 	return nil
 }
 
 func (v *Validator) validateChannel(info ImportFileInfo, line LineImportData) (err error) {
-	ive := validateNotNil(info, "channel", line.Channel, func(data ChannelImportData) *ImportValidationError {
+	ivErr := validateNotNil(info, "channel", line.Channel, func(data ChannelImportData) *ImportValidationError {
 		appErr := validateChannelImportData(&data)
 		if appErr != nil {
 			return &ImportValidationError{
@@ -509,15 +509,15 @@ func (v *Validator) validateChannel(info ImportFileInfo, line LineImportData) (e
 
 		return nil
 	})
-	if ive != nil {
-		return v.onError(ive)
+	if ivErr != nil {
+		return v.onError(ivErr)
 	}
 
 	return nil
 }
 
 func (v *Validator) validateUser(info ImportFileInfo, line LineImportData) (err error) {
-	ive := validateNotNil(info, "user", line.User, func(data UserImportData) *ImportValidationError {
+	ivErr := validateNotNil(info, "user", line.User, func(data UserImportData) *ImportValidationError {
 		appErr := validateUserImportData(&data)
 		if appErr != nil {
 			return &ImportValidationError{
@@ -551,15 +551,15 @@ func (v *Validator) validateUser(info ImportFileInfo, line LineImportData) (err 
 
 		return nil
 	})
-	if ive != nil {
-		return v.onError(ive)
+	if ivErr != nil {
+		return v.onError(ivErr)
 	}
 
 	return nil
 }
 
 func (v *Validator) validatePost(info ImportFileInfo, line LineImportData) (err error) {
-	ive := validateNotNil(info, "post", line.Post, func(data PostImportData) *ImportValidationError {
+	ivErr := validateNotNil(info, "post", line.Post, func(data PostImportData) *ImportValidationError {
 		appErr := validatePostImportData(&data, model.PostMessageMaxRunesV1)
 		if appErr != nil {
 			return &ImportValidationError{
@@ -599,8 +599,8 @@ func (v *Validator) validatePost(info ImportFileInfo, line LineImportData) (err 
 
 		return nil
 	})
-	if ive != nil {
-		if err = v.onError(ive); err != nil {
+	if ivErr != nil {
+		if err = v.onError(ivErr); err != nil {
 			return err
 		}
 	}
@@ -639,7 +639,7 @@ func (v *Validator) validatePost(info ImportFileInfo, line LineImportData) (err 
 }
 
 func (v *Validator) validateDirectChannel(info ImportFileInfo, line LineImportData) (err error) {
-	ive := validateNotNil(info, "direct_channel", line.DirectChannel, func(data DirectChannelImportData) *ImportValidationError {
+	ivErr := validateNotNil(info, "direct_channel", line.DirectChannel, func(data DirectChannelImportData) *ImportValidationError {
 		appErr := validateDirectChannelImportData(&data)
 		if appErr != nil {
 			return &ImportValidationError{
@@ -675,8 +675,8 @@ func (v *Validator) validateDirectChannel(info ImportFileInfo, line LineImportDa
 
 		return nil
 	})
-	if ive != nil {
-		if err = v.onError(ive); err != nil {
+	if ivErr != nil {
+		if err = v.onError(ivErr); err != nil {
 			return err
 		}
 	}
@@ -687,7 +687,7 @@ func (v *Validator) validateDirectChannel(info ImportFileInfo, line LineImportDa
 }
 
 func (v *Validator) validateDirectPost(info ImportFileInfo, line LineImportData) (err error) {
-	ive := validateNotNil(info, "direct_post", line.DirectPost, func(data DirectPostImportData) *ImportValidationError {
+	ivErr := validateNotNil(info, "direct_post", line.DirectPost, func(data DirectPostImportData) *ImportValidationError {
 		appErr := validateDirectPostImportData(&data, model.PostMessageMaxRunesV1)
 		if appErr != nil {
 			return &ImportValidationError{
@@ -709,8 +709,8 @@ func (v *Validator) validateDirectPost(info ImportFileInfo, line LineImportData)
 
 		return nil
 	})
-	if ive != nil {
-		if err = v.onError(ive); err != nil {
+	if ivErr != nil {
+		if err = v.onError(ivErr); err != nil {
 			return err
 		}
 	}
@@ -763,7 +763,7 @@ func (v *Validator) validateDirectPost(info ImportFileInfo, line LineImportData)
 }
 
 func (v *Validator) validateEmoji(info ImportFileInfo, line LineImportData) (err error) {
-	ive := validateNotNil(info, "emoji", line.Emoji, func(data EmojiImportData) *ImportValidationError {
+	ivErr := validateNotNil(info, "emoji", line.Emoji, func(data EmojiImportData) *ImportValidationError {
 		appErr := validateEmojiImportData(&data)
 		if appErr != nil {
 			return &ImportValidationError{
@@ -807,8 +807,8 @@ func (v *Validator) validateEmoji(info ImportFileInfo, line LineImportData) (err
 
 		return nil
 	})
-	if ive != nil {
-		return v.onError(ive)
+	if ivErr != nil {
+		return v.onError(ivErr)
 	}
 
 	return nil

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -290,10 +290,20 @@ func (v *Validator) validateLines(info ImportFileInfo, zf *zip.File) error {
 			return err
 		}
 
-		if info.LineNumber%10000 == 0 {
-			fmt.Printf("Progress: %d/%d (%.2f%%)\n", info.LineNumber, info.TotalLines, float64(info.LineNumber)*100/float64(info.TotalLines))
+		if info.LineNumber%1024 == 0 {
+			fmt.Printf("Progress: %d/%d (%.2f%%)\r", info.LineNumber, info.TotalLines, float64(info.LineNumber)*100/float64(info.TotalLines))
 		}
 	}
+	if err = s.Err(); err != nil {
+		if err = v.onError(&ImportValidationError{
+			ImportFileInfo: info,
+			Err:            err,
+		}); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Progress: %d/%d (100.00%%)\n", info.TotalLines, info.TotalLines)
 
 	return nil
 }

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package importer
 
 import (

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -34,7 +34,7 @@ type ChannelTeam struct {
 	Team    string
 }
 
-type Validator struct {
+type Validator struct { //nolint:govet
 	archiveName       string
 	onError           func(*ImportValidationError) error
 	ignoreAttachments bool

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -60,10 +60,11 @@ type Validator struct { //nolint:govet
 	lines uint64
 }
 
-func NewValidator(name string) *Validator {
+func NewValidator(name string, ignoreAttachments bool) *Validator {
 	return &Validator{
-		archiveName: name,
-		onError:     func(ive *ImportValidationError) error { return ive },
+		archiveName:       name,
+		onError:           func(ive *ImportValidationError) error { return ive },
+		ignoreAttachments: ignoreAttachments,
 
 		attachments:     make(map[string]*zip.File),
 		attachmentsUsed: make(map[string]uint64),
@@ -74,10 +75,6 @@ func NewValidator(name string) *Validator {
 		users:    map[string]ImportFileInfo{},
 		emojis:   map[string]ImportFileInfo{},
 	}
-}
-
-func (v *Validator) IgnoreAttachments(ia bool) {
-	v.ignoreAttachments = ia
 }
 
 func (v *Validator) Schemes() []string {

--- a/commands/importer/validate.go
+++ b/commands/importer/validate.go
@@ -25,9 +25,9 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/mattermost/mattermost-server/v6/model"
 	_ "golang.org/x/image/webp" // image decoder
 
-	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mmctl/v6/printer"
 )
 

--- a/commands/importer/validators.go
+++ b/commands/importer/validators.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package importer
 
 import (

--- a/commands/importer/validators.go
+++ b/commands/importer/validators.go
@@ -1,0 +1,609 @@
+package importer
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+)
+
+func validateSchemeImportData(data *SchemeImportData) *model.AppError {
+
+	if data.Scope == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_scheme_import_data.null_scope.error", nil, "", http.StatusBadRequest)
+	}
+
+	switch *data.Scope {
+	case model.SchemeScopeTeam:
+		if data.DefaultTeamAdminRole == nil || data.DefaultTeamUserRole == nil || data.DefaultChannelAdminRole == nil || data.DefaultChannelUserRole == nil {
+			return model.NewAppError("BulkImport", "app.import.validate_scheme_import_data.wrong_roles_for_scope.error", nil, "", http.StatusBadRequest)
+		}
+	case model.SchemeScopeChannel:
+		if data.DefaultTeamAdminRole != nil || data.DefaultTeamUserRole != nil || data.DefaultChannelAdminRole == nil || data.DefaultChannelUserRole == nil {
+			return model.NewAppError("BulkImport", "app.import.validate_scheme_import_data.wrong_roles_for_scope.error", nil, "", http.StatusBadRequest)
+		}
+	default:
+		return model.NewAppError("BulkImport", "app.import.validate_scheme_import_data.unknown_scheme.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Name == nil || !model.IsValidSchemeName(*data.Name) {
+		return model.NewAppError("BulkImport", "app.import.validate_scheme_import_data.name_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.DisplayName == nil || *data.DisplayName == "" || len(*data.DisplayName) > model.SchemeDisplayNameMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_scheme_import_data.display_name_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Description != nil && len(*data.Description) > model.SchemeDescriptionMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_scheme_import_data.description_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.DefaultTeamAdminRole != nil {
+		if err := validateRoleImportData(data.DefaultTeamAdminRole); err != nil {
+			return err
+		}
+	}
+
+	if data.DefaultTeamUserRole != nil {
+		if err := validateRoleImportData(data.DefaultTeamUserRole); err != nil {
+			return err
+		}
+	}
+
+	if data.DefaultTeamGuestRole != nil {
+		if err := validateRoleImportData(data.DefaultTeamGuestRole); err != nil {
+			return err
+		}
+	}
+
+	if data.DefaultChannelAdminRole != nil {
+		if err := validateRoleImportData(data.DefaultChannelAdminRole); err != nil {
+			return err
+		}
+	}
+
+	if data.DefaultChannelUserRole != nil {
+		if err := validateRoleImportData(data.DefaultChannelUserRole); err != nil {
+			return err
+		}
+	}
+
+	if data.DefaultChannelGuestRole != nil {
+		if err := validateRoleImportData(data.DefaultChannelGuestRole); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateRoleImportData(data *RoleImportData) *model.AppError {
+
+	if data.Name == nil || !model.IsValidRoleName(*data.Name) {
+		return model.NewAppError("BulkImport", "app.import.validate_role_import_data.name_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.DisplayName == nil || *data.DisplayName == "" || len(*data.DisplayName) > model.RoleDisplayNameMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_role_import_data.display_name_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Description != nil && len(*data.Description) > model.RoleDescriptionMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_role_import_data.description_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Permissions != nil {
+		for _, permission := range *data.Permissions {
+			permissionValidated := false
+			for _, p := range append(model.AllPermissions, model.DeprecatedPermissions...) {
+				if permission == p.Id {
+					permissionValidated = true
+					break
+				}
+			}
+
+			if !permissionValidated {
+				return model.NewAppError("BulkImport", "app.import.validate_role_import_data.invalid_permission.error", nil, "permission"+permission, http.StatusBadRequest)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateTeamImportData(data *TeamImportData) *model.AppError {
+
+	if data.Name == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.name_missing.error", nil, "", http.StatusBadRequest)
+	} else if len(*data.Name) > model.TeamNameMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.name_length.error", nil, "", http.StatusBadRequest)
+	} else if model.IsReservedTeamName(*data.Name) {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.name_reserved.error", nil, "", http.StatusBadRequest)
+	} else if !model.IsValidTeamName(*data.Name) {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.name_characters.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.DisplayName == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.display_name_missing.error", nil, "", http.StatusBadRequest)
+	} else if utf8.RuneCountInString(*data.DisplayName) == 0 || utf8.RuneCountInString(*data.DisplayName) > model.TeamDisplayNameMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.display_name_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Type == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.type_missing.error", nil, "", http.StatusBadRequest)
+	} else if *data.Type != model.TeamOpen && *data.Type != model.TeamInvite {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.type_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Description != nil && len(*data.Description) > model.TeamDescriptionMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.description_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Scheme != nil && !model.IsValidSchemeName(*data.Scheme) {
+		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.scheme_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	return nil
+}
+
+func validateChannelImportData(data *ChannelImportData) *model.AppError {
+
+	if data.Team == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.team_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Name == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.name_missing.error", nil, "", http.StatusBadRequest)
+	} else if len(*data.Name) > model.ChannelNameMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.name_length.error", nil, "", http.StatusBadRequest)
+	} else if !model.IsValidChannelIdentifier(*data.Name) {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.name_characters.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.DisplayName == nil || utf8.RuneCountInString(*data.DisplayName) == 0 {
+		data.DisplayName = data.Name // when displayName is missing we use name instead for displaying so we might as well convert it here.
+	} else if utf8.RuneCountInString(*data.DisplayName) > model.ChannelDisplayNameMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.display_name_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Type == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.type_missing.error", nil, "", http.StatusBadRequest)
+	} else if *data.Type != model.ChannelTypeOpen && *data.Type != model.ChannelTypePrivate {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.type_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Header != nil && utf8.RuneCountInString(*data.Header) > model.ChannelHeaderMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.header_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Purpose != nil && utf8.RuneCountInString(*data.Purpose) > model.ChannelPurposeMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.purpose_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Scheme != nil && !model.IsValidSchemeName(*data.Scheme) {
+		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.scheme_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	return nil
+}
+
+func validateUserImportData(data *UserImportData) *model.AppError {
+	if data.ProfileImage != nil {
+		if _, err := os.Stat(*data.ProfileImage); os.IsNotExist(err) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.profile_image.error", nil, "", http.StatusBadRequest)
+		}
+	}
+
+	if data.Username == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.username_missing.error", nil, "", http.StatusBadRequest)
+	} else if !model.IsValidUsername(*data.Username) {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.username_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Email == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.email_missing.error", nil, "", http.StatusBadRequest)
+	} else if *data.Email == "" || len(*data.Email) > model.UserEmailMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.email_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.AuthData != nil && data.Password != nil {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.auth_data_and_password.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.AuthData != nil && len(*data.AuthData) > model.UserAuthDataMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.auth_data_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	blank := func(str *string) bool {
+		if str == nil {
+			return true
+		}
+		return *str == ""
+	}
+
+	if (!blank(data.AuthService) && blank(data.AuthData)) || (blank(data.AuthService) && !blank(data.AuthData)) {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.auth_data_and_service_dependency.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Password != nil && *data.Password == "" {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.password_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Password != nil && len(*data.Password) > model.UserPasswordMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.password_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Nickname != nil && utf8.RuneCountInString(*data.Nickname) > model.UserNicknameMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.nickname_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.FirstName != nil && utf8.RuneCountInString(*data.FirstName) > model.UserFirstNameMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.first_name_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.LastName != nil && utf8.RuneCountInString(*data.LastName) > model.UserLastNameMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.last_name_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Position != nil && utf8.RuneCountInString(*data.Position) > model.UserPositionMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.position_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Roles != nil && !model.IsValidUserRoles(*data.Roles) {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.roles_invalid.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.NotifyProps != nil {
+		if data.NotifyProps.Desktop != nil && !isValidUserNotifyLevel(*data.NotifyProps.Desktop) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.notify_props_desktop_invalid.error", nil, "", http.StatusBadRequest)
+		}
+
+		if data.NotifyProps.DesktopSound != nil && !isValidTrueOrFalseString(*data.NotifyProps.DesktopSound) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.notify_props_desktop_sound_invalid.error", nil, "", http.StatusBadRequest)
+		}
+
+		if data.NotifyProps.Email != nil && !isValidTrueOrFalseString(*data.NotifyProps.Email) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.notify_props_email_invalid.error", nil, "", http.StatusBadRequest)
+		}
+
+		if data.NotifyProps.Mobile != nil && !isValidUserNotifyLevel(*data.NotifyProps.Mobile) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.notify_props_mobile_invalid.error", nil, "", http.StatusBadRequest)
+		}
+
+		if data.NotifyProps.MobilePushStatus != nil && !isValidPushStatusNotifyLevel(*data.NotifyProps.MobilePushStatus) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.notify_props_mobile_push_status_invalid.error", nil, "", http.StatusBadRequest)
+		}
+
+		if data.NotifyProps.ChannelTrigger != nil && !isValidTrueOrFalseString(*data.NotifyProps.ChannelTrigger) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.notify_props_channel_trigger_invalid.error", nil, "", http.StatusBadRequest)
+		}
+
+		if data.NotifyProps.CommentsTrigger != nil && !isValidCommentsNotifyLevel(*data.NotifyProps.CommentsTrigger) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.notify_props_comments_trigger_invalid.error", nil, "", http.StatusBadRequest)
+		}
+	}
+
+	if data.UseMarkdownPreview != nil && !isValidTrueOrFalseString(*data.UseMarkdownPreview) {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.advanced_props_feature_markdown_preview.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.UseFormatting != nil && !isValidTrueOrFalseString(*data.UseFormatting) {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.advanced_props_formatting.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.ShowUnreadSection != nil && !isValidTrueOrFalseString(*data.ShowUnreadSection) {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.advanced_props_show_unread_section.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.EmailInterval != nil && !isValidEmailBatchingInterval(*data.EmailInterval) {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.advanced_props_email_interval.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Teams != nil {
+		return validateUserTeamsImportData(data.Teams)
+	}
+
+	return nil
+}
+
+func validateUserTeamsImportData(data *[]UserTeamImportData) *model.AppError {
+	if data == nil {
+		return nil
+	}
+
+	for _, tdata := range *data {
+		if tdata.Name == nil {
+			return model.NewAppError("BulkImport", "app.import.validate_user_teams_import_data.team_name_missing.error", nil, "", http.StatusBadRequest)
+		}
+
+		if tdata.Roles != nil && !model.IsValidUserRoles(*tdata.Roles) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_teams_import_data.invalid_roles.error", nil, "", http.StatusBadRequest)
+		}
+
+		if tdata.Channels != nil {
+			if err := validateUserChannelsImportData(tdata.Channels); err != nil {
+				return err
+			}
+		}
+
+		if tdata.Theme != nil && strings.Trim(*tdata.Theme, " \t\r") != "" {
+			var unused map[string]string
+			if err := json.NewDecoder(strings.NewReader(*tdata.Theme)).Decode(&unused); err != nil {
+				return model.NewAppError("BulkImport", "app.import.validate_user_teams_import_data.invalid_team_theme.error", nil, "", http.StatusBadRequest)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateUserChannelsImportData(data *[]UserChannelImportData) *model.AppError {
+	if data == nil {
+		return nil
+	}
+
+	for _, cdata := range *data {
+		if cdata.Name == nil {
+			return model.NewAppError("BulkImport", "app.import.validate_user_channels_import_data.channel_name_missing.error", nil, "", http.StatusBadRequest)
+		}
+
+		if cdata.Roles != nil && !model.IsValidUserRoles(*cdata.Roles) {
+			return model.NewAppError("BulkImport", "app.import.validate_user_channels_import_data.invalid_roles.error", nil, "", http.StatusBadRequest)
+		}
+
+		if cdata.NotifyProps != nil {
+			if cdata.NotifyProps.Desktop != nil && !model.IsChannelNotifyLevelValid(*cdata.NotifyProps.Desktop) {
+				return model.NewAppError("BulkImport", "app.import.validate_user_channels_import_data.invalid_notify_props_desktop.error", nil, "", http.StatusBadRequest)
+			}
+
+			if cdata.NotifyProps.Mobile != nil && !model.IsChannelNotifyLevelValid(*cdata.NotifyProps.Mobile) {
+				return model.NewAppError("BulkImport", "app.import.validate_user_channels_import_data.invalid_notify_props_mobile.error", nil, "", http.StatusBadRequest)
+			}
+
+			if cdata.NotifyProps.MarkUnread != nil && !model.IsChannelMarkUnreadLevelValid(*cdata.NotifyProps.MarkUnread) {
+				return model.NewAppError("BulkImport", "app.import.validate_user_channels_import_data.invalid_notify_props_mark_unread.error", nil, "", http.StatusBadRequest)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateReactionImportData(data *ReactionImportData, parentCreateAt int64) *model.AppError {
+	if data.User == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.user_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.EmojiName == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.emoji_name_missing.error", nil, "", http.StatusBadRequest)
+	} else if utf8.RuneCountInString(*data.EmojiName) > model.EmojiNameMaxLength {
+		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.emoji_name_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.CreateAt == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.create_at_missing.error", nil, "", http.StatusBadRequest)
+	} else if *data.CreateAt == 0 {
+		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.create_at_zero.error", nil, "", http.StatusBadRequest)
+	} else if *data.CreateAt < parentCreateAt {
+		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.create_at_before_parent.error", nil, "", http.StatusBadRequest)
+	}
+
+	return nil
+}
+
+func validateReplyImportData(data *ReplyImportData, parentCreateAt int64, maxPostSize int) *model.AppError {
+	if data.User == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_reply_import_data.user_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Message == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_reply_import_data.message_missing.error", nil, "", http.StatusBadRequest)
+	} else if utf8.RuneCountInString(*data.Message) > maxPostSize {
+		return model.NewAppError("BulkImport", "app.import.validate_reply_import_data.message_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.CreateAt == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_reply_import_data.create_at_missing.error", nil, "", http.StatusBadRequest)
+	} else if *data.CreateAt == 0 {
+		return model.NewAppError("BulkImport", "app.import.validate_reply_import_data.create_at_zero.error", nil, "", http.StatusBadRequest)
+	} else if *data.CreateAt < parentCreateAt {
+		mlog.Warn("Reply CreateAt is before parent post CreateAt", mlog.Int64("reply_create_at", *data.CreateAt), mlog.Int64("parent_create_at", parentCreateAt))
+	}
+
+	return nil
+}
+
+func validatePostImportData(data *PostImportData, maxPostSize int) *model.AppError {
+	if data.Team == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.team_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Channel == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.channel_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.User == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.user_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Message == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.message_missing.error", nil, "", http.StatusBadRequest)
+	} else if utf8.RuneCountInString(*data.Message) > maxPostSize {
+		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.message_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.CreateAt == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.create_at_missing.error", nil, "", http.StatusBadRequest)
+	} else if *data.CreateAt == 0 {
+		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.create_at_zero.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Reactions != nil {
+		for _, reaction := range *data.Reactions {
+			reaction := reaction
+			validateReactionImportData(&reaction, *data.CreateAt)
+		}
+	}
+
+	if data.Replies != nil {
+		for _, reply := range *data.Replies {
+			reply := reply
+			validateReplyImportData(&reply, *data.CreateAt, maxPostSize)
+		}
+	}
+
+	if data.Props != nil && utf8.RuneCountInString(model.StringInterfaceToJSON(*data.Props)) > model.PostPropsMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.props_too_large.error", nil, "", http.StatusBadRequest)
+	}
+
+	return nil
+}
+
+func validateDirectChannelImportData(data *DirectChannelImportData) *model.AppError {
+	if data.Members == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_direct_channel_import_data.members_required.error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(*data.Members) != 2 {
+		if len(*data.Members) < model.ChannelGroupMinUsers {
+			return model.NewAppError("BulkImport", "app.import.validate_direct_channel_import_data.members_too_few.error", nil, "", http.StatusBadRequest)
+		} else if len(*data.Members) > model.ChannelGroupMaxUsers {
+			return model.NewAppError("BulkImport", "app.import.validate_direct_channel_import_data.members_too_many.error", nil, "", http.StatusBadRequest)
+		}
+	}
+
+	if data.Header != nil && utf8.RuneCountInString(*data.Header) > model.ChannelHeaderMaxRunes {
+		return model.NewAppError("BulkImport", "app.import.validate_direct_channel_import_data.header_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.FavoritedBy != nil {
+		for _, favoriter := range *data.FavoritedBy {
+			found := false
+			for _, member := range *data.Members {
+				if favoriter == member {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return model.NewAppError("BulkImport", "app.import.validate_direct_channel_import_data.unknown_favoriter.error", map[string]any{"Username": favoriter}, "", http.StatusBadRequest)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateDirectPostImportData(data *DirectPostImportData, maxPostSize int) *model.AppError {
+	if data.ChannelMembers == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.channel_members_required.error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(*data.ChannelMembers) != 2 {
+		if len(*data.ChannelMembers) < model.ChannelGroupMinUsers {
+			return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.channel_members_too_few.error", nil, "", http.StatusBadRequest)
+		} else if len(*data.ChannelMembers) > model.ChannelGroupMaxUsers {
+			return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.channel_members_too_many.error", nil, "", http.StatusBadRequest)
+		}
+	}
+
+	if data.User == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.user_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Message == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.message_missing.error", nil, "", http.StatusBadRequest)
+	} else if utf8.RuneCountInString(*data.Message) > maxPostSize {
+		return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.message_length.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.CreateAt == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.create_at_missing.error", nil, "", http.StatusBadRequest)
+	} else if *data.CreateAt == 0 {
+		return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.create_at_zero.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.FlaggedBy != nil {
+		for _, flagger := range *data.FlaggedBy {
+			found := false
+			for _, member := range *data.ChannelMembers {
+				if flagger == member {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.unknown_flagger.error", map[string]any{"Username": flagger}, "", http.StatusBadRequest)
+			}
+		}
+	}
+
+	if data.Reactions != nil {
+		for _, reaction := range *data.Reactions {
+			reaction := reaction
+			validateReactionImportData(&reaction, *data.CreateAt)
+		}
+	}
+
+	if data.Replies != nil {
+		for _, reply := range *data.Replies {
+			reply := reply
+			validateReplyImportData(&reply, *data.CreateAt, maxPostSize)
+		}
+	}
+
+	return nil
+}
+
+// validateEmojiImportData validates emoji data and returns if the import name
+// conflicts with a system emoji.
+func validateEmojiImportData(data *EmojiImportData) *model.AppError {
+	if data == nil {
+		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.empty.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Name == nil || *data.Name == "" {
+		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.name_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if data.Image == nil || *data.Image == "" {
+		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.image_missing.error", nil, "", http.StatusBadRequest)
+	}
+
+	if err := model.IsValidEmojiName(*data.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isValidTrueOrFalseString(value string) bool {
+	return value == "true" || value == "false"
+}
+
+func isValidUserNotifyLevel(notifyLevel string) bool {
+	return notifyLevel == model.ChannelNotifyAll ||
+		notifyLevel == model.ChannelNotifyMention ||
+		notifyLevel == model.ChannelNotifyNone
+}
+
+func isValidPushStatusNotifyLevel(notifyLevel string) bool {
+	return notifyLevel == model.StatusOnline ||
+		notifyLevel == model.StatusAway ||
+		notifyLevel == model.StatusOffline
+}
+
+func isValidCommentsNotifyLevel(notifyLevel string) bool {
+	return notifyLevel == model.CommentsNotifyAny ||
+		notifyLevel == model.CommentsNotifyRoot ||
+		notifyLevel == model.CommentsNotifyNever
+}
+
+func isValidEmailBatchingInterval(emailInterval string) bool {
+	return emailInterval == model.PreferenceEmailIntervalImmediately ||
+		emailInterval == model.PreferenceEmailIntervalFifteen ||
+		emailInterval == model.PreferenceEmailIntervalHour
+}

--- a/docs/mmctl_import_validate.rst
+++ b/docs/mmctl_import_validate.rst
@@ -29,7 +29,7 @@ Options
 
   -h, --help                 help for validate
       --ignore-attachments   Don't check if the attached files are present in the archive
-      --team stringArray     The names of the team[s] (flag can be repeated)
+      --team stringArray     The names of the team[s]. The flag can be repeated. Omit this flag to disable the check
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/mmctl_import_validate.rst
+++ b/docs/mmctl_import_validate.rst
@@ -27,9 +27,10 @@ Options
 
 ::
 
-  -h, --help                 help for validate
-      --ignore-attachments   Don't check if the attached files are present in the archive
-      --team stringArray     The names of the team[s]. The flag can be repeated. Omit this flag to disable the check
+      --check-missing-teams   Check for teams that are not defined but referenced in the archive
+  -h, --help                  help for validate
+      --ignore-attachments    Don't check if the attached files are present in the archive
+      --team stringArray      Predefined team[s] to assume as already present on the destination server. Implies --check-missing-teams. The flag can be repeated
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/mmctl_import_validate.rst
+++ b/docs/mmctl_import_validate.rst
@@ -29,7 +29,7 @@ Options
 
   -h, --help                 help for validate
       --ignore-attachments   Don't check if the attached files are present in the archive
-      --team stringArray     Predefined teams
+      --team stringArray     The names of the team[s] (flag can be repeated)
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/mmctl_import_validate.rst
+++ b/docs/mmctl_import_validate.rst
@@ -1,22 +1,35 @@
-.. _mmctl_import:
+.. _mmctl_import_validate:
 
-mmctl import
-------------
+mmctl import validate
+---------------------
 
-Management of imports
+Validate an import file
 
 Synopsis
 ~~~~~~~~
 
 
-Management of imports
+Validate an import file
+
+::
+
+  mmctl import validate [filepath] [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    import validate import_file.zip --team myteam --team myotherteam
 
 Options
 ~~~~~~~
 
 ::
 
-  -h, --help   help for import
+  -h, --help                 help for validate
+      --ignore-attachments   Don't check if the attached files are present in the archive
+      --team stringArray     Predefined teams
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -36,10 +49,5 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
-* `mmctl import job <mmctl_import_job.rst>`_ 	 - List and show import jobs
-* `mmctl import list <mmctl_import_list.rst>`_ 	 - List import files
-* `mmctl import process <mmctl_import_process.rst>`_ 	 - Start an import job
-* `mmctl import upload <mmctl_import_upload.rst>`_ 	 - Upload import files
-* `mmctl import validate <mmctl_import_validate.rst>`_ 	 - Validate an import file
+* `mmctl import <mmctl_import.rst>`_ 	 - Management of imports
 

--- a/go.mod
+++ b/go.mod
@@ -15,16 +15,15 @@ require (
 	github.com/magefile/mage v1.13.0
 	github.com/mattermost/gosaml2 v0.8.0
 	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d
-	github.com/mattermost/mattermost-server/v6 v6.6.1
+	github.com/mattermost/mattermost-server/v6 v6.0.0-20220721093312-c597ae719ae0
 	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.7.2
 	github.com/tylerb/graceful v1.2.15
-	golang.org/x/image v0.0.0-20220413100746-70e8d0d3baa9
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
 	gopkg.in/olivere/elastic.v6 v6.2.37
 )
@@ -32,7 +31,6 @@ require (
 require (
 	code.sajari.com/docconv v1.2.0 // indirect
 	github.com/JalfResi/justext v0.0.0-20170829062021-c0282dea7198 // indirect
-	github.com/Masterminds/squirrel v1.5.2 // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/fatih/color v1.13.0
 	github.com/golang/mock v1.6.0
@@ -85,10 +83,10 @@ require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blevesearch/bleve/v2 v2.3.2 // indirect
-	github.com/blevesearch/bleve_index_api v1.0.1 // indirect
+	github.com/blevesearch/bleve_index_api v1.0.2 // indirect
 	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
 	github.com/blevesearch/gtreap v0.1.1 // indirect
-	github.com/blevesearch/mmap-go v1.0.3 // indirect
+	github.com/blevesearch/mmap-go v1.0.4 // indirect
 	github.com/blevesearch/scorch_segment_api/v2 v2.1.0 // indirect
 	github.com/blevesearch/segment v0.9.0 // indirect
 	github.com/blevesearch/snowballstem v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,36 @@ require (
 	github.com/magefile/mage v1.13.0
 	github.com/mattermost/gosaml2 v0.8.0
 	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d
+	github.com/mattermost/mattermost-server/v6 v6.6.1
+	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
+	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.12.2
+	github.com/sirupsen/logrus v1.8.1
+	github.com/spf13/cobra v1.4.0
+	github.com/spf13/viper v1.11.0
+	github.com/stretchr/testify v1.7.1
+	github.com/tylerb/graceful v1.2.15
+	golang.org/x/image v0.0.0-20220413100746-70e8d0d3baa9
+	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
+	gopkg.in/olivere/elastic.v6 v6.2.37
+)
+
+require (
+	code.sajari.com/docconv v1.2.0 // indirect
+	github.com/JalfResi/justext v0.0.0-20170829062021-c0282dea7198 // indirect
+	github.com/Masterminds/squirrel v1.5.2 // indirect
+	github.com/PuerkitoBio/goquery v1.8.0 // indirect
+	github.com/fatih/color v1.13.0
+	github.com/golang/mock v1.6.0
+	github.com/gorilla/handlers v1.5.1
+	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
+	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/memberlist v0.3.1
+	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428
+	github.com/isacikgoz/prompt v0.1.0
+	github.com/magefile/mage v1.13.0
+	github.com/mattermost/gosaml2 v0.8.0
+	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d
 	github.com/mattermost/mattermost-server/v6 v6.0.0-20220721093312-c597ae719ae0
 	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
 	github.com/pkg/errors v0.9.1
@@ -37,15 +67,39 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
+	github.com/advancedlogic/GoOse v0.0.0-20210820140952-9d5822d4a625 // indirect
+	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/andybalholm/cascadia v1.3.1 // indirect
+	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/armon/go-metrics v0.3.11 // indirect
+	github.com/avct/uasurfer v0.0.0-20191028135549-26b5daa857f1 // indirect
 	github.com/avct/uasurfer v0.0.0-20191028135549-26b5daa857f1 // indirect
 	github.com/aws/aws-sdk-go v1.44.34 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/beevik/etree v1.1.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.2.2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blevesearch/bleve/v2 v2.3.2 // indirect
+	github.com/blevesearch/bleve_index_api v1.0.1 // indirect
+	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
+	github.com/blevesearch/gtreap v0.1.1 // indirect
+	github.com/blevesearch/mmap-go v1.0.3 // indirect
+	github.com/blevesearch/scorch_segment_api/v2 v2.1.0 // indirect
+	github.com/blevesearch/segment v0.9.0 // indirect
+	github.com/blevesearch/snowballstem v0.9.0 // indirect
+	github.com/blevesearch/upsidedown_store_api v1.0.1 // indirect
+	github.com/blevesearch/vellum v1.0.7 // indirect
+	github.com/blevesearch/zapx/v11 v11.3.3 // indirect
+	github.com/blevesearch/zapx/v12 v12.3.3 // indirect
+	github.com/blevesearch/zapx/v13 v13.3.3 // indirect
+	github.com/blevesearch/zapx/v14 v14.3.3 // indirect
+	github.com/blevesearch/zapx/v15 v15.3.3 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/blevesearch/bleve_index_api v1.0.2 // indirect
 	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
 	github.com/blevesearch/gtreap v0.1.1 // indirect
@@ -73,13 +127,17 @@ require (
 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09 // indirect
 	github.com/fatih/set v0.2.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fortytw2/leaktest v1.3.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/getsentry/sentry-go v0.13.0 // indirect
 	github.com/gigawattio/window v0.0.0-20180317192513-0f5467e35573 // indirect
+	github.com/gigawattio/window v0.0.0-20180317192513-0f5467e35573 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
+	github.com/go-resty/resty/v2 v2.7.0 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/golang-migrate/migrate/v4 v4.15.2 // indirect
@@ -113,8 +171,13 @@ require (
 	github.com/jonboulle/clockwork v0.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.15.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.13 // indirect
+	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
@@ -137,7 +200,11 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.18 // indirect
 	github.com/miekg/dns v1.1.49 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
+	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.28 // indirect
+	github.com/minio/sha256-simd v1.0.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
@@ -145,7 +212,17 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
+	github.com/oklog/run v1.1.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/olivere/elastic v6.2.37+incompatible // indirect
+	github.com/oov/psd v0.0.0-20220121172623-5db5eafcecbb // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/otiai10/gosseract/v2 v2.3.1 // indirect
+	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/olivere/elastic v6.2.37+incompatible // indirect
@@ -163,7 +240,12 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/reflog/dateconstraints v0.2.1 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/reflog/dateconstraints v0.2.1 // indirect
+	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.3 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rs/cors v1.8.2 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/xid v1.4.0 // indirect
@@ -180,6 +262,7 @@ require (
 	github.com/splitio/go-client/v6 v6.1.3 // indirect
 	github.com/splitio/go-split-commons/v4 v4.0.4 // indirect
 	github.com/splitio/go-toolkit/v5 v5.1.0 // indirect
+	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.2
 	github.com/tylerb/graceful v1.2.15
+	golang.org/x/image v0.0.0-20220601225756-64ec528b34cd
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
 	gopkg.in/olivere/elastic.v6 v6.2.37
 )
@@ -32,72 +33,23 @@ require (
 	code.sajari.com/docconv v1.2.0 // indirect
 	github.com/JalfResi/justext v0.0.0-20170829062021-c0282dea7198 // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
-	github.com/fatih/color v1.13.0
-	github.com/golang/mock v1.6.0
-	github.com/gorilla/handlers v1.5.1
-	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
-	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/memberlist v0.3.1
-	github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428
-	github.com/isacikgoz/prompt v0.1.0
-	github.com/magefile/mage v1.13.0
-	github.com/mattermost/gosaml2 v0.8.0
-	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d
-	github.com/mattermost/mattermost-server/v6 v6.0.0-20220721093312-c597ae719ae0
-	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
-	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.12.2
-	github.com/sirupsen/logrus v1.8.1
-	github.com/spf13/cobra v1.4.0
-	github.com/spf13/viper v1.11.0
-	github.com/stretchr/testify v1.7.2
-	github.com/tylerb/graceful v1.2.15
-	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171
-	gopkg.in/olivere/elastic.v6 v6.2.37
 )
 
 require (
-	code.sajari.com/docconv v1.2.0 // indirect
-	github.com/JalfResi/justext v0.0.0-20170829062021-c0282dea7198 // indirect
-	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/RoaringBitmap/roaring v1.2.1 // indirect
-	github.com/advancedlogic/GoOse v0.0.0-20210820140952-9d5822d4a625 // indirect
-	github.com/andybalholm/brotli v1.0.4 // indirect
-	github.com/andybalholm/cascadia v1.3.1 // indirect
-	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/advancedlogic/GoOse v0.0.0-20210820140952-9d5822d4a625 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/armon/go-metrics v0.3.11 // indirect
 	github.com/avct/uasurfer v0.0.0-20191028135549-26b5daa857f1 // indirect
-	github.com/avct/uasurfer v0.0.0-20191028135549-26b5daa857f1 // indirect
 	github.com/aws/aws-sdk-go v1.44.34 // indirect
-	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/beevik/etree v1.1.0 // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.2.2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blevesearch/bleve/v2 v2.3.2 // indirect
-	github.com/blevesearch/bleve_index_api v1.0.2 // indirect
-	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
-	github.com/blevesearch/gtreap v0.1.1 // indirect
-	github.com/blevesearch/mmap-go v1.0.4 // indirect
-	github.com/blevesearch/scorch_segment_api/v2 v2.1.0 // indirect
-	github.com/blevesearch/segment v0.9.0 // indirect
-	github.com/blevesearch/snowballstem v0.9.0 // indirect
-	github.com/blevesearch/upsidedown_store_api v1.0.1 // indirect
-	github.com/blevesearch/vellum v1.0.7 // indirect
-	github.com/blevesearch/zapx/v11 v11.3.3 // indirect
-	github.com/blevesearch/zapx/v12 v12.3.3 // indirect
-	github.com/blevesearch/zapx/v13 v13.3.3 // indirect
-	github.com/blevesearch/zapx/v14 v14.3.3 // indirect
-	github.com/blevesearch/zapx/v15 v15.3.3 // indirect
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/blevesearch/bleve_index_api v1.0.2 // indirect
 	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
 	github.com/blevesearch/gtreap v0.1.1 // indirect
@@ -125,17 +77,13 @@ require (
 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09 // indirect
 	github.com/fatih/set v0.2.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
-	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fortytw2/leaktest v1.3.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/getsentry/sentry-go v0.13.0 // indirect
 	github.com/gigawattio/window v0.0.0-20180317192513-0f5467e35573 // indirect
-	github.com/gigawattio/window v0.0.0-20180317192513-0f5467e35573 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
-	github.com/go-resty/resty/v2 v2.7.0 // indirect
-	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/golang-migrate/migrate/v4 v4.15.2 // indirect
@@ -169,13 +117,8 @@ require (
 	github.com/jonboulle/clockwork v0.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.15.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.13 // indirect
-	github.com/klauspost/pgzip v1.2.5 // indirect
-	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
-	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
@@ -198,11 +141,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.18 // indirect
 	github.com/miekg/dns v1.1.49 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
-	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/minio-go/v7 v7.0.28 // indirect
-	github.com/minio/sha256-simd v1.0.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
@@ -210,17 +149,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
-	github.com/oklog/run v1.1.0 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/olivere/elastic v6.2.37+incompatible // indirect
-	github.com/oov/psd v0.0.0-20220121172623-5db5eafcecbb // indirect
-	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/otiai10/gosseract/v2 v2.3.1 // indirect
-	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/olivere/elastic v6.2.37+incompatible // indirect
@@ -238,12 +167,7 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/reflog/dateconstraints v0.2.1 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect
-	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/reflog/dateconstraints v0.2.1 // indirect
-	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.3 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/rs/cors v1.8.2 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/xid v1.4.0 // indirect
@@ -260,7 +184,6 @@ require (
 	github.com/splitio/go-client/v6 v6.1.3 // indirect
 	github.com/splitio/go-split-commons/v4 v4.0.4 // indirect
 	github.com/splitio/go-toolkit/v5 v5.1.0 // indirect
-	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
@@ -282,7 +205,6 @@ require (
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
-	golang.org/x/image v0.0.0-20220601225756-64ec528b34cd // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220614195744-fb05da6f9022 // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -166,15 +166,12 @@ github.com/blevesearch/vellum/utf8
 github.com/blevesearch/zapx/v11
 # github.com/blevesearch/zapx/v12 v12.3.4
 ## explicit; go 1.17
-## explicit; go 1.13
 github.com/blevesearch/zapx/v12
 # github.com/blevesearch/zapx/v13 v13.3.4
 ## explicit; go 1.17
-## explicit; go 1.13
 github.com/blevesearch/zapx/v13
 # github.com/blevesearch/zapx/v14 v14.3.4
 ## explicit; go 1.17
-## explicit; go 1.13
 github.com/blevesearch/zapx/v14
 # github.com/blevesearch/zapx/v15 v15.3.4
 ## explicit; go 1.17

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -166,12 +166,15 @@ github.com/blevesearch/vellum/utf8
 github.com/blevesearch/zapx/v11
 # github.com/blevesearch/zapx/v12 v12.3.4
 ## explicit; go 1.17
+## explicit; go 1.13
 github.com/blevesearch/zapx/v12
 # github.com/blevesearch/zapx/v13 v13.3.4
 ## explicit; go 1.17
+## explicit; go 1.13
 github.com/blevesearch/zapx/v13
 # github.com/blevesearch/zapx/v14 v14.3.4
 ## explicit; go 1.17
+## explicit; go 1.13
 github.com/blevesearch/zapx/v14
 # github.com/blevesearch/zapx/v15 v15.3.4
 ## explicit; go 1.17


### PR DESCRIPTION
#### Summary
Adds a validation command for imports. The command uses a copy (currently) of the validators in the `mattermost-server`.

```
mmctl import validate import.zip --team myteam
```
to ignore the attachments when validating, use the `--ignore-attachments` flag.
```
mmctl import validate import.zip --team myteam --ignore-attachments
```

#### Ticket Link
[MM-38705](https://mattermost.atlassian.net/browse/MM-38705)

#### Changelog
```release-note
mmctl now allows users to validate import files before uploading them to the server
```