### PR TITLE
Remove --local option from bot create doc since it is not available

### DIFF
--- a/docs/mmctl_bot_create.rst
+++ b/docs/mmctl_bot_create.rst
@@ -42,7 +42,6 @@ Options inherited from parent commands
       --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
       --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
       --json                         the output format will be in json format
-      --local                        allows communicating with the server through a unix socket
       --quiet                        prevent mmctl to generate output for the commands
       --strict                       will only run commands if the mmctl version matches the server one
       --suppress-warnings            disables printing warning messages


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The documentation on `bot create` lists `--local` as an option, but it is disabled/not available for the specific command. This PR removes `--local` from the list of available options.
