### PR TITLE
Add a new command to upload a license from a license payload string

### DIFF
--- a/commands/license.go
+++ b/commands/license.go
@@ -26,6 +26,14 @@ var UploadLicenseCmd = &cobra.Command{
 	RunE:    withClient(uploadLicenseCmdF),
 }
 
+var UploadLicenseStringCmd = &cobra.Command{
+	Use:     "upload-string [license]",
+	Short:   "Upload a license from a string.",
+	Long:    "Upload a license from a string. Replaces current license.",
+	Example: " license upload-string \"mylicensestring\"",
+	RunE:    withClient(uploadLicenseStringCmdF),
+}
+
 var RemoveLicenseCmd = &cobra.Command{
 	Use:     "remove",
 	Short:   "Remove the current license.",
@@ -38,6 +46,22 @@ func init() {
 	LicenseCmd.AddCommand(UploadLicenseCmd)
 	LicenseCmd.AddCommand(RemoveLicenseCmd)
 	RootCmd.AddCommand(LicenseCmd)
+}
+
+func uploadLicenseStringCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("enter one license file to upload")
+	}
+
+	licenseBytes := []byte(args[0])
+
+	if _, err := c.UploadLicenseFile(licenseBytes); err != nil {
+		return err
+	}
+
+	printer.Print("Uploaded license file")
+
+	return nil
 }
 
 func uploadLicenseCmdF(c client.Client, cmd *cobra.Command, args []string) error {

--- a/commands/license.go
+++ b/commands/license.go
@@ -45,6 +45,7 @@ var RemoveLicenseCmd = &cobra.Command{
 func init() {
 	LicenseCmd.AddCommand(UploadLicenseCmd)
 	LicenseCmd.AddCommand(RemoveLicenseCmd)
+	LicenseCmd.AddCommand(UploadLicenseStringCmd)
 	RootCmd.AddCommand(LicenseCmd)
 }
 

--- a/commands/license_test.go
+++ b/commands/license_test.go
@@ -99,3 +99,28 @@ func (s *MmctlUnitTestSuite) TestUploadLicenseCmdF() {
 		s.Require().EqualError(err, "enter one license file to upload")
 	})
 }
+
+func (s *MmctlUnitTestSuite) TestUploadLicenseStringCmdF() {
+	// create temporary file
+	licenseString := string(fakeLicensePayload)
+
+	mockLicenseFile := []byte(fakeLicensePayload)
+
+	s.Run("Upload license successfully", func() {
+		printer.Clean()
+		s.client.
+			EXPECT().
+			UploadLicenseFile(mockLicenseFile).
+			Return(&model.Response{StatusCode: http.StatusOK}, nil).
+			Times(1)
+
+		err := uploadLicenseStringCmdF(s.client, &cobra.Command{}, []string{licenseString})
+		s.Require().Nil(err)
+	})
+
+	s.Run("Fail to upload license if no license string is given", func() {
+		printer.Clean()
+		err := uploadLicenseStringCmdF(s.client, &cobra.Command{}, []string{})
+		s.Require().EqualError(err, "enter one license file to upload")
+	})
+}

--- a/docs/mmctl_license.rst
+++ b/docs/mmctl_license.rst
@@ -39,4 +39,5 @@ SEE ALSO
 * `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
 * `mmctl license remove <mmctl_license_remove.rst>`_ 	 - Remove the current license.
 * `mmctl license upload <mmctl_license_upload.rst>`_ 	 - Upload a license.
+* `mmctl license upload-string <mmctl_license_upload-string.rst>`_ 	 - Upload a license from a string.
 

--- a/docs/mmctl_license_upload-string.rst
+++ b/docs/mmctl_license_upload-string.rst
@@ -1,9 +1,9 @@
-.. _mmctl_license_upload_string:
+.. _mmctl_license_upload-string:
 
-mmctl license upload string
---------------------
+mmctl license upload-string
+---------------------------
 
-Upload a license from a string
+Upload a license from a string.
 
 Synopsis
 ~~~~~~~~
@@ -20,14 +20,14 @@ Examples
 
 ::
 
-    license upload "your-license-string"
+   license upload-string "mylicensestring"
 
 Options
 ~~~~~~~
 
 ::
 
-  -h, --help   help for upload
+  -h, --help   help for upload-string
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/mmctl_license_upload_string.rst
+++ b/docs/mmctl_license_upload_string.rst
@@ -1,4 +1,4 @@
-.. _mmctl_license_upload:
+.. _mmctl_license_upload_string:
 
 mmctl license upload string
 --------------------

--- a/docs/mmctl_license_upload_string.rst
+++ b/docs/mmctl_license_upload_string.rst
@@ -1,0 +1,51 @@
+.. _mmctl_license_upload:
+
+mmctl license upload string
+--------------------
+
+Upload a license from a string
+
+Synopsis
+~~~~~~~~
+
+
+Upload a license from a string. Replaces current license.
+
+::
+
+  mmctl license upload-string [license] [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    license upload "your-license-string"
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for upload
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
+      --disable-pager                disables paged output
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+      --json                         the output format will be in json format
+      --local                        allows communicating with the server through a unix socket
+      --quiet                        prevent mmctl to generate output for the commands
+      --strict                       will only run commands if the mmctl version matches the server one
+      --suppress-warnings            disables printing warning messages
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl license <mmctl_license.rst>`_ 	 - Licensing commands
+


### PR DESCRIPTION
#### Summary
This command allows uploading a license from a license payload string. We'll need this in Cloud for some upcoming plan change optimizations.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46000

