### PR TITLE
Add subcommand for canceling export jobs

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -58,7 +58,7 @@ var ExportListCmd = &cobra.Command{
 
 var ExportJobCmd = &cobra.Command{
 	Use:   "job",
-	Short: "List and show export jobs",
+	Short: "List, show and cancel export jobs",
 }
 
 var ExportJobListCmd = &cobra.Command{
@@ -72,7 +72,7 @@ var ExportJobListCmd = &cobra.Command{
 
 var ExportJobShowCmd = &cobra.Command{
 	Use:     "show [exportJobID]",
-	Example: "  export job show",
+	Example: "  export job show o98rj3ur83dp5dppfyk5yk6osy",
 	Short:   "Show export job",
 	Args:    cobra.ExactArgs(1),
 	RunE:    withClient(exportJobShowCmdF),
@@ -80,7 +80,7 @@ var ExportJobShowCmd = &cobra.Command{
 
 var ExportJobCancelCmd = &cobra.Command{
 	Use:     "cancel [exportJobID]",
-	Example: "  export job cancel",
+	Example: "  export job cancel o98rj3ur83dp5dppfyk5yk6osy",
 	Short:   "Cancel export job",
 	Args:    cobra.ExactArgs(1),
 	RunE:    withClient(exportJobCancelCmdF),

--- a/commands/export.go
+++ b/commands/export.go
@@ -78,6 +78,14 @@ var ExportJobShowCmd = &cobra.Command{
 	RunE:    withClient(exportJobShowCmdF),
 }
 
+var ExportJobCancelCmd = &cobra.Command{
+	Use:     "cancel [exportJobID]",
+	Example: "  export job cancel",
+	Short:   "Cancel export job",
+	Args:    cobra.ExactArgs(1),
+	RunE:    withClient(exportJobCancelCmdF),
+}
+
 func init() {
 	ExportCreateCmd.Flags().Bool("attachments", false, "Set to true to include file attachments in the export file.")
 	_ = ExportCreateCmd.Flags().MarkHidden("attachments")
@@ -99,6 +107,7 @@ func init() {
 	ExportJobCmd.AddCommand(
 		ExportJobListCmd,
 		ExportJobShowCmd,
+		ExportJobCancelCmd,
 	)
 	ExportCmd.AddCommand(
 		ExportCreateCmd,
@@ -228,6 +237,19 @@ func exportJobShowCmdF(c client.Client, command *cobra.Command, args []string) e
 	}
 
 	printJob(job)
+
+	return nil
+}
+
+func exportJobCancelCmdF(c client.Client, _ *cobra.Command, args []string) error {
+	job, _, err := c.GetJob(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to get export job: %w", err)
+	}
+
+	if _, err := c.CancelJob(job.Id); err != nil {
+		return fmt.Errorf("failed to cancel export job: %w", err)
+	}
 
 	return nil
 }

--- a/docs/mmctl_export.rst
+++ b/docs/mmctl_export.rst
@@ -42,3 +42,4 @@ SEE ALSO
 * `mmctl export download <mmctl_export_download.rst>`_ 	 - Download export files
 * `mmctl export job <mmctl_export_job.rst>`_ 	 - List, show and cancel export jobs
 * `mmctl export list <mmctl_export_list.rst>`_ 	 - List export files
+

--- a/docs/mmctl_export_job.rst
+++ b/docs/mmctl_export_job.rst
@@ -3,13 +3,13 @@
 mmctl export job
 ----------------
 
-List and show export jobs
+List, show and cancel export jobs
 
 Synopsis
 ~~~~~~~~
 
 
-List and show export jobs
+List, show and cancel export jobs
 
 Options
 ~~~~~~~
@@ -39,4 +39,3 @@ SEE ALSO
 * `mmctl export <mmctl_export.rst>`_ 	 - Management of exports
 * `mmctl export job list <mmctl_export_job_list.rst>`_ 	 - List export jobs
 * `mmctl export job show <mmctl_export_job_show.rst>`_ 	 - Show export job
-

--- a/docs/mmctl_export_job.rst
+++ b/docs/mmctl_export_job.rst
@@ -37,5 +37,7 @@ SEE ALSO
 ~~~~~~~~
 
 * `mmctl export <mmctl_export.rst>`_ 	 - Management of exports
+* `mmctl export job cancel <mmctl_export_job_cancel.rst>`_ 	 - Cancel export job
 * `mmctl export job list <mmctl_export_job_list.rst>`_ 	 - List export jobs
 * `mmctl export job show <mmctl_export_job_show.rst>`_ 	 - Show export job
+

--- a/docs/mmctl_export_job_cancel.rst
+++ b/docs/mmctl_export_job_cancel.rst
@@ -1,7 +1,7 @@
 .. _mmctl_export_job_cancel:
 
 mmctl export job cancel
----------------------
+-----------------------
 
 Cancel export job
 
@@ -48,3 +48,4 @@ SEE ALSO
 ~~~~~~~~
 
 * `mmctl export job <mmctl_export_job.rst>`_ 	 - List, show and cancel export jobs
+

--- a/docs/mmctl_export_job_cancel.rst
+++ b/docs/mmctl_export_job_cancel.rst
@@ -1,22 +1,33 @@
-.. _mmctl_export:
+.. _mmctl_export_job_cancel:
 
-mmctl export
-------------
+mmctl export job cancel
+---------------------
 
-Management of exports
+Cancel export job
 
 Synopsis
 ~~~~~~~~
 
 
-Management of exports
+Cancel export job
+
+::
+
+  mmctl export job cancel [exportJobID] [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    export job cancel o98rj3ur83dp5dppfyk5yk6osy
 
 Options
 ~~~~~~~
 
 ::
 
-  -h, --help   help for export
+  -h, --help   help for cancel
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -36,9 +47,4 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
-* `mmctl export create <mmctl_export_create.rst>`_ 	 - Create export file
-* `mmctl export delete <mmctl_export_delete.rst>`_ 	 - Delete export file
-* `mmctl export download <mmctl_export_download.rst>`_ 	 - Download export files
 * `mmctl export job <mmctl_export_job.rst>`_ 	 - List, show and cancel export jobs
-* `mmctl export list <mmctl_export_list.rst>`_ 	 - List export files

--- a/docs/mmctl_export_job_list.rst
+++ b/docs/mmctl_export_job_list.rst
@@ -51,3 +51,4 @@ SEE ALSO
 ~~~~~~~~
 
 * `mmctl export job <mmctl_export_job.rst>`_ 	 - List, show and cancel export jobs
+

--- a/docs/mmctl_export_job_list.rst
+++ b/docs/mmctl_export_job_list.rst
@@ -50,5 +50,4 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl export job <mmctl_export_job.rst>`_ 	 - List and show export jobs
-
+* `mmctl export job <mmctl_export_job.rst>`_ 	 - List, show and cancel export jobs

--- a/docs/mmctl_export_job_show.rst
+++ b/docs/mmctl_export_job_show.rst
@@ -48,3 +48,4 @@ SEE ALSO
 ~~~~~~~~
 
 * `mmctl export job <mmctl_export_job.rst>`_ 	 - List, show and cancel export jobs
+

--- a/docs/mmctl_export_job_show.rst
+++ b/docs/mmctl_export_job_show.rst
@@ -20,7 +20,7 @@ Examples
 
 ::
 
-    export job show
+    export job show o98rj3ur83dp5dppfyk5yk6osy
 
 Options
 ~~~~~~~
@@ -47,5 +47,4 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl export job <mmctl_export_job.rst>`_ 	 - List and show export jobs
-
+* `mmctl export job <mmctl_export_job.rst>`_ 	 - List, show and cancel export jobs


### PR DESCRIPTION
#### Summary

At the moment, the mattermost client already knows how to cancel a job, but `mmctl` has no subcommands to expose this functionality and cancel an export job.

This PR adds a new subcommand `mmctl export job cancel [export job id]` to cancel an export job. 

#### Ticket Link

This PR is not resolving any open issues in Jira or GitHub. If necessary, I can create a GitHub issue to be able to link the PR to that.

#### Testing instructions

1. Create a new export job
2. Get the export job's ID
3. Execute `mmctl export job cancel <ID>`

First, the export job's state should be `cancel_requested`, then it should switch to `canceled` after some time.

#### Example

```bash
# Create and cancel the job
$ ./mmctl export create --attachments \
      | awk -F": " '{print $2}' \
      | xargs -n1 -I{} ./mmctl export job cancel "{}"

# Get job list again
$ ./mmctl export job list
  ID: 59uow53d53f6byk5a4hbwg6y4c
  Status: canceled
  Created: 2022-09-20 08:21:55 +0200 CEST

  ID: kw1kppccy7b7dnoqzdayh9q4jw
  Status: success
  Created: 2022-09-20 08:21:39 +0200 CEST
  Started: 2022-09-20 08:21:40 +0200 CEST
  Data: map[include_attachments:true]
```

#### Documentation

Although it was not completely necessary to update the `mmctl export job show` subcommand's example usage, I did it to have a more consistent documentation.

