### PR TITLE
[MM-48390] Validate imports against the users, teams, channels from the server

### DIFF
--- a/commands/importer/utils.go
+++ b/commands/importer/utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ImportFileInfo struct {
-	ArchiveName string `json:"archive_name"`
+	Source      string `json:"archive_name"`
 	FileName    string `json:"file_name,omitempty"`
 	CurrentLine uint64 `json:"current_line,omitempty"`
 	TotalLines  uint64 `json:"total_lines,omitempty"`
@@ -50,8 +50,8 @@ func (e *ImportValidationError) Error() string {
 	msg := &strings.Builder{}
 	msg.WriteString("import validation error")
 
-	if e.FileName != "" || e.ArchiveName != "" {
-		fmt.Fprintf(msg, " in %s->%s:%d", e.ArchiveName, e.FileName, e.CurrentLine)
+	if e.FileName != "" || e.Source != "" {
+		fmt.Fprintf(msg, " in %s->%s:%d", e.Source, e.FileName, e.CurrentLine)
 	}
 
 	if e.FieldName != "" {

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 )
 
@@ -88,4 +89,25 @@ func addToZip(zipWriter *zip.Writer, basedir, path string) error {
 	}
 
 	return nil
+}
+
+func getPages[T any](fn func(page, numPerPage int, etag string) ([]T, *model.Response, error), perPage int) ([]T, error) {
+	var (
+		results []T
+		etag    string
+	)
+
+	for i := 0; ; i++ {
+		result, resp, err := fn(i, perPage, etag)
+		if err != nil {
+			return results, err
+		}
+		if len(result) == 0 {
+			break
+		}
+
+		results = append(results, result...)
+		etag = resp.Etag
+	}
+	return results, nil
 }


### PR DESCRIPTION
#### Summary
The import validator can now validate the import users, channels, and teams against a live server, should one me configured. This allows us to warn the user about users that would be overwritten, users with different email addresses, and duplicate teams and channels.

#### Ticket Link
[MM-48390](https://mattermost.atlassian.net/browse/MM-48390)