### PR TITLE
[MM-47351] | Add error handling for integrityCmdF function

### DIFF
--- a/commands/integrity.go
+++ b/commands/integrity.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/mattermost/mmctl/v6/client"
 	"github.com/mattermost/mmctl/v6/printer"
@@ -86,13 +87,16 @@ func integrityCmdF(c client.Client, command *cobra.Command, args []string) error
 	if err != nil {
 		return fmt.Errorf("unable to perform integrity check. Error: %w", err)
 	}
+
+	var errs *multierror.Error
 	for _, result := range results {
 		if result.Err != nil {
+			errs = multierror.Append(errs, result.Err)
 			printer.PrintError(result.Err.Error())
 			continue
 		}
 		printIntegrityCheckResult(result, verboseFlag)
 	}
 
-	return nil
+	return errs.ErrorOrNil()
 }

--- a/commands/integrity.go
+++ b/commands/integrity.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/mattermost/mmctl/v6/client"

--- a/commands/integrity_test.go
+++ b/commands/integrity_test.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"errors"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/mattermost/mmctl/v6/printer"
 
@@ -99,9 +100,11 @@ func (s *MmctlUnitTestSuite) TestIntegrityCmd() {
 			CheckIntegrity().
 			Return(mockResults, &model.Response{}, nil).
 			Times(1)
+		var expected error
+		expected = multierror.Append(expected, errors.New("test error"))
 
 		err := integrityCmdF(s.client, cmd, []string{})
-		s.Require().Nil(err)
+		s.Require().EqualError(err, expected.Error())
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(mockData, printer.GetLines()[0])

--- a/commands/integrity_test.go
+++ b/commands/integrity_test.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"errors"
+
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/mattermost/mmctl/v6/printer"


### PR DESCRIPTION

#### Summary
Returns multi error instead of printing and returning nil

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21209


