### PR TITLE
MM-47817: Review changeUsersActiveStatus function to return an error in case of a failure

### DIFF
--- a/commands/user.go
+++ b/commands/user.go
@@ -360,11 +360,7 @@ Global Flags:
 }
 
 func userActivateCmdF(c client.Client, command *cobra.Command, args []string) error {
-	if err := changeUsersActiveStatus(c, args, true); err != nil {
-		return err
-	}
-
-	return nil
+	return changeUsersActiveStatus(c, args, true)
 }
 
 func changeUsersActiveStatus(c client.Client, userArgs []string, active bool) error {
@@ -395,11 +391,7 @@ func changeUserActiveStatus(c client.Client, user *model.User, activate bool) er
 }
 
 func userDeactivateCmdF(c client.Client, cmd *cobra.Command, args []string) error {
-	if err := changeUsersActiveStatus(c, args, false); err != nil {
-		return err
-	}
-
-	return nil
+	return changeUsersActiveStatus(c, args, false)
 }
 
 func userCreateCmdF(c client.Client, cmd *cobra.Command, args []string) error {

--- a/commands/user_e2e_test.go
+++ b/commands/user_e2e_test.go
@@ -42,7 +42,7 @@ func (s *MmctlE2ETestSuite) TestUserActivateCmd() {
 		s.Require().Nil(appErr)
 
 		err := userActivateCmdF(s.th.Client, &cobra.Command{}, []string{user.Email})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "unable to change activation status of user: "+user.Id)
@@ -56,7 +56,7 @@ func (s *MmctlE2ETestSuite) TestUserActivateCmd() {
 		printer.Clean()
 
 		err := userActivateCmdF(c, &cobra.Command{}, []string{"nonexistent@email"})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("1 error occurred:\n\t* user nonexistent@email not found\n\n", printer.GetErrorLines()[0])
@@ -92,7 +92,7 @@ func (s *MmctlE2ETestSuite) TestUserDeactivateCmd() {
 		s.Require().Nil(appErr)
 
 		err := userDeactivateCmdF(s.th.Client, &cobra.Command{}, []string{user.Email})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "unable to change activation status of user: "+user.Id)
@@ -106,7 +106,7 @@ func (s *MmctlE2ETestSuite) TestUserDeactivateCmd() {
 		printer.Clean()
 
 		err := userDeactivateCmdF(c, &cobra.Command{}, []string{"nonexistent@email"})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("1 error occurred:\n\t* user nonexistent@email not found\n\n", printer.GetErrorLines()[0])
@@ -559,7 +559,6 @@ func (s *MmctlE2ETestSuite) TestUpdateUsernameCmd() {
 		printer.Clean()
 		newUsername := "basicusernamechange"
 		err := updateUsernameCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicUser2.Id, newUsername})
-		s.Require().NotNil(err)
 		s.Require().EqualError(err, ": You do not have the appropriate permissions., ")
 
 		u, err := s.th.App.GetUser(s.th.BasicUser2.Id)

--- a/commands/user_e2e_test.go
+++ b/commands/user_e2e_test.go
@@ -42,7 +42,7 @@ func (s *MmctlE2ETestSuite) TestUserActivateCmd() {
 		s.Require().Nil(appErr)
 
 		err := userActivateCmdF(s.th.Client, &cobra.Command{}, []string{user.Email})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "unable to change activation status of user: "+user.Id)
@@ -56,7 +56,7 @@ func (s *MmctlE2ETestSuite) TestUserActivateCmd() {
 		printer.Clean()
 
 		err := userActivateCmdF(c, &cobra.Command{}, []string{"nonexistent@email"})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("1 error occurred:\n\t* user nonexistent@email not found\n\n", printer.GetErrorLines()[0])
@@ -92,7 +92,7 @@ func (s *MmctlE2ETestSuite) TestUserDeactivateCmd() {
 		s.Require().Nil(appErr)
 
 		err := userDeactivateCmdF(s.th.Client, &cobra.Command{}, []string{user.Email})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "unable to change activation status of user: "+user.Id)
@@ -106,7 +106,7 @@ func (s *MmctlE2ETestSuite) TestUserDeactivateCmd() {
 		printer.Clean()
 
 		err := userDeactivateCmdF(c, &cobra.Command{}, []string{"nonexistent@email"})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("1 error occurred:\n\t* user nonexistent@email not found\n\n", printer.GetErrorLines()[0])
@@ -559,6 +559,7 @@ func (s *MmctlE2ETestSuite) TestUpdateUsernameCmd() {
 		printer.Clean()
 		newUsername := "basicusernamechange"
 		err := updateUsernameCmdF(s.th.Client, &cobra.Command{}, []string{s.th.BasicUser2.Id, newUsername})
+		s.Require().NotNil(err)
 		s.Require().EqualError(err, ": You do not have the appropriate permissions., ")
 
 		u, err := s.th.App.GetUser(s.th.BasicUser2.Id)

--- a/commands/user_test.go
+++ b/commands/user_test.go
@@ -67,7 +67,7 @@ func (s *MmctlUnitTestSuite) TestUserActivateCmd() {
 			Times(1)
 
 		err := userActivateCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %s not found\n\n", emailArg), printer.GetErrorLines()[0])
@@ -91,7 +91,7 @@ func (s *MmctlUnitTestSuite) TestUserActivateCmd() {
 			Times(1)
 
 		err := userActivateCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Errorf("unable to change activation status of user: %v", mockUser.Id).Error(), printer.GetErrorLines()[0])
@@ -172,7 +172,7 @@ func (s *MmctlUnitTestSuite) TestUserActivateCmd() {
 			Times(1)
 
 		err := userActivateCmdF(s.client, &cobra.Command{}, emailArgs)
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 2)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %s not found\n\n", emailArgs[1]), printer.GetErrorLines()[0])
@@ -227,7 +227,7 @@ func (s *MmctlUnitTestSuite) TestDeactivateUserCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %v not found\n\n", emailArg), printer.GetErrorLines()[0])
@@ -251,7 +251,7 @@ func (s *MmctlUnitTestSuite) TestDeactivateUserCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Errorf("unable to change activation status of user: %v", mockUser.Id).Error(), printer.GetErrorLines()[0])
@@ -356,7 +356,7 @@ func (s *MmctlUnitTestSuite) TestDeactivateUserCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, emailArgs)
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Equal("You must also deactivate user "+mockUser2.Id+" in the SSO provider or they will be reactivated on next login or sync.", printer.GetLines()[0])
 		s.Require().Len(printer.GetErrorLines(), 2)
@@ -2024,7 +2024,7 @@ func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, []string{arg})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %s not found\n\n", arg), printer.GetErrorLines()[0])
@@ -2160,7 +2160,7 @@ func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, []string{mockUser1.Email, nonexistentEmail})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %s not found\n\n", nonexistentEmail), printer.GetErrorLines()[0])

--- a/commands/user_test.go
+++ b/commands/user_test.go
@@ -67,7 +67,7 @@ func (s *MmctlUnitTestSuite) TestUserActivateCmd() {
 			Times(1)
 
 		err := userActivateCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %s not found\n\n", emailArg), printer.GetErrorLines()[0])
@@ -91,7 +91,7 @@ func (s *MmctlUnitTestSuite) TestUserActivateCmd() {
 			Times(1)
 
 		err := userActivateCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Errorf("unable to change activation status of user: %v", mockUser.Id).Error(), printer.GetErrorLines()[0])
@@ -172,7 +172,7 @@ func (s *MmctlUnitTestSuite) TestUserActivateCmd() {
 			Times(1)
 
 		err := userActivateCmdF(s.client, &cobra.Command{}, emailArgs)
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 2)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %s not found\n\n", emailArgs[1]), printer.GetErrorLines()[0])
@@ -227,7 +227,7 @@ func (s *MmctlUnitTestSuite) TestDeactivateUserCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %v not found\n\n", emailArg), printer.GetErrorLines()[0])
@@ -251,7 +251,7 @@ func (s *MmctlUnitTestSuite) TestDeactivateUserCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Errorf("unable to change activation status of user: %v", mockUser.Id).Error(), printer.GetErrorLines()[0])
@@ -356,7 +356,7 @@ func (s *MmctlUnitTestSuite) TestDeactivateUserCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, emailArgs)
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Equal("You must also deactivate user "+mockUser2.Id+" in the SSO provider or they will be reactivated on next login or sync.", printer.GetLines()[0])
 		s.Require().Len(printer.GetErrorLines(), 2)
@@ -2024,7 +2024,7 @@ func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, []string{arg})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %s not found\n\n", arg), printer.GetErrorLines()[0])
@@ -2160,7 +2160,7 @@ func (s *MmctlUnitTestSuite) TestUserDeactivateCmd() {
 			Times(1)
 
 		err := userDeactivateCmdF(s.client, &cobra.Command{}, []string{mockUser1.Email, nonexistentEmail})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(fmt.Sprintf("1 error occurred:\n\t* user %s not found\n\n", nonexistentEmail), printer.GetErrorLines()[0])


### PR DESCRIPTION
#### Summary
This PR makes necessary changes for changeUsersActiveStatus function to return an error in case of a failure

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21469
JIRA: https://mattermost.atlassian.net/browse/MM-47817
