### PR TITLE
[MM-47821] Review searchUserCmdF function to return an error in case of a failure (#21465)

### DIFF
--- a/commands/user.go
+++ b/commands/user.go
@@ -685,6 +685,7 @@ func searchUserCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	users, err := getUsersFromArgs(c, args)
 	if err != nil {
 		printer.PrintError(err.Error())
+		return err
 	}
 
 	for i, user := range users {

--- a/commands/user_test.go
+++ b/commands/user_test.go
@@ -626,6 +626,75 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 		s.Require().Nil(err)
 		s.Require().Equal("1 error occurred:\n\t* user test/../hello?@mattermost.com not found\n\n", printer.GetErrorLines()[0])
 	})
+
+	s.Run("Got error while getting user by email", func() {
+		printer.Clean()
+		arg := "example@example.com"
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(arg, "").
+			Return(nil, &model.Response{}, errors.New("Error while getting user by email")).
+			Times(1)
+
+		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().NotNil(err)
+		s.Require().Equal(err.Error(), "Error while getting user by email")
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Equal("1 error occurred:\n\t* Error while getting user by email\n\n", printer.GetErrorLines()[0])
+	})
+
+	s.Run("Got error while getting user by username", func() {
+		printer.Clean()
+		arg := "example@example.com"
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(arg, "").
+			Return(nil, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByUsername(arg, "").
+			Return(nil, &model.Response{}, errors.New("Error while getting user by username")).
+			Times(1)
+
+		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().NotNil(err)
+		s.Require().Equal(err.Error(), "Error while getting user by username")
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Equal("1 error occurred:\n\t* Error while getting user by username\n\n", printer.GetErrorLines()[0])
+	})
+
+	s.Run("Got error while getting user", func() {
+		printer.Clean()
+		arg := "example@example.com"
+
+		s.client.
+			EXPECT().
+			GetUserByEmail(arg, "").
+			Return(nil, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUserByUsername(arg, "").
+			Return(nil, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUser(arg, "").
+			Return(nil, &model.Response{}, errors.New("Error while getting user")).
+			Times(1)
+
+		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
+		s.Require().NotNil(err)
+		s.Require().Equal(err.Error(), "Error while getting user")
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Equal("1 error occurred:\n\t* Error while getting user\n\n", printer.GetErrorLines()[0])
+	})
 }
 
 func (s *MmctlUnitTestSuite) TestChangePasswordUserCmdF() {

--- a/commands/user_test.go
+++ b/commands/user_test.go
@@ -613,7 +613,7 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 			Times(1)
 
 		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Equal("1 error occurred:\n\t* user example@example.com not found\n\n", printer.GetErrorLines()[0])
 	})
@@ -623,7 +623,7 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 		arg := "test/../hello?@mattermost.com"
 
 		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Equal("1 error occurred:\n\t* user test/../hello?@mattermost.com not found\n\n", printer.GetErrorLines()[0])
 	})
 
@@ -639,8 +639,8 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 
 		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
 		s.Require().NotNil(err)
-		s.Require().Equal(err.Error(), "Error while getting user by email")
 		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Equal("1 error occurred:\n\t* Error while getting user by email\n\n", err.Error())
 		s.Require().Equal("1 error occurred:\n\t* Error while getting user by email\n\n", printer.GetErrorLines()[0])
 	})
 
@@ -662,8 +662,8 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 
 		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
 		s.Require().NotNil(err)
-		s.Require().Equal(err.Error(), "Error while getting user by username")
 		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Equal("1 error occurred:\n\t* Error while getting user by username\n\n", err.Error())
 		s.Require().Equal("1 error occurred:\n\t* Error while getting user by username\n\n", printer.GetErrorLines()[0])
 	})
 
@@ -691,8 +691,8 @@ func (s *MmctlUnitTestSuite) TestSearchUserCmd() {
 
 		err := searchUserCmdF(s.client, &cobra.Command{}, []string{arg})
 		s.Require().NotNil(err)
-		s.Require().Equal(err.Error(), "Error while getting user")
 		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Equal("1 error occurred:\n\t* Error while getting user\n\n", err.Error())
 		s.Require().Equal("1 error occurred:\n\t* Error while getting user\n\n", printer.GetErrorLines()[0])
 	})
 }


### PR DESCRIPTION
#### Summary

Return error from the searchUserCmdF if an error occurs while getting user.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/21465

JIRA: https://mattermost.atlassian.net/browse/MM-47821
