### PR TITLE
fix: listCommandCmdF multi error handling

### DIFF
--- a/commands/roles.go
+++ b/commands/roles.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 )
 
@@ -57,9 +58,11 @@ func init() {
 }
 
 func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) error {
+	var Error error
 	users := getUsersFromUserArgs(c, args)
 	for i, user := range users {
 		if user == nil {
+			Error = multierror.Append(Error, fmt.Errorf("unable to find user %q", args[i]))
 			printer.PrintError(fmt.Sprintf("unable to find user %q", args[i]))
 			continue
 		}
@@ -75,6 +78,7 @@ func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) erro
 		if !systemAdmin {
 			roles = append(roles, model.SystemAdminRoleId)
 			if _, err := c.UpdateUserRoles(user.Id, strings.Join(roles, " ")); err != nil {
+				Error = multierror.Append(Error, fmt.Errorf("can't update roles for user %q: %s", args[i], err))
 				printer.PrintError(fmt.Sprintf("can't update roles for user %q: %s", args[i], err))
 				continue
 			}
@@ -83,7 +87,7 @@ func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) erro
 		}
 	}
 
-	return nil
+	return Error
 }
 
 func rolesMemberCmdF(c client.Client, _ *cobra.Command, args []string) error {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
added multi error handling in listCommandCmdF function
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/21210

