### PR TITLE
refact: adding error handling for assignUsersCmdF

### DIFF
--- a/commands/permission_role_test.go
+++ b/commands/permission_role_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -126,9 +127,13 @@ func (s *MmctlUnitTestSuite) TestAssignUsersCmd() {
 			Return(nil, &model.Response{}, nil).
 			Times(1)
 
+		expectedError := &multierror.Error{}
+		expectedError = multierror.Append(expectedError, fmt.Errorf("couldn't find user 'notfound'"))
+
 		args := []string{mockRole.Name, mockUser1.Username, notFoundUser.Username, mockUser2.Username}
 		err := assignUsersCmdF(s.client, &cobra.Command{}, args)
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
+		s.Require().Equal(expectedError.ErrorOrNil(), err)
 	})
 
 	s.Run("Assigning to a non-existent role", func() {
@@ -215,9 +220,13 @@ func (s *MmctlUnitTestSuite) TestAssignUsersCmd() {
 			Return(nil, &model.Response{}, nil).
 			Times(1)
 
+		expectedError := &multierror.Error{}
+		expectedError = multierror.Append(expectedError, fmt.Errorf("couldn't find user '%s'", requestedUser))
+
 		args := []string{mockRole.Name, requestedUser}
 		err := assignUsersCmdF(s.client, &cobra.Command{}, args)
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
+		s.Require().Equal(expectedError.ErrorOrNil(), err)
 	})
 }
 

--- a/commands/permission_role_test.go
+++ b/commands/permission_role_test.go
@@ -9,11 +9,11 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-	"github.com/mattermost/mmctl/v6/printer"
-
 	"github.com/mattermost/mattermost-server/v6/model"
 
+	"github.com/mattermost/mmctl/v6/printer"
+
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/permissions_role.go
+++ b/commands/permissions_role.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 )
@@ -162,9 +163,11 @@ func assignUsersCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 
 	users := getUsersFromUserArgs(c, args[1:])
 
+	var errs *multierror.Error
 	for i, user := range users {
 		if user == nil {
 			printer.PrintError("Couldn't find user '" + args[i+1] + "'.")
+			errs = multierror.Append(errs, fmt.Errorf("couldn't find user '%s'", args[i+1]))
 			continue
 		}
 
@@ -188,7 +191,7 @@ func assignUsersCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return nil
+	return errs.ErrorOrNil()
 }
 
 func unassignUsersCmdF(c client.Client, cmd *cobra.Command, args []string) error {

--- a/commands/permissions_role.go
+++ b/commands/permissions_role.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/mattermost/mattermost-server/v6/model"
+
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/permissions_role_e2e_test.go
+++ b/commands/permissions_role_e2e_test.go
@@ -37,6 +37,15 @@ func (s *MmctlE2ETestSuite) TestAssignUsersCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
+	s.RunForSystemAdminAndLocal("Assigning non existen user to a role", func(c client.Client) {
+		printer.Clean()
+
+		err := assignUsersCmdF(c, &cobra.Command{}, []string{model.SystemManagerRoleId, "non_existent_user"})
+		s.Require().Error(err)
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 0)
+	})
+
 	s.RunForSystemAdminAndLocal("MM-T3648 Assigning a user to a role", func(c client.Client) {
 		printer.Clean()
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
I added error handling for one error that was not being returned at the end of the function.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

fixes https://github.com/mattermost/mattermost-server/issues/21208

Somethings to note:
1. Ive noticed that on E2E tests there is a MM-TXXX, what is that? should I add one of those to my test?
2. I kept the printer error to stderr, this could result in duplicate errors, should it be removed?
