### PR TITLE
[MM-47810] Return error from rolesMemberCmdF

### DIFF
--- a/commands/roles.go
+++ b/commands/roles.go
@@ -120,7 +120,7 @@ func rolesMemberCmdF(c client.Client, _ *cobra.Command, args []string) error {
 			if _, err := c.UpdateUserRoles(user.Id, strings.Join(newRoles, " ")); err != nil {
 				updateErr := fmt.Errorf("can't update roles for user %q: %w", args[i], err)
 				errs = multierror.Append(errs, updateErr)
-				printer.PrintError(err.Error())
+				printer.PrintError(updateErr.Error())
 				continue
 			}
 

--- a/commands/roles.go
+++ b/commands/roles.go
@@ -93,10 +93,13 @@ func rolesSystemAdminCmdF(c client.Client, _ *cobra.Command, args []string) erro
 }
 
 func rolesMemberCmdF(c client.Client, _ *cobra.Command, args []string) error {
+	var errs *multierror.Error
 	users := getUsersFromUserArgs(c, args)
 	for i, user := range users {
 		if user == nil {
-			printer.PrintError(fmt.Sprintf("unable to find user %q", args[i]))
+			userErr := fmt.Errorf("unable to find user %q", args[i])
+			errs = multierror.Append(errs, userErr)
+			printer.PrintError(userErr.Error())
 			continue
 		}
 
@@ -115,7 +118,9 @@ func rolesMemberCmdF(c client.Client, _ *cobra.Command, args []string) error {
 
 		if shouldRemoveSysadmin {
 			if _, err := c.UpdateUserRoles(user.Id, strings.Join(newRoles, " ")); err != nil {
-				printer.PrintError(fmt.Sprintf("can't update roles for user %q: %s", args[i], err))
+				updateErr := fmt.Errorf("can't update roles for user %q: %w", args[i], err)
+				errs = multierror.Append(errs, updateErr)
+				printer.PrintError(err.Error())
 				continue
 			}
 
@@ -123,5 +128,5 @@ func rolesMemberCmdF(c client.Client, _ *cobra.Command, args []string) error {
 		}
 	}
 
-	return nil
+	return errs.ErrorOrNil()
 }

--- a/commands/roles_test.go
+++ b/commands/roles_test.go
@@ -181,7 +181,7 @@ func (s *MmctlUnitTestSuite) TestMakeMemberCmd() {
 			Times(1)
 
 		err := rolesMemberCmdF(s.client, &cobra.Command{}, []string{mockUser.Email})
-		s.Require().Nil(err)
+		s.Require().ErrorContains(err, "can't update roles for user")
 
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
@@ -212,7 +212,7 @@ func (s *MmctlUnitTestSuite) TestMakeMemberCmd() {
 			Times(1)
 
 		err := rolesMemberCmdF(s.client, &cobra.Command{}, []string{emailArg})
-		s.Require().Nil(err)
+		s.Require().ErrorContains(err, "unable to find user")
 
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)


### PR DESCRIPTION
Return error from rolesMemberCmdF

I applied the same approach with rolesSystemAdminCmd function.

Ticket: [https://github.com/mattermost/mattermost-server/issues/21476](https://github.com/mattermost/mattermost-server/issues/21476)

JIRA Issue: [https://mattermost.atlassian.net/browse/MM-47810](https://mattermost.atlassian.net/browse/MM-47810)