### PR TITLE
refact: removeAllUsersFromChannel to return an error

### DIFF
--- a/commands/channel_users.go
+++ b/commands/channel_users.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
 

--- a/commands/channel_users.go
+++ b/commands/channel_users.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
@@ -118,12 +120,12 @@ func removeAllUsersFromChannel(c client.Client, channel *model.Channel) error {
 	members, _, err := c.GetChannelMembers(channel.Id, 0, 10000, "")
 	if err != nil {
 		printer.PrintError("Unable to remove all users from " + channel.Name + ". Error: " + err.Error())
-		return errors.Errorf("Unable to remove all users from " + channel.Name + ". Error: " + err.Error())
+		return fmt.Errorf("unable to remove all users from %q: %w", channel.Name, err)
 	}
 
 	for _, member := range members {
 		if _, err := c.RemoveUserFromChannel(channel.Id, member.UserId); err != nil {
-			result = multierror.Append(result, errors.Errorf("Unable to remove '"+member.UserId+"' from "+channel.Name+". Error: "+err.Error()))
+			result = multierror.Append(result, fmt.Errorf("unable to remove %q from %q Error: %w", member.UserId, channel.Name, err))
 			printer.PrintError("Unable to remove '" + member.UserId + "' from " + channel.Name + ". Error: " + err.Error())
 		}
 	}

--- a/commands/channel_users_test.go
+++ b/commands/channel_users_test.go
@@ -449,8 +449,7 @@ func (s *MmctlUnitTestSuite) TestChannelUsersRemoveCmd() {
 
 		err := channelUsersRemoveCmdF(s.client, cmd, args)
 
-		s.Require().ErrorContains(err, "Unable to remove '"+mockUser3.Id+"' from "+channelName)
+		s.Require().ErrorContains(err, "unable to remove '"+mockUser3.Id+"' from "+channelName)
 		s.Require().Len(printer.GetLines(), 0)
 	})
-
 }

--- a/commands/channel_users_test.go
+++ b/commands/channel_users_test.go
@@ -434,7 +434,6 @@ func (s *MmctlUnitTestSuite) TestChannelUsersRemoveCmd() {
 			Times(1)
 
 		err := channelUsersRemoveCmdF(s.client, cmd, args)
-		s.Require().NotNil(err)
 		s.Require().ErrorContains(err, "unable to remove")
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)

--- a/commands/channel_users_test.go
+++ b/commands/channel_users_test.go
@@ -407,9 +407,7 @@ func (s *MmctlUnitTestSuite) TestChannelUsersRemoveCmd() {
 		}
 
 		mockMember1 := model.ChannelMember{ChannelId: channelID, UserId: mockUser.Id}
-		mockMember2 := model.ChannelMember{ChannelId: channelID, UserId: mockUser2.Id}
-		mockMember3 := model.ChannelMember{ChannelId: channelID, UserId: mockUser3.Id}
-		mockChannelMembers := model.ChannelMembers{mockMember1, mockMember2, mockMember3}
+		mockChannelMembers := model.ChannelMembers{mockMember1}
 
 		s.client.
 			EXPECT().
@@ -432,24 +430,13 @@ func (s *MmctlUnitTestSuite) TestChannelUsersRemoveCmd() {
 		s.client.
 			EXPECT().
 			RemoveUserFromChannel(foundChannel.Id, mockUser.Id).
-			Return(&model.Response{StatusCode: http.StatusOK}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			RemoveUserFromChannel(foundChannel.Id, mockUser2.Id).
-			Return(&model.Response{StatusCode: http.StatusOK}, nil).
-			Times(1)
-
-		s.client.
-			EXPECT().
-			RemoveUserFromChannel(foundChannel.Id, mockUser3.Id).
-			Return(&model.Response{StatusCode: http.StatusNotFound}, nil).
+			Return(&model.Response{StatusCode: http.StatusNotFound}, errors.New("mock error")).
 			Times(1)
 
 		err := channelUsersRemoveCmdF(s.client, cmd, args)
-
-		s.Require().ErrorContains(err, "unable to remove '"+mockUser3.Id+"' from "+channelName)
+		s.Require().NotNil(err)
+		s.Require().ErrorContains(err, "unable to remove")
 		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
refactor removeAllUsersFromChannel to feedback the error on return instead of just printing
<!--
A description of what this pull request does.
-->

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-47341
Issue: https://github.com/mattermost/mattermost-server/issues/21218
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

