### PR TITLE
[GH-21210] refactor(commands): add error handling to listCommandCmdF

### DIFF
--- a/commands/command.go
+++ b/commands/command.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/spf13/cobra"
@@ -195,7 +195,7 @@ func listCommandCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	} else {
 		teams = getTeamsFromTeamArgs(c, args)
 	}
-	
+
 	var errs *multierror.Error
 	for i, team := range teams {
 		if team == nil {

--- a/commands/command.go
+++ b/commands/command.go
@@ -206,7 +206,7 @@ func listCommandCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		commands, _, err := c.ListCommands(team.Id, true)
 		if err != nil {
 			printer.PrintError("Unable to list commands for '" + team.Id + "'")
-			errs = multierror.Append(errs, fmt.Errorf("unable to list commands for '%s'", team.Id))
+			errs = multierror.Append(errs, fmt.Errorf("unable to list commands for '%s': %w", team.Id, err))
 			continue
 		}
 		for _, command := range commands {

--- a/commands/command_e2e_test.go
+++ b/commands/command_e2e_test.go
@@ -23,7 +23,7 @@ func (s *MmctlE2ETestSuite) TestListCommandCmd() {
 		nonexistentTeamID := "nonexistent-team-id"
 
 		err := listCommandCmdF(c, &cobra.Command{}, []string{nonexistentTeamID})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
 		s.Equal("Unable to find team '"+nonexistentTeamID+"'", printer.GetErrorLines()[0])
@@ -154,7 +154,7 @@ func (s *MmctlE2ETestSuite) TestListCommandCmd() {
 		}()
 
 		err := listCommandCmdF(s.th.Client, &cobra.Command{}, []string{team.Id})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
 		s.Equal("Unable to find team '"+team.Id+"'", printer.GetErrorLines()[0])

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -457,7 +457,7 @@ func (s *MmctlUnitTestSuite) TestCommandListCmdF() {
 		// second try to search the team by name
 		s.client.EXPECT().GetTeamByName(teamID, "").Return(nil, &model.Response{}, nil).Times(1)
 		err := listCommandCmdF(s.client, cmd, []string{teamID})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
 		s.Equal("Unable to find team '"+teamID+"'", printer.GetErrorLines()[0])
@@ -471,7 +471,7 @@ func (s *MmctlUnitTestSuite) TestCommandListCmdF() {
 		s.client.EXPECT().GetTeam(teamID, "").Return(team, &model.Response{}, nil).Times(1)
 		s.client.EXPECT().ListCommands(teamID, true).Return(nil, &model.Response{}, errors.New("")).Times(1)
 		err := listCommandCmdF(s.client, cmd, []string{teamID})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
 		s.Equal("Unable to list commands for '"+teamID+"'", printer.GetErrorLines()[0])

--- a/commands/enterprise.go
+++ b/commands/enterprise.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+//go:build enterprise
 // +build enterprise
 
 package commands


### PR DESCRIPTION
#### Summary
Added error handling in `listCommandCmdF` for errors that were only printed and not returned.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21210

