### PR TITLE
Issue 21219: improve error handling for botDisableCmdF

### DIFF
--- a/commands/bot.go
+++ b/commands/bot.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -236,22 +237,26 @@ func botEnableCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 
 func botDisableCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	users := getUsersFromUserArgs(c, args)
+
+	var result *multierror.Error
 	for i, user := range users {
 		if user == nil {
 			printer.PrintError(fmt.Sprintf("can't find user '%v'", args[i]))
+			result = multierror.Append(result, fmt.Errorf("can't find user '%v'", args[i]))
 			continue
 		}
 
 		bot, _, err := c.DisableBot(user.Id)
 		if err != nil {
 			printer.PrintError(fmt.Sprintf("could not disable bot '%v'", args[i]))
+			result = multierror.Append(result, fmt.Errorf("could not disable bot '%v'", args[i]))
 			continue
 		}
 
 		printer.PrintT("Disabled bot {{.UserId}} ({{.Username}})", bot)
 	}
 
-	return nil
+	return result.ErrorOrNil()
 }
 
 func botAssignCmdF(c client.Client, cmd *cobra.Command, args []string) error {

--- a/commands/bot.go
+++ b/commands/bot.go
@@ -242,14 +242,14 @@ func botDisableCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	for i, user := range users {
 		if user == nil {
 			printer.PrintError(fmt.Sprintf("can't find user '%v'", args[i]))
-			result = multierror.Append(result, fmt.Errorf("can't find user '%v'", args[i]))
+			result = multierror.Append(result, fmt.Errorf("can't find user %q", args[i]))
 			continue
 		}
 
 		bot, _, err := c.DisableBot(user.Id)
 		if err != nil {
 			printer.PrintError(fmt.Sprintf("could not disable bot '%v'", args[i]))
-			result = multierror.Append(result, fmt.Errorf("could not disable bot '%v'", args[i]))
+			result = multierror.Append(result, fmt.Errorf("could not disable bot %q: %w", args[i], err))
 			continue
 		}
 

--- a/commands/bot_e2e_test.go
+++ b/commands/bot_e2e_test.go
@@ -284,7 +284,7 @@ func (s *MmctlE2ETestSuite) TestBotDisableCmd() {
 		s.Require().Nil(appErr)
 
 		err := botDisableCmdF(s.th.Client, &cobra.Command{}, []string{newBot.UserId})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 
@@ -295,7 +295,7 @@ func (s *MmctlE2ETestSuite) TestBotDisableCmd() {
 		printer.Clean()
 
 		err := botDisableCmdF(c, &cobra.Command{}, []string{"nonexistent-bot-userid"})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 

--- a/commands/bot_e2e_test.go
+++ b/commands/bot_e2e_test.go
@@ -284,7 +284,7 @@ func (s *MmctlE2ETestSuite) TestBotDisableCmd() {
 		s.Require().Nil(appErr)
 
 		err := botDisableCmdF(s.th.Client, &cobra.Command{}, []string{newBot.UserId})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 
@@ -295,7 +295,7 @@ func (s *MmctlE2ETestSuite) TestBotDisableCmd() {
 		printer.Clean()
 
 		err := botDisableCmdF(c, &cobra.Command{}, []string{"nonexistent-bot-userid"})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 

--- a/commands/bot_test.go
+++ b/commands/bot_test.go
@@ -464,7 +464,7 @@ func (s *MmctlUnitTestSuite) TestBotDisableCmd() {
 			Times(1)
 
 		err := botDisableCmdF(s.client, &cobra.Command{}, []string{botArg})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], "can't find user 'a-bot'")
 	})
@@ -499,7 +499,7 @@ func (s *MmctlUnitTestSuite) TestBotDisableCmd() {
 			Times(1)
 
 		err := botDisableCmdF(s.client, cmd, []string{botArg})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], "could not disable bot 'a-bot'")
 	})


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Error handling for the `botDisableCmdF` function updated to return an error in case of failure. 
Update includes the use of `multierror.Error` for appending all errors and returning error if one occurs.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

Fixes https://github.com/mattermost/mattermost-server/issues/21219

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/21219
