### PR TITLE
 Added non-zero error return to pluginAddCmdF

### DIFF
--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -104,9 +104,12 @@ func pluginAddCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		} else {
 			_, _, err = c.UploadPlugin(fileReader)
 		}
-
+		
+		var result error
 		if err != nil {
 			printer.PrintError("Unable to add plugin: " + args[i] + ". Error: " + err.Error())
+			result = multierror.Append(result, err)
+			return result
 		} else {
 			printer.Print("Added plugin: " + plugin)
 		}


### PR DESCRIPTION
Added error return to pluginAddCmdF function.
Summary

Added non-zero error return to the pluginAddCmdF function.
Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/21224
