### PR TITLE
Refactor | Creating error at return and update tests

### DIFF
--- a/commands/channel.go
+++ b/commands/channel.go
@@ -598,7 +598,7 @@ func deleteChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) erro
 		}
 	}
 
-	var result error
+	var result *multierror.Error
 
 	channels := getChannelsFromChannelArgs(c, args)
 	for i, channel := range channels {
@@ -612,5 +612,5 @@ func deleteChannelsCmdF(c client.Client, cmd *cobra.Command, args []string) erro
 			printer.PrintT("Deleted channel '{{.Name}}'", channel)
 		}
 	}
-	return result
+	return result.ErrorOrNil()
 }

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/pkg/errors"
 
 	"path/filepath"
 
@@ -196,8 +198,10 @@ func (s *MmctlE2ETestSuite) TestPluginInstallURLCmd() {
 		printer.Clean()
 		defer removePluginIfInstalled(s.th.Client, s, jiraPluginID)
 
+		var expected error
+		expected = multierror.Append(expected, errors.New(": You do not have the appropriate permissions., "))
 		err := pluginInstallURLCmdF(s.th.Client, &cobra.Command{}, []string{jiraURL})
-		s.Require().NotNil(err)
+		s.Require().EqualError(err, expected.Error())
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to install plugin from URL \"%s\".", jiraURL))
@@ -213,9 +217,11 @@ func (s *MmctlE2ETestSuite) TestPluginInstallURLCmd() {
 		printer.Clean()
 
 		const pluginURL = "https://plugins-store.test.mattermost.com/release/mattermost-nonexistent-plugin-v2.0.0.tar.gz"
+		var expected error
+		expected = multierror.Append(expected, errors.New(": An error occurred while downloading the plugin., "))
 
 		err := pluginInstallURLCmdF(c, &cobra.Command{}, []string{pluginURL})
-		s.Require().NotNil(err)
+		s.Require().EqualError(err, expected.Error())
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to install plugin from URL \"%s\".", pluginURL))
@@ -237,8 +243,10 @@ func (s *MmctlE2ETestSuite) TestPluginInstallURLCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 		s.Require().Equal(jiraPluginID, printer.GetLines()[0].(*model.Manifest).Id)
 
+		var expected error
+		expected = multierror.Append(expected, errors.New(": Unable to install plugin. A plugin with the same ID is already installed., "))
 		err = pluginInstallURLCmdF(c, &cobra.Command{}, []string{jiraURL})
-		s.Require().NotNil(err)
+		s.Require().EqualError(err, expected.Error())
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to install plugin from URL \"%s\".", jiraURL))

--- a/commands/plugin_test.go
+++ b/commands/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
@@ -197,8 +198,11 @@ func (s *MmctlUnitTestSuite) TestPluginInstallUrlCmd() {
 			Return(nil, &model.Response{}, errors.New("mock error")).
 			Times(1)
 
+		var expected error
+		expected = multierror.Append(expected, errors.New("mock error"))
+
 		err := pluginInstallURLCmdF(s.client, &cobra.Command{}, args)
-		s.Require().NotNil(err)
+		s.Require().EqualError(err, expected.Error())
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("Unable to install plugin from URL \"https://example.com/plugin2.tar.gz\". Error: mock error", printer.GetErrorLines()[0])
 		s.Require().Len(printer.GetLines(), 1)


### PR DESCRIPTION
#### Summary
This PR is an enhancement on closed tickets https://github.com/mattermost/mattermost-server/issues/21211 and https://github.com/mattermost/mattermost-server/issues/21223 in order to maintain code consistency.

This includes
- Creating error at return
- Updating tests to test against expected error

