### PR TITLE
ref: return  multi-error from moveChannelCmdF

### DIFF
--- a/commands/channel.go
+++ b/commands/channel.go
@@ -518,10 +518,12 @@ func moveChannelCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to find destination team %q", args[0])
 	}
 
+	var result *multierror.Error
+
 	channels := getChannelsFromChannelArgs(c, args[1:])
 	for i, channel := range channels {
 		if channel == nil {
-			printer.PrintError(fmt.Sprintf("Unable to find channel %q", args[i+1]))
+			result = multierror.Append(result, fmt.Errorf("unable to find channel %q", args[i+1]))
 			continue
 		}
 
@@ -531,12 +533,12 @@ func moveChannelCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 
 		newChannel, _, err := c.MoveChannel(channel.Id, team.Id, force)
 		if err != nil {
-			printer.PrintError(fmt.Sprintf("unable to move channel %q: %s", channel.Name, err))
+			result = multierror.Append(result, fmt.Errorf("unable to move channel %q: %w", channel.Name, err))
 			continue
 		}
 		printer.PrintT(fmt.Sprintf("Moved channel {{.Name}} to %q ({{.TeamId}}) from %s.", team.Name, channel.TeamId), newChannel)
 	}
-	return nil
+	return result.ErrorOrNil()
 }
 
 func getPrivateChannels(c client.Client, teamID string) ([]*model.Channel, error) {

--- a/commands/channel_e2e_test.go
+++ b/commands/channel_e2e_test.go
@@ -528,11 +528,12 @@ func (s *MmctlE2ETestSuite) TestMoveChannelCmd() {
 		args := []string{s.th.BasicTeam.Id, "no-channel"}
 		cmd := &cobra.Command{}
 
+		var expected error
+		expected = multierror.Append(expected, fmt.Errorf("unable to find channel %q", "no-channel"))
+
 		err := moveChannelCmdF(c, cmd, args)
-		s.Require().NoError(err)
-		s.Require().Len(printer.GetLines(), 0)
-		s.Require().Len(printer.GetErrorLines(), 1)
-		s.Require().Equal(fmt.Sprintf("Unable to find channel %q", "no-channel"), printer.GetErrorLines()[0])
+
+		s.Require().EqualError(err, expected.Error())
 	})
 
 	s.RunForSystemAdminAndLocal("Moving channel which is already moved to particular team", func(c client.Client) {

--- a/commands/channel_test.go
+++ b/commands/channel_test.go
@@ -2480,7 +2480,7 @@ func (s *MmctlUnitTestSuite) TestMoveChannelCmdF() {
 			Times(1)
 
 		err := moveChannelCmdF(s.client, cmd, []string{dstTeamName, "team:channel"})
-		s.Require().NotNil(err)
+
 		s.Require().EqualError(err, fmt.Sprintf("unable to find destination team %q", dstTeamName))
 	})
 
@@ -2511,9 +2511,10 @@ func (s *MmctlUnitTestSuite) TestMoveChannelCmdF() {
 			Times(1)
 
 		err := moveChannelCmdF(s.client, cmd, []string{dstTeamID, channelID})
-		s.Require().Nil(err)
-		s.Len(printer.GetErrorLines(), 1)
-		s.Require().Equal(fmt.Sprintf("Unable to find channel %q", channelID), printer.GetErrorLines()[0])
+		var expected error
+		expected = multierror.Append(expected, fmt.Errorf("unable to find channel %q", channelID))
+
+		s.Require().EqualError(err, expected.Error())
 	})
 
 	s.Run("Fail on client.MoveChannel to another team by using Ids", func() {
@@ -2547,9 +2548,10 @@ func (s *MmctlUnitTestSuite) TestMoveChannelCmdF() {
 			Times(1)
 
 		err := moveChannelCmdF(s.client, cmd, []string{dstTeamID, channelID})
-		s.Require().Nil(err)
-		s.Len(printer.GetErrorLines(), 1)
-		s.Contains(printer.GetErrorLines()[0], fmt.Sprintf("unable to move channel %q: ", "some-name"))
+		var expected error
+		expected = multierror.Append(expected, fmt.Errorf("unable to move channel %q: some-error", "some-name"))
+
+		s.Require().EqualError(err, expected.Error())
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Returns multi error instead of printing and returning nil


#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/21214
