### PR TITLE
[GH-21224]: Add error returns to plugin.go and update tests

### DIFF
--- a/commands/plugin.go
+++ b/commands/plugin.go
@@ -93,7 +93,7 @@ func init() {
 
 func pluginAddCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
-
+	var multiErr *multierror.Error
 	for i, plugin := range args {
 		fileReader, err := os.Open(plugin)
 		if err != nil {
@@ -108,13 +108,14 @@ func pluginAddCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 
 		if err != nil {
 			printer.PrintError("Unable to add plugin: " + args[i] + ". Error: " + err.Error())
+			multiErr = multierror.Append(multiErr, err)
 		} else {
 			printer.Print("Added plugin: " + plugin)
 		}
 		fileReader.Close()
 	}
 
-	return nil
+	return multiErr.ErrorOrNil()
 }
 
 func pluginInstallURLCmdF(c client.Client, cmd *cobra.Command, args []string) error {
@@ -135,39 +136,45 @@ func pluginInstallURLCmdF(c client.Client, cmd *cobra.Command, args []string) er
 }
 
 func pluginDeleteCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	var multiErr *multierror.Error
 	for _, plugin := range args {
 		if _, err := c.RemovePlugin(plugin); err != nil {
 			printer.PrintError("Unable to delete plugin: " + plugin + ". Error: " + err.Error())
+			multiErr = multierror.Append(multiErr, err)
 		} else {
 			printer.Print("Deleted plugin: " + plugin)
 		}
 	}
 
-	return nil
+	return multiErr.ErrorOrNil()
 }
 
 func pluginEnableCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	var multiErr *multierror.Error
 	for _, plugin := range args {
 		if _, err := c.EnablePlugin(plugin); err != nil {
 			printer.PrintError("Unable to enable plugin: " + plugin + ". Error: " + err.Error())
+			multiErr = multierror.Append(multiErr, err)
 		} else {
 			printer.Print("Enabled plugin: " + plugin)
 		}
 	}
 
-	return nil
+	return multiErr.ErrorOrNil()
 }
 
 func pluginDisableCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	var multiErr *multierror.Error
 	for _, plugin := range args {
 		if _, err := c.DisablePlugin(plugin); err != nil {
 			printer.PrintError("Unable to disable plugin: " + plugin + ". Error: " + err.Error())
+			multiErr = multierror.Append(multiErr, err)
 		} else {
 			printer.Print("Disabled plugin: " + plugin)
 		}
 	}
 
-	return nil
+	return multiErr.ErrorOrNil()
 }
 
 func pluginListCmdF(c client.Client, cmd *cobra.Command, args []string) error {

--- a/commands/plugin_e2e_test.go
+++ b/commands/plugin_e2e_test.go
@@ -46,7 +46,7 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 		printer.Clean()
 
 		err = pluginAddCmdF(c, &cobra.Command{}, []string{pluginPath})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 
 		s.Require().Equal(0, len(printer.GetLines()))
 		s.Require().Equal(1, len(printer.GetErrorLines()))
@@ -108,7 +108,7 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 		printer.Clean()
 
 		err := pluginAddCmdF(c, &cobra.Command{}, []string{pluginPath})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Equal(1, len(printer.GetErrorLines()))
 		s.Require().Contains(printer.GetErrorLines()[0], "Plugins and/or plugin uploads have been disabled.")
 	})
@@ -156,7 +156,7 @@ func (s *MmctlE2ETestSuite) TestPluginAddCmd() {
 		})
 
 		err := pluginAddCmdF(s.th.Client, &cobra.Command{}, []string{pluginPath})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Equal(1, len(printer.GetErrorLines()))
 		s.Require().Contains(printer.GetErrorLines()[0], "You do not have the appropriate permissions")
 	})
@@ -329,7 +329,7 @@ func (s *MmctlE2ETestSuite) TestPluginDeleteCmd() {
 		printer.Clean()
 
 		err := pluginDeleteCmdF(c, &cobra.Command{}, []string{dummyPluginID})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to delete plugin: %s.", dummyPluginID))
@@ -367,7 +367,7 @@ func (s *MmctlE2ETestSuite) TestPluginDeleteCmd() {
 
 		// Delete Test
 		err := pluginDeleteCmdF(s.th.Client, &cobra.Command{}, []string{jiraPluginID})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Contains(printer.GetErrorLines()[0], fmt.Sprintf("Unable to delete plugin: %s.", jiraPluginID))

--- a/commands/plugin_test.go
+++ b/commands/plugin_test.go
@@ -80,13 +80,13 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 		mockError := errors.New("plugin add error")
 
 		s.client.
-			EXPECT().
-			UploadPlugin(gomock.AssignableToTypeOf(tmpFile)).
-			Return(&model.Manifest{}, &model.Response{}, mockError).
-			Times(1)
+		 	EXPECT().
+		 	UploadPlugin(gomock.AssignableToTypeOf(tmpFile)).
+		 	Return(&model.Manifest{}, &model.Response{}, mockError).
+		 	Times(1)
 
 		err = pluginAddCmdF(s.client, &cobra.Command{}, []string{pluginName})
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "Unable to add plugin: "+pluginName+". Error: "+mockError.Error())
 	})
@@ -117,7 +117,7 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 		}
 
 		err := pluginAddCmdF(s.client, &cobra.Command{}, args)
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Equal(printer.GetLines()[0], "Added plugin: "+args[1])
 		s.Require().Len(printer.GetErrorLines(), 2)
@@ -240,7 +240,7 @@ func (s *MmctlUnitTestSuite) TestPluginDisableCmd() {
 			Times(1)
 
 		err := pluginDisableCmdF(s.client, &cobra.Command{}, []string{arg})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "Unable to disable plugin: "+arg+". Error: "+mockError.Error())
@@ -268,7 +268,7 @@ func (s *MmctlUnitTestSuite) TestPluginDisableCmd() {
 		}
 
 		err := pluginDisableCmdF(s.client, &cobra.Command{}, args)
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 2)
 		s.Require().Equal(printer.GetLines()[0], "Disabled plugin: "+args[1])
 		s.Require().Equal(printer.GetLines()[1], "Disabled plugin: "+args[2])
@@ -329,7 +329,7 @@ func (s *MmctlUnitTestSuite) TestPluginEnableCmd() {
 			Times(1)
 
 		err := pluginEnableCmdF(s.client, &cobra.Command{}, []string{pluginArg})
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal(printer.GetErrorLines()[0], "Unable to enable plugin: "+pluginArg+". Error: "+mockErr.Error())
@@ -361,7 +361,7 @@ func (s *MmctlUnitTestSuite) TestPluginEnableCmd() {
 		}
 
 		err := pluginEnableCmdF(s.client, &cobra.Command{}, allPlugins)
-		s.Require().Nil(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 2)
 		s.Require().Equal(printer.GetLines()[0], "Enabled plugin: "+okPlugins[0])
 		s.Require().Equal(printer.GetLines()[1], "Enabled plugin: "+okPlugins[1])
@@ -548,7 +548,7 @@ func (s *MmctlUnitTestSuite) TestPluginDeleteCmd() {
 			Times(1)
 
 		err := pluginDeleteCmdF(s.client, &cobra.Command{}, []string{args})
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 0)
 		s.Require().Len(printer.GetErrorLines(), 1)
 		s.Require().Equal("Unable to delete plugin: "+args+". Error: "+mockError.Error(), printer.GetErrorLines()[0])
@@ -609,7 +609,7 @@ func (s *MmctlUnitTestSuite) TestPluginDeleteCmd() {
 			Times(1)
 
 		err := pluginDeleteCmdF(s.client, &cobra.Command{}, args)
-		s.Require().NoError(err)
+		s.Require().NotNil(err)
 		s.Require().Len(printer.GetLines(), 2)
 		s.Require().Equal("Deleted plugin: "+args[0], printer.GetLines()[0])
 		s.Require().Equal("Deleted plugin: "+args[3], printer.GetLines()[1])


### PR DESCRIPTION
#### Summary
This PR adds the ability errors (including groups of errors) to be returned by the subcommands in plugin.go. The e2e and unit tests are also updated. 

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/21224

