### PR TITLE
MM-47811: improve error handling for removeUserFromTeam function

### DIFF
--- a/commands/team_users.go
+++ b/commands/team_users.go
@@ -58,7 +58,6 @@ func teamUsersRemoveCmdF(c client.Client, cmd *cobra.Command, args []string) err
 	for i, user := range users {
 		if err := removeUserFromTeam(c, team, user, args[i+1]); err != nil {
 			errs = multierror.Append(errs, err)
-			printer.PrintError(err.Error())
 		}
 	}
 
@@ -67,7 +66,9 @@ func teamUsersRemoveCmdF(c client.Client, cmd *cobra.Command, args []string) err
 
 func removeUserFromTeam(c client.Client, team *model.Team, user *model.User, userArg string) error {
 	if user == nil {
-		return errors.New("Can't find user '" + userArg + "'")
+		err := errors.Errorf("can't find user '%s'", userArg)
+		printer.PrintError(err.Error())
+		return err
 	}
 
 	var err error

--- a/commands/team_users.go
+++ b/commands/team_users.go
@@ -58,6 +58,7 @@ func teamUsersRemoveCmdF(c client.Client, cmd *cobra.Command, args []string) err
 	for i, user := range users {
 		if err := removeUserFromTeam(c, team, user, args[i+1]); err != nil {
 			errs = multierror.Append(errs, err)
+			printer.PrintError(err.Error())
 		}
 	}
 
@@ -72,6 +73,7 @@ func removeUserFromTeam(c client.Client, team *model.Team, user *model.User, use
 	var err error
 	if _, err = c.RemoveTeamMember(team.Id, user.Id); err != nil {
 		err = fmt.Errorf("unable to remove '%s' from %s. Error: %w", userArg, team.Name, err)
+		printer.PrintError(err.Error())
 	}
 
 	return err

--- a/commands/team_users.go
+++ b/commands/team_users.go
@@ -4,11 +4,11 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mmctl/v6/client"
@@ -66,7 +66,7 @@ func teamUsersRemoveCmdF(c client.Client, cmd *cobra.Command, args []string) err
 
 func removeUserFromTeam(c client.Client, team *model.Team, user *model.User, userArg string) error {
 	if user == nil {
-		err := errors.Errorf("can't find user '%s'", userArg)
+		err := fmt.Errorf("can't find user '%s'", userArg)
 		printer.PrintError(err.Error())
 		return err
 	}
@@ -90,7 +90,7 @@ func teamUsersAddCmdF(c client.Client, cmd *cobra.Command, args []string) error 
 	users := getUsersFromUserArgs(c, args[1:])
 	for i, user := range users {
 		if user == nil {
-			userErr := errors.Errorf("can't find user '%s'", args[i+1])
+			userErr := fmt.Errorf("can't find user '%s'", args[i+1])
 			printer.PrintError(userErr.Error())
 			errs = multierror.Append(errs, userErr)
 			continue

--- a/commands/team_users_test.go
+++ b/commands/team_users_test.go
@@ -66,7 +66,7 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 			Times(1)
 
 		err := teamUsersRemoveCmdF(s.client, &cobra.Command{}, []string{teamArg, mockUser.Id})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "Can't find user '"+userArg+"'")
@@ -236,10 +236,10 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 			Times(1)
 
 		err := teamUsersRemoveCmdF(s.client, &cobra.Command{}, []string{mockTeam.Id, mockUser.Id})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
-		s.Require().Len(printer.GetErrorLines(), 1)
-		s.Require().Equal(printer.GetErrorLines()[0], "Unable to remove '"+mockUser.Id+"' from "+mockTeam.Name+". Error: "+mockError.Error())
+		s.Require().Len(printer.GetErrorLines(), 2)
+		s.Require().Equal(printer.GetErrorLines()[0], "unable to remove '"+mockUser.Id+"' from "+mockTeam.Name+". Error: "+mockError.Error())
 	})
 }
 

--- a/commands/team_users_test.go
+++ b/commands/team_users_test.go
@@ -69,7 +69,7 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
-		s.Require().Equal(printer.GetErrorLines()[0], "Can't find user '"+userArg+"'")
+		s.Require().Equal(printer.GetErrorLines()[0], "can't find user '"+userArg+"'")
 	})
 
 	s.Run("Remove users from team by email and get team by name should not return an error", func() {
@@ -238,7 +238,7 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 		err := teamUsersRemoveCmdF(s.client, &cobra.Command{}, []string{mockTeam.Id, mockUser.Id})
 		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
-		s.Require().Len(printer.GetErrorLines(), 2)
+		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "unable to remove '"+mockUser.Id+"' from "+mockTeam.Name+". Error: "+mockError.Error())
 	})
 }

--- a/commands/team_users_test.go
+++ b/commands/team_users_test.go
@@ -3,10 +3,10 @@
 package commands
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mmctl/v6/printer"
@@ -66,7 +66,7 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 			Times(1)
 
 		err := teamUsersRemoveCmdF(s.client, &cobra.Command{}, []string{teamArg, mockUser.Id})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "can't find user '"+userArg+"'")
@@ -236,7 +236,7 @@ func (s *MmctlUnitTestSuite) TestTeamUsersArchiveCmd() {
 			Times(1)
 
 		err := teamUsersRemoveCmdF(s.client, &cobra.Command{}, []string{mockTeam.Id, mockUser.Id})
-		s.Require().NotNil(err)
+		s.Require().Error(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "unable to remove '"+mockUser.Id+"' from "+mockTeam.Name+". Error: "+mockError.Error())


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Error handling for the `removeUserFromTeam` function updated to return an error in case of failure.
Update includes the use of `multierror.Error` for appending all errors and returning error if one occurs for the function `teamUsersRemoveCmdF`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/21475
