### PR TITLE
Issue 21220: improve error handling for botEnableCmdF function

### DIFF
--- a/commands/bot.go
+++ b/commands/bot.go
@@ -223,14 +223,14 @@ func botEnableCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	for i, user := range users {
 		if user == nil {
 			printer.PrintError(fmt.Sprintf("can't find user '%v'", args[i]))
-			result = multierror.Append(result, fmt.Errorf("can't find user '%v'", args[i]))
+			result = multierror.Append(result, fmt.Errorf("can't find user %q", args[i]))
 			continue
 		}
 
 		bot, _, err := c.EnableBot(user.Id)
 		if err != nil {
 			printer.PrintError(fmt.Sprintf("could not enable bot '%v'", args[i]))
-			result = multierror.Append(result, fmt.Errorf("could not enable bot '%v'", args[i]))
+			result = multierror.Append(result, fmt.Errorf("could not enable bot %q: %w", args[i], err))
 			continue
 		}
 

--- a/commands/bot_e2e_test.go
+++ b/commands/bot_e2e_test.go
@@ -198,7 +198,7 @@ func (s *MmctlE2ETestSuite) TestBotEnableCmd() {
 		s.Require().Nil(appErr)
 
 		err := botEnableCmdF(s.th.Client, &cobra.Command{}, []string{newBot.UserId})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 
@@ -209,7 +209,7 @@ func (s *MmctlE2ETestSuite) TestBotEnableCmd() {
 		printer.Clean()
 
 		err := botEnableCmdF(c, &cobra.Command{}, []string{"nonexistent-bot-userid"})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 

--- a/commands/bot_e2e_test.go
+++ b/commands/bot_e2e_test.go
@@ -198,7 +198,7 @@ func (s *MmctlE2ETestSuite) TestBotEnableCmd() {
 		s.Require().Nil(appErr)
 
 		err := botEnableCmdF(s.th.Client, &cobra.Command{}, []string{newBot.UserId})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 
@@ -209,7 +209,7 @@ func (s *MmctlE2ETestSuite) TestBotEnableCmd() {
 		printer.Clean()
 
 		err := botEnableCmdF(c, &cobra.Command{}, []string{"nonexistent-bot-userid"})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 

--- a/commands/bot_test.go
+++ b/commands/bot_test.go
@@ -562,7 +562,7 @@ func (s *MmctlUnitTestSuite) TestBotEnableCmd() {
 			Times(1)
 
 		err := botEnableCmdF(s.client, &cobra.Command{}, []string{botArg})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], "can't find user 'a-bot'")
 	})
@@ -597,7 +597,7 @@ func (s *MmctlUnitTestSuite) TestBotEnableCmd() {
 			Times(1)
 
 		err := botEnableCmdF(s.client, cmd, []string{botArg})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], "could not enable bot 'a-bot'")
 	})


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Error handling for the `botEnableCmdF` function updated to return an error in case of failure. 
Update includes the use of `multierror.Error` for appending all errors and returning error if one occurs.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/21220

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/21220
