### PR TITLE
[MM-47398] add http proxy support

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -156,6 +156,7 @@ func NewAPIv4Client(instanceURL string, allowInsecureSHA1, allowInsecureTLS bool
 	client.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
+			Proxy:           http.ProxyFromEnvironment,
 		},
 	}
 


### PR DESCRIPTION

#### Summary
Enable `HTTP_PROXY` and `HTTPS_PROXY` environment variables to be used for mmctl.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47398

