### PR TITLE
Trims whitespace from command arguments in RootCmd

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -73,6 +73,9 @@ var RootCmd = &cobra.Command{
 	Long:              `Mattermost offers workplace messaging across web, PC and phones with archiving, search and integration with your existing systems. Documentation available at https://docs.mattermost.com`,
 	DisableAutoGenTag: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		for i, arg := range args {
+			args[i] = strings.TrimSpace(arg)
+		}
 		format := viper.GetString("format")
 		if viper.GetBool("disable-pager") {
 			printer.OverrideEnablePager(false)

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func executeRawCommand(root *cobra.Command, args string) (c *cobra.Command, output string, err error) {
+
+	actual := new(bytes.Buffer)
+	RootCmd.SetOut(actual)
+	RootCmd.SetErr(actual)
+	RootCmd.SetArgs(strings.Split(args, " "))
+	c, err = RootCmd.ExecuteC()
+	return c, actual.String(), err
+}
+
+func (s *MmctlUnitTestSuite) TestArgumentsHaveWhitespaceTrimmed() {
+
+	arguments := []string{"value_1", "value_2"}
+	lineEndings := []string{"\n", "\r", "\r\n"}
+	prettyNames := []string{"-n", "-r", "-r-n"}
+	commandCalled := false
+
+	for i, lineEnding := range lineEndings {
+		testName := fmt.Sprintf("Commands have their arguments stripped of whitespace[%s]", prettyNames[i])
+		s.Run(testName, func() {
+			commandCalled = false
+			commandFunction := func(command *cobra.Command, args []string) {
+				commandCalled = true
+				s.Equal(arguments, args, "Expected arguments to have their whitespace trimmed")
+
+			}
+			mockCommand := &cobra.Command{Use: "test", Run: commandFunction}
+			commandString := strings.Join([]string{"test", " ", arguments[0], lineEnding, " ", arguments[1], lineEnding}, "")
+			RootCmd.AddCommand(mockCommand)
+			executeRawCommand(RootCmd, commandString)
+			s.Require().True(commandCalled, "Expected mock command to be called")
+		})
+	}
+
+}


### PR DESCRIPTION
#### Summary
This PR introduces a change to trim whitespace from command arguments globally across the entire `mmctl` tool. I decided to go this route rather than fixing the specific case since I figured it would be nice to solve this "once and for all" rather than having to address individual cases. If however we desire a more direct fix I have a version of that change stashed as well.

- Also includes a new test for the `root` file to ensure that this whitespace trimming is working as expected.

This change not only addresses the raised issue but should prevent trailing whitespace from being an issue on any commands from `mmctl`. 

<details>
<summary>Examples can be found here</summary>

### Add users to channel
(Using input (With CRLF line endings)
```
ngeist+1@spiria.com
ngeist+2@spiria.com
```

**Before**
```
ngeist@PC-0109:~/repos/mmctl$ cat demo.txt | xargs ./mmctl channel users add team-1:Apple314
'an't find user 'ngeist+1@spiria.com
'an't find user 'ngeist+2@spiria.com
```

**After**
```
ngeist@PC-0109:~/repos/mmctl$ cat demo.txt | xargs ./mmctl channel users add team-1:Apple314
```
![image](https://user-images.githubusercontent.com/9254315/226944695-a8069172-3159-46b4-8278-193a51bd440f.png)


### Remove users from channel

**Before**
```
ngeist@PC-0109:~/repos/mmctl$ cat demo.txt | xargs ./mmctl channel users remove team-1:Apple314
'an't find user 'ngeist+1@spiria.com
'an't find user 'ngeist+2@spiria.com
ngeist@PC-0109:~/repos/mmctl$
```

**After**
```
ngeist@PC-0109:~/repos/mmctl$ cat demo.txt | xargs ./mmctl channel users remove team-1:Apple314
```
![image](https://user-images.githubusercontent.com/9254315/226944913-fd0b5774-c36e-4c27-9159-5f276974d99c.png)

### Channel list
(Using input (With CRLF line endings)
```
team-1

```
**Before**
```
ngeist@PC-0109:~/repos/mmctl$ cat demo_2.txt | xargs ./mmctl channel list
Error: 1 error occurred:
        * unable to find team "team-1\r"
```

**After**
```
ngeist@PC-0109:~/repos/mmctl$ cat demo_2.txt | xargs ./mmctl channel list
apple314
channel-2
off-topic
town-square

There are 4 channels on http://localhost:8065/
```

</details>



#### Ticket Link
[GH-21873](https://github.com/mattermost/mattermost-server/issues/21873)
[MM-48057](https://mattermost.atlassian.net/browse/MM-48057)

