### PR TITLE
[MM-47825] refactor rolesSystemAdminCmdF function to return an error #21477

### DIFF
--- a/commands/roles.go
+++ b/commands/roles.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/pkg/errors"
 
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
@@ -59,13 +58,13 @@ func init() {
 }
 
 func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) error {
-	var errs error
+	var errs *multierror.Error
 	users := getUsersFromUserArgs(c, args)
 	for i, user := range users {
 		if user == nil {
-			errStr := fmt.Sprintf("unable to find user %q", args[i])
-			errs = multierror.Append(errs, errors.New(errStr))
-			printer.PrintError(errStr)
+			err := fmt.Errorf("unable to find user %q", args[i])
+			errs = multierror.Append(errs, err)
+			printer.PrintError(err.Error())
 			continue
 		}
 
@@ -80,9 +79,9 @@ func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) erro
 		if !systemAdmin {
 			roles = append(roles, model.SystemAdminRoleId)
 			if _, err := c.UpdateUserRoles(user.Id, strings.Join(roles, " ")); err != nil {
-				errStr := fmt.Sprintf("can't update roles for user %q: %s", args[i], err)
-				errs = multierror.Append(errs, errors.New(errStr))
-				printer.PrintError(errStr)
+				err := fmt.Errorf("can't update roles for user %q: %s", args[i], err)
+				errs = multierror.Append(errs, err)
+				printer.PrintError(err.Error())
 				continue
 			}
 
@@ -90,7 +89,7 @@ func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) erro
 		}
 	}
 
-	return errs
+	return errs.ErrorOrNil()
 }
 
 func rolesMemberCmdF(c client.Client, _ *cobra.Command, args []string) error {

--- a/commands/roles.go
+++ b/commands/roles.go
@@ -79,7 +79,7 @@ func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) erro
 		if !systemAdmin {
 			roles = append(roles, model.SystemAdminRoleId)
 			if _, err := c.UpdateUserRoles(user.Id, strings.Join(roles, " ")); err != nil {
-				err := fmt.Errorf("can't update roles for user %q: %s", args[i], err)
+				err := fmt.Errorf("can't update roles for user %q: %w", args[i], err)
 				errs = multierror.Append(errs, err)
 				printer.PrintError(err.Error())
 				continue

--- a/commands/roles.go
+++ b/commands/roles.go
@@ -62,9 +62,9 @@ func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) erro
 	users := getUsersFromUserArgs(c, args)
 	for i, user := range users {
 		if user == nil {
-			err := fmt.Errorf("unable to find user %q", args[i])
-			errs = multierror.Append(errs, err)
-			printer.PrintError(err.Error())
+			userErr := fmt.Errorf("unable to find user %q", args[i])
+			errs = multierror.Append(errs, userErr)
+			printer.PrintError(userErr.Error())
 			continue
 		}
 
@@ -79,9 +79,9 @@ func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) erro
 		if !systemAdmin {
 			roles = append(roles, model.SystemAdminRoleId)
 			if _, err := c.UpdateUserRoles(user.Id, strings.Join(roles, " ")); err != nil {
-				err := fmt.Errorf("can't update roles for user %q: %w", args[i], err)
-				errs = multierror.Append(errs, err)
-				printer.PrintError(err.Error())
+				updateErr := fmt.Errorf("can't update roles for user %q: %w", args[i], err)
+				errs = multierror.Append(errs, updateErr)
+				printer.PrintError(updateErr.Error())
 				continue
 			}
 

--- a/commands/roles_test.go
+++ b/commands/roles_test.go
@@ -85,7 +85,8 @@ func (s *MmctlUnitTestSuite) TestMakeAdminCmd() {
 			Times(1)
 
 		err := rolesSystemAdminCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().Nil(err)
+		s.Require().Error(err)
+		s.Require().ErrorContains(err, "unable to find user")
 
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
@@ -111,7 +112,8 @@ func (s *MmctlUnitTestSuite) TestMakeAdminCmd() {
 			Times(1)
 
 		err := rolesSystemAdminCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
-		s.Require().Nil(err)
+		s.Require().Error(err)
+		s.Require().ErrorContains(err, "can't update roles for user")
 
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)

--- a/commands/roles_test.go
+++ b/commands/roles_test.go
@@ -85,7 +85,6 @@ func (s *MmctlUnitTestSuite) TestMakeAdminCmd() {
 			Times(1)
 
 		err := rolesSystemAdminCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().Error(err)
 		s.Require().ErrorContains(err, "unable to find user")
 
 		s.Require().Len(printer.GetLines(), 0)
@@ -112,7 +111,6 @@ func (s *MmctlUnitTestSuite) TestMakeAdminCmd() {
 			Times(1)
 
 		err := rolesSystemAdminCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
-		s.Require().Error(err)
 		s.Require().ErrorContains(err, "can't update roles for user")
 
 		s.Require().Len(printer.GetLines(), 0)


### PR DESCRIPTION
#### Summary
Added multi error handing in rolesSystemAdminCmdF function

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/21477
JIRA: https://mattermost.atlassian.net/browse/MM-47825