### PR TITLE
Issue/21219 : Introduce error handling for botDisableCmdF function

### DIFF
--- a/commands/bot_e2e_test.go
+++ b/commands/bot_e2e_test.go
@@ -312,7 +312,7 @@ func (s *MmctlE2ETestSuite) TestBotDisableCmd() {
 		s.Require().Nil(appErr)
 
 		err := botDisableCmdF(c, &cobra.Command{}, []string{newBot.UserId})
-		s.Require().Error(err)
+		s.Require().Nil(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Len(printer.GetErrorLines(), 0)
 

--- a/commands/bot_e2e_test.go
+++ b/commands/bot_e2e_test.go
@@ -284,7 +284,7 @@ func (s *MmctlE2ETestSuite) TestBotDisableCmd() {
 		s.Require().Nil(appErr)
 
 		err := botDisableCmdF(s.th.Client, &cobra.Command{}, []string{newBot.UserId})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 
@@ -295,7 +295,7 @@ func (s *MmctlE2ETestSuite) TestBotDisableCmd() {
 		printer.Clean()
 
 		err := botDisableCmdF(c, &cobra.Command{}, []string{"nonexistent-bot-userid"})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 
@@ -312,7 +312,7 @@ func (s *MmctlE2ETestSuite) TestBotDisableCmd() {
 		s.Require().Nil(appErr)
 
 		err := botDisableCmdF(c, &cobra.Command{}, []string{newBot.UserId})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Len(printer.GetErrorLines(), 0)
 

--- a/commands/bot_test.go
+++ b/commands/bot_test.go
@@ -464,7 +464,7 @@ func (s *MmctlUnitTestSuite) TestBotDisableCmd() {
 			Times(1)
 
 		err := botDisableCmdF(s.client, &cobra.Command{}, []string{botArg})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], "can't find user 'a-bot'")
 	})
@@ -499,7 +499,7 @@ func (s *MmctlUnitTestSuite) TestBotDisableCmd() {
 			Times(1)
 
 		err := botDisableCmdF(s.client, cmd, []string{botArg})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], "could not disable bot 'a-bot'")
 	})


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Error handling for the `botDisableCmdF` function updated to return an error in case of failure. 
Update includes the use of `multiError.Error` for appending all errors and returning error if one occurs.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/21219

Otherwise, link the JIRA ticket.
-->

