### PR TITLE
added --inactive flag

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -95,6 +95,7 @@ type Client interface {
 	GetUsers(page, perPage int, etag string) ([]*model.User, *model.Response, error)
 	GetUsersByIds(userIDs []string) ([]*model.User, *model.Response, error)
 	GetUsersInTeam(teamID string, page, perPage int, etag string) ([]*model.User, *model.Response, error)
+	GetUsersWithOptions(etag string)([]*model.User, *model.Response, error)
 	UpdateUserActive(userID string, activate bool) (*model.Response, error)
 	UpdateTeam(team *model.Team) (*model.Team, *model.Response, error)
 	UpdateChannelPrivacy(channelID string, privacy model.ChannelType) (*model.Channel, *model.Response, error)

--- a/commands/user.go
+++ b/commands/user.go
@@ -731,6 +731,10 @@ func listUsersCmdF(c client.Client, command *cobra.Command, args []string) error
 	if err != nil {
 		return err
 	}
+	showInactive, err := command.Flags().GetBool("inactive")
+	if err != nil {
+		return err
+	}
 
 	if showAll {
 		page = 0
@@ -754,6 +758,12 @@ func listUsersCmdF(c client.Client, command *cobra.Command, args []string) error
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("Failed to fetch users for team %s", teamName))
 			}
+		} else if showInactive {
+			users, _, err = c.GetUsersWithOptions("")
+			if err != nil {
+				return errors.Wrap(err, "Failed to fetch inactive users")
+			}
+
 		} else {
 			users, _, err = c.GetUsers(page, perPage, "")
 			if err != nil {

--- a/commands/user.go
+++ b/commands/user.go
@@ -277,6 +277,7 @@ func init() {
 	ListUsersCmd.Flags().Int("per-page", 200, "Number of users to be fetched")
 	ListUsersCmd.Flags().Bool("all", false, "Fetch all users. --page flag will be ignore if provided")
 	ListUsersCmd.Flags().String("team", "", "If supplied, only users belonging to this team will be listed")
+	ListUsersCmd.Flags().Bool("inactive", false, "If supplied, only inactive users will be listed")
 
 	UserConvertCmd.Flags().Bool("bot", false, "If supplied, convert users to bots")
 	UserConvertCmd.Flags().Bool("user", false, "If supplied, convert a bot to a user")

--- a/commands/user_e2e_test.go
+++ b/commands/user_e2e_test.go
@@ -175,6 +175,7 @@ func (s *MmctlE2ETestSuite) TestListUserCmd() {
 		cmd.Flags().IntVar(&perpage, "per-page", perpage, "perpage")
 		cmd.Flags().BoolVar(&all, "all", all, "all")
 		cmd.Flags().StringVar(&team, "team", team, "team")
+		cmd.Flags().BoolVar(&inactive, "inactive", inactive, "inactive")
 
 		err := listUsersCmdF(c, cmd, []string{})
 		s.Require().Nil(err)
@@ -199,6 +200,7 @@ func (s *MmctlE2ETestSuite) TestListUserCmd() {
 		cmd.Flags().IntVar(&perpage, "per-page", perpage, "perpage")
 		cmd.Flags().BoolVar(&all, "all", all, "all")
 		cmd.Flags().StringVar(&team, "team", team, "team")
+		cmd.Flags().BoolVar(&inactive, "inactive", inactive, "inactive")
 
 		err := listUsersCmdF(c, cmd, []string{})
 		s.Require().Nil(err)

--- a/docs/mmctl_user_list.rst
+++ b/docs/mmctl_user_list.rst
@@ -32,6 +32,7 @@ Options
       --page int       Page number to fetch for the list of users
       --per-page int   Number of users to be fetched (default 200)
       --team string    If supplied, only users belonging to this team will be listed
+      --inactive       If supplied, only inactive users will be listed
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
This PR adds a flag to mmctl user list command to print deactivated users

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43074

