### PR TITLE
[MM-47814] - Refactor deleteTeamsCmdF function error handling

### DIFF
--- a/commands/team.go
+++ b/commands/team.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 
 	"github.com/hashicorp/go-multierror"
@@ -306,24 +307,24 @@ func deleteTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	var result error
+	var result *multierror.Error
 
 	teams := getTeamsFromTeamArgs(c, args)
 	for i, team := range teams {
 		if team == nil {
 			printer.PrintError("Unable to find team '" + args[i] + "'")
-			result = multierror.Append(result, errors.New("unable to find team '"+args[i]+"'"))
+			result = multierror.Append(result, fmt.Errorf("unable to find team %s", args[i]))
 			continue
 		}
 		if _, err := deleteTeam(c, team); err != nil {
 			printer.PrintError("Unable to delete team '" + team.Name + "' error: " + err.Error())
-			result = multierror.Append(result, errors.New("unable to delete team '"+team.Name+"' error: "+err.Error()))
+			result = multierror.Append(result, fmt.Errorf("unable to delete team %s error: %s", team.Name, args[i]))
 		} else {
 			printer.PrintT("Deleted team '{{.Name}}'", team)
 		}
 	}
 
-	return result
+	return result.ErrorOrNil()
 }
 
 func modifyTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {

--- a/commands/team.go
+++ b/commands/team.go
@@ -318,7 +318,7 @@ func deleteTeamsCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 		}
 		if _, err := deleteTeam(c, team); err != nil {
 			printer.PrintError("Unable to delete team '" + team.Name + "' error: " + err.Error())
-			result = multierror.Append(result, fmt.Errorf("unable to delete team %s error: %s", team.Name, args[i]))
+			result = multierror.Append(result, fmt.Errorf("unable to delete team %s error: %w", team.Name, err))
 		} else {
 			printer.PrintT("Deleted team '{{.Name}}'", team)
 		}

--- a/commands/team_e2e_test.go
+++ b/commands/team_e2e_test.go
@@ -134,7 +134,7 @@ func (s *MmctlE2ETestSuite) TestDeleteTeamsCmdF() {
 
 		// Delete should fail for SystemAdmin client
 		err := deleteTeamsCmdF(s.th.SystemAdminClient, cmd, args)
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Len(printer.GetLines(), 0)
 		s.Len(printer.GetErrorLines(), 1)
 		s.Equal("Unable to delete team '"+s.th.BasicTeam.Name+"' error: : Permanent team deletion feature is not enabled. Please contact your System Administrator., ", printer.GetErrorLines()[0])

--- a/commands/team_test.go
+++ b/commands/team_test.go
@@ -496,7 +496,7 @@ func (s *MmctlUnitTestSuite) TestDeleteTeamsCmd() {
 		cmd.Flags().Bool("confirm", true, "")
 
 		err := deleteTeamsCmdF(s.client, cmd, []string{"team1"})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Equal("Unable to delete team 'team1' error: an error occurred on deleting a team",
 			printer.GetErrorLines()[0])
 	})

--- a/commands/team_test.go
+++ b/commands/team_test.go
@@ -440,7 +440,7 @@ func (s *MmctlUnitTestSuite) TestDeleteTeamsCmd() {
 		cmd.Flags().Bool("confirm", true, "")
 
 		err := deleteTeamsCmdF(s.client, cmd, []string{"team1"})
-		s.Require().Nil(err)
+		s.Require().Error(err)
 		s.Require().Equal("Unable to find team 'team1'", printer.GetErrorLines()[0])
 	})
 
@@ -496,7 +496,7 @@ func (s *MmctlUnitTestSuite) TestDeleteTeamsCmd() {
 		cmd.Flags().Bool("confirm", true, "")
 
 		err := deleteTeamsCmdF(s.client, cmd, []string{"team1"})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Equal("Unable to delete team 'team1' error: an error occurred on deleting a team",
 			printer.GetErrorLines()[0])
 	})


### PR DESCRIPTION
**Summary**
This PR makes necessary changes for deleteTeamsCmdF function to return an error in case of a failure

**Ticket Link**
Fixes https://github.com/mattermost/mattermost-server/issues/21472
JIRA: https://mattermost.atlassian.net/browse/MM-47814