### PR TITLE
Showing websockets events as strings instead of as bytes arrays

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.46.2
+          version: v1.51.2

--- a/commands/websockets.go
+++ b/commands/websockets.go
@@ -34,6 +34,11 @@ func websocketCmdF(cmd *cobra.Command, args []string) error {
 	fmt.Println("Press CTRL+C to exit")
 	for {
 		event := <-c.EventChannel
-		fmt.Println(event.ToJSON())
+		data, err := event.ToJSON()
+		if err != nil {
+			fmt.Println(err.Error())
+		} else {
+			fmt.Println(string(data))
+		}
 	}
 }


### PR DESCRIPTION
I was trying to use the `mmctl websocket` command to monitor the debugbar information and was showing me byte arrays. This PR prints strings instead.