### PR TITLE
Use go install instead of go get 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ endif
 govet:
 ifeq ($(ADVANCED_VET), TRUE)
 	@if ! [ -x "$$(command -v mattermost-govet)" ]; then \
-		echo "mattermost-govet is not installed. Please install it executing \"GO111MODULE=off go get -u github.com/mattermost/mattermost-govet\""; \
+		echo "mattermost-govet is not installed. Please install it executing \"go install github.com/mattermost/mattermost-govet@latest\""; \
 		exit 1; \
 	fi;
 	@echo Running mattermost-govet


### PR DESCRIPTION
#### Summary
The installation of binaries using `go get` is not longer supported. The command errors with:
```sh
$ go get -u mattermost-govet
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

`go install` should be used instead.

#### Ticket Link
None
