### PR TITLE
[GH-21223] Add error handling for pluginInstallUvRLCmdF

### DIFF
--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -6,10 +6,10 @@ package commands
 import (
 	"os"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"os"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
 
@@ -118,17 +119,19 @@ func pluginAddCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 
 func pluginInstallURLCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
+	var multiErr *multierror.Error
 
 	for _, plugin := range args {
 		manifest, _, err := c.InstallPluginFromURL(plugin, force)
 		if err != nil {
 			printer.PrintError("Unable to install plugin from URL \"" + plugin + "\". Error: " + err.Error())
+			multiErr = multierror.Append(multiErr, err)
 		} else {
 			printer.PrintT("Plugin {{.Name}} successfully installed", manifest)
 		}
 	}
 
-	return nil
+	return multiErr.ErrorOrNil()
 }
 
 func pluginDeleteCmdF(c client.Client, cmd *cobra.Command, args []string) error {

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -197,7 +197,7 @@ func (s *MmctlE2ETestSuite) TestPluginInstallURLCmd() {
 		defer removePluginIfInstalled(s.th.Client, s, jiraPluginID)
 
 		err := pluginInstallURLCmdF(s.th.Client, &cobra.Command{}, []string{jiraURL})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to install plugin from URL \"%s\".", jiraURL))
@@ -215,7 +215,7 @@ func (s *MmctlE2ETestSuite) TestPluginInstallURLCmd() {
 		const pluginURL = "https://plugins-store.test.mattermost.com/release/mattermost-nonexistent-plugin-v2.0.0.tar.gz"
 
 		err := pluginInstallURLCmdF(c, &cobra.Command{}, []string{pluginURL})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to install plugin from URL \"%s\".", pluginURL))
@@ -238,7 +238,7 @@ func (s *MmctlE2ETestSuite) TestPluginInstallURLCmd() {
 		s.Require().Equal(jiraPluginID, printer.GetLines()[0].(*model.Manifest).Id)
 
 		err = pluginInstallURLCmdF(c, &cobra.Command{}, []string{jiraURL})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to install plugin from URL \"%s\".", jiraURL))

--- a/commands/plugin_test.go
+++ b/commands/plugin_test.go
@@ -198,7 +198,7 @@ func (s *MmctlUnitTestSuite) TestPluginInstallUrlCmd() {
 			Times(1)
 
 		err := pluginInstallURLCmdF(s.client, &cobra.Command{}, args)
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("Unable to install plugin from URL \"https://example.com/plugin2.tar.gz\". Error: mock error", printer.GetErrorLines()[0])
 		s.Require().Len(printer.GetLines(), 1)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This pull request adds error handling for pluginInstallUvRLCmdF. The errors are grouped with `multierror.Error` package and returned once the loop is done.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/21223

